### PR TITLE
fix some bugs

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.de.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.de.json
@@ -282,5 +282,14 @@
       }
     ],
     "inputHint": "acceptingInput"
+  },
+  "NoTasksInList": {
+    "replies": [
+      {
+        "text": "Ihre To Do Liste ist leer.",
+        "speak": "Ihre To Do Liste ist leer."
+      }
+    ],
+    "inputHint": "expectingInput"
   }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.zh.json
@@ -153,5 +153,14 @@
       }
     ],
     "inputHint": "expectingInput"
+  },
+  "NoTasksInList": {
+    "replies": [
+      {
+        "text": "您的待办事项表是空的.",
+        "speak": "您的待办事项表是空的."
+      }
+    ],
+    "inputHint": "expectingInput"
   }
 }


### PR DESCRIPTION
Fix below issues:
1. Prompt a message("Your to do list is empty.") to users if users try to delete/mark a task of an empty task list. Before fixing, it always prompted "Which task will you operate" which is not good experience.
2. Add some new patterns for "AddToDo", including "remind me to {TaskContent}" and "remind me that {TaskContent}".
3, Add a new entity type called "TaskType" which will be used later to distinguish task type(ToDo, Shopping, Grocery).