### PR TITLE
Rylengel/disabletranslatorstartup

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -112,17 +112,12 @@ namespace VirtualAssistant
                 options.Middleware.Add(new AutoSaveStateMiddleware(userState, conversationState));
 
                 // Translator is an optional component for scenarios when an Assistant needs to work beyond native language support
-                //var translatorKey = Configuration.GetValue<string>("translatorKey");
+                var translatorKey = Configuration.GetValue<string>("translatorKey");
 
-                //if (!string.IsNullOrEmpty(translatorKey))
-                //{
-                //    options.Middleware.Add(new TranslationMiddleware(new string[] { "en", "fr", "it", "de", "es" }, translatorKey, false));
-                //}
-                //else
-                //{
-                //    throw new InvalidOperationException("Microsoft Text Translation API key is missing. Please add your translation key to the 'translatorKey' setting.");
-                //}
-
+                if (!string.IsNullOrEmpty(translatorKey))
+                {
+                    options.Middleware.Add(new TranslationMiddleware(new string[] { "en", "fr", "it", "de", "es" }, translatorKey, false));
+                }
             });
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -112,16 +112,16 @@ namespace VirtualAssistant
                 options.Middleware.Add(new AutoSaveStateMiddleware(userState, conversationState));
 
                 // Translator is an optional component for scenarios when an Assistant needs to work beyond native language support
-                var translatorKey = Configuration.GetValue<string>("translatorKey");
+                //var translatorKey = Configuration.GetValue<string>("translatorKey");
 
-                if (!string.IsNullOrEmpty(translatorKey))
-                {
-                    options.Middleware.Add(new TranslationMiddleware(new string[] { "en", "fr", "it", "de", "es" }, translatorKey, false));
-                }
-                else
-                {
-                    throw new InvalidOperationException("Microsoft Text Translation API key is missing. Please add your translation key to the 'translatorKey' setting.");
-                }
+                //if (!string.IsNullOrEmpty(translatorKey))
+                //{
+                //    options.Middleware.Add(new TranslationMiddleware(new string[] { "en", "fr", "it", "de", "es" }, translatorKey, false));
+                //}
+                //else
+                //{
+                //    throw new InvalidOperationException("Microsoft Text Translation API key is missing. Please add your translation key to the 'translatorKey' setting.");
+                //}
 
             });
         }


### PR DESCRIPTION
If translatorKey is missing - will continue ahead rather than break with an exception. This leave it optional for the developer to provide if they so choose.