### PR TITLE
Flow stucked in skills after Luis update

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -118,7 +118,7 @@ namespace VirtualAssistant
 
                                 case General.Intent.Logout:
                                     {
-                                        await OnLogout(dc);
+                                        await LogoutAsync(dc);
                                         break;
                                     }
 
@@ -230,7 +230,7 @@ namespace VirtualAssistant
             }
         }
 
-        protected virtual async Task<InterruptionAction> OnLogout(DialogContext dc)
+        protected virtual async Task<InterruptionAction> LogoutAsync(DialogContext dc)
         {
             BotFrameworkAdapter adapter;
             var supported = dc.Context.Adapter is BotFrameworkAdapter;

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/EnterpriseDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/EnterpriseDialog.cs
@@ -33,7 +33,7 @@ namespace VirtualAssistant
             var intent = luisResult.TopIntent().intent;
 
             // TODO - Evolve this pattern
-            if (luisResult.TopIntent().score > 0.3)
+            if (luisResult.TopIntent().score > 0.5)
             {
                 // Add the luis result (intent and entities) for further processing in the derived dialog
                 dc.Context.TurnState.Add(LuisResultKey, luisResult);

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -221,20 +221,23 @@ namespace CalendarSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    // check intent
-                    switch (topIntent)
+                    if (luisResult.TopIntent().score > 0.3)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        // check intent
+                        switch (topIntent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -221,7 +221,7 @@ namespace CalendarSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    if (luisResult.TopIntent().score > 0.3)
+                    if (luisResult.TopIntent().score > 0.5)
                     {
                         // check intent
                         switch (topIntent)
@@ -235,6 +235,12 @@ namespace CalendarSkill
                             case General.Intent.Help:
                                 {
                                     // result = await OnHelp(dc);
+                                    break;
+                                }
+
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
                                     break;
                                 }
                         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -210,7 +210,7 @@ namespace EmailSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.3)
+                    if (luisResult.TopIntent().score > 0.5)
                     {
                         switch (topIntent)
                         {
@@ -223,6 +223,11 @@ namespace EmailSkill
                             case General.Intent.Help:
                                 {
                                     // result = await OnHelp(dc);
+                                    break;
+                                }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
                                     break;
                                 }
                         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -225,6 +225,7 @@ namespace EmailSkill
                                     // result = await OnHelp(dc);
                                     break;
                                 }
+
                             case General.Intent.Logout:
                                 {
                                     result = await OnLogout(dc);

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -210,19 +210,22 @@ namespace EmailSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    switch (topIntent)
+                    if (luisResult.TopIntent().score > 0.3)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -280,7 +280,7 @@ namespace PointOfInterestSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.3)
+                    if (luisResult.TopIntent().score > 0.5)
                     {
                         switch (topIntent)
                         {

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -280,25 +280,28 @@ namespace PointOfInterestSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    switch (topIntent)
+                    if (luisResult.TopIntent().score > 0.3)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -199,25 +199,28 @@ namespace ToDoSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    switch (topIntent)
+                    if (luisResult.TopIntent().score > 0.3)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -199,7 +199,7 @@ namespace ToDoSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.3)
+                    if (luisResult.TopIntent().score > 0.5)
                     {
                         switch (topIntent)
                         {


### PR DESCRIPTION
After Luis update, many user inputs are detected as "Cancel" with General model. This will make many slot filling scenario stuck in skills.

How fix:
Add a score threshold for general luis model to avoid low score Cancel.

Additional: add logout logic. 
