### PR TITLE
add exception handling when loading response resources

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.cs
@@ -18,8 +18,9 @@ namespace CalendarSkill.Dialogs.Shared.Resources
     public static class CalendarSharedResponses
     {
         private const string JsonFileName = "CalendarSharedResponses.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -39,31 +40,54 @@ namespace CalendarSkill.Dialogs.Shared.Resources
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(CalendarSharedResponses).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+                    try
+                    {
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+                    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -87,21 +111,14 @@ namespace CalendarSkill.Dialogs.Shared.Resources
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.tt
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.tt
@@ -27,8 +27,9 @@ namespace <#= namespaceName #>
     public static class <#= className #>
     {
         private const string JsonFileName = "<#=className#>.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -40,31 +41,54 @@ namespace <#= namespaceName #>
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(<#= className #>).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+                    try
+                    {
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+                    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -88,21 +112,14 @@ namespace <#= namespaceName #>
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.cs
@@ -18,8 +18,9 @@ namespace EmailSkill.Dialogs.Shared.Resources
     public static class EmailSharedResponses
     {
         private const string JsonFileName = "EmailSharedResponses.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -59,31 +60,54 @@ namespace EmailSkill.Dialogs.Shared.Resources
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(EmailSharedResponses).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+                    try
+                    {
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+                    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -107,21 +131,14 @@ namespace EmailSkill.Dialogs.Shared.Resources
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.tt
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.tt
@@ -27,8 +27,9 @@ namespace <#= namespaceName #>
     public static class <#= className #>
     {
         private const string JsonFileName = "<#=className#>.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -40,31 +41,54 @@ namespace <#= namespaceName #>
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(<#= className #>).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+                    try
+                    {
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+                    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -88,21 +112,14 @@ namespace <#= namespaceName #>
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.tt
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.tt
@@ -27,8 +27,9 @@ namespace <#= namespaceName #>
     public static class <#= className #>
     {
         private const string JsonFileName = "<#=className#>.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -40,31 +41,54 @@ namespace <#= namespaceName #>
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(<#= className #>).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+                    try
+                    {
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+                    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -88,21 +112,14 @@ namespace <#= namespaceName #>
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.cs
@@ -18,8 +18,9 @@ namespace ToDoSkill.Dialogs.Shared.Resources
     public static class ToDoSharedResponses
     {
         private const string JsonFileName = "ToDoSharedResponses.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -51,31 +52,54 @@ namespace ToDoSkill.Dialogs.Shared.Resources
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(ToDoSharedResponses).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+				    try
+					{
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+				    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -99,21 +123,14 @@ namespace ToDoSkill.Dialogs.Shared.Resources
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.tt
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.tt
@@ -27,8 +27,9 @@ namespace <#= namespaceName #>
     public static class <#= className #>
     {
         private const string JsonFileName = "<#=className#>.*.json";
+        private static Exception resourceLoadingException;
 
-        private static Dictionary<string, Dictionary<string, BotResponse>> jsonResponses;
+        private static Dictionary<string, Dictionary<string, BotResponse>> _jsonResponses;
 
         // Generated code:
         // This code runs in the text json:
@@ -40,31 +41,54 @@ namespace <#= namespaceName #>
         {
             get
             {
-                if (jsonResponses != null)
+                if (_jsonResponses != null)
                 {
-                    return jsonResponses;
+                    return _jsonResponses;
                 }
 
-                jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
+                _jsonResponses = new Dictionary<string, Dictionary<string, BotResponse>>();
                 var dir = Path.GetDirectoryName(typeof(<#= className #>).Assembly.Location);
                 var resDir = Path.Combine(dir, "Dialogs\\Shared\\Resources");
 
                 var jsonFiles = Directory.GetFiles(resDir, JsonFileName);
                 foreach (var file in jsonFiles)
                 {
-                    var jsonData = File.ReadAllText(file);
-                    var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
-                    var key = new FileInfo(file).Name.Split(".")[1].ToLower();
+				    try
+					{
+                        var jsonData = File.ReadAllText(file);
+                        var responses = JsonConvert.DeserializeObject<Dictionary<string, BotResponse>>(jsonData);
+                        var key = new FileInfo(file).Name.Split(".")[1].ToLower();
 
-                    jsonResponses.Add(key, responses);
+                        _jsonResponses.Add(key, responses);
+				    }
+                    catch (JsonReaderException ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = new Exception($"Deserialization exception when deserializing response resource file {file}: {ex.Message}");
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _jsonResponses = null;
+                        resourceLoadingException = ex;
+                        break;
+                    }
                 }
 
-                return jsonResponses;
+                resourceLoadingException = null;
+                return _jsonResponses;
             }
         }
 
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)
         {
+            // warm up the JsonResponses loading to see if it actually exist. If not, throw with the loading time exception that's actually helpful
+            var jsonResponses = JsonResponses;
+            if (jsonResponses == null && resourceLoadingException != null)
+            {
+                throw resourceLoadingException;
+            }
+
             var locale = CultureInfo.CurrentUICulture.Name;
             var theK = GetJsonResponseKeyForLocale(locale, propertyName);
 
@@ -88,21 +112,14 @@ namespace <#= namespaceName #>
 
         private static string GetJsonResponseKeyForLocale(string locale, string propertyName)
         {
-            try
+            if (JsonResponses.ContainsKey(locale))
             {
-                if (JsonResponses.ContainsKey(locale))
-                {
-                    return JsonResponses[locale].ContainsKey(propertyName) ?
-                        JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
-                        null;
-                }
+                return JsonResponses[locale].ContainsKey(propertyName) ?
+                    JsonResponses[locale].Keys.FirstOrDefault(k => string.Compare(k, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0) :
+                    null;
+            }
 
-                return null;
-            }
-            catch (KeyNotFoundException)
-            {
-                return null;
-            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
**Problem**
When there's something wrong with the resource json files, the error we're getting is not always very obvious. Normally it'll be 'the dictionary with the key "en" could not be found' but it really could be any file that's malformed. We need better error handling for this type of issue

**Solution**
When loading JsonResponses static property, set an exception variable if there's one, and in GetBotResponse function, check if there's an exception and if there is, throw immediately to avoid any future operations.