### PR TITLE
Add date time entities usage

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.0.7" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkillState.cs
@@ -19,7 +19,13 @@ namespace CalendarSkill
             StartTime = null;
             StartTimeString = null;
             StartDateTime = null;
+            EndDate = null;
+            EndTime = null;
             EndDateTime = null;
+            OriginalStartDate = null;
+            OriginalStartTime = null;
+            OriginalEndDate = null;
+            OriginalEndTime = null;
             Location = null;
             Attendees = new List<EventModel.Attendee>();
             APIToken = null;
@@ -53,6 +59,18 @@ namespace CalendarSkill
         public DateTime? StartTime { get; set; }
 
         public DateTime? StartDateTime { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public DateTime? EndTime { get; set; }
+
+        public DateTime? OriginalStartDate { get; set; }
+
+        public DateTime? OriginalStartTime { get; set; }
+
+        public DateTime? OriginalEndDate { get; set; }
+
+        public DateTime? OriginalEndTime { get; set; }
 
         public DateTime? EndDateTime { get; set; }
 
@@ -108,7 +126,13 @@ namespace CalendarSkill
             StartTime = null;
             StartTimeString = null;
             StartDateTime = null;
+            EndDate = null;
+            EndTime = null;
             EndDateTime = null;
+            OriginalStartDate = null;
+            OriginalStartTime = null;
+            OriginalEndDate = null;
+            OriginalEndTime = null;
             Location = null;
             Attendees = new List<EventModel.Attendee>();
             APIToken = null;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Common/TimeConverter.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Common/TimeConverter.cs
@@ -9,7 +9,7 @@ namespace CalendarSkill.Common
     {
         public static DateTime ConvertLuisLocalToUtc(DateTime time, TimeZoneInfo timeZone)
         {
-            if (time.Kind != DateTimeKind.Local)
+            if (time.Kind != DateTimeKind.Local && time.Kind != DateTimeKind.Unspecified)
             {
                 throw new Exception("Input time is not a Lius time.");
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -678,31 +678,34 @@ namespace CalendarSkill
                 if (sc.Result != null)
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    var dateTime = DateTime.Parse(dateTimeResolutions.First().Value);
-                    var dateTimeConvertType = dateTimeResolutions.First().Timex;
-
-                    if (dateTime != null)
+                    if (dateTimeResolutions.First().Value != null)
                     {
-                        bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
-                        if (ContainsTime(dateTimeConvertType))
-                        {
-                            state.StartTime = TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone());
-                        }
+                        var dateTime = DateTime.Parse(dateTimeResolutions.First().Value);
+                        var dateTimeConvertType = dateTimeResolutions.First().Timex;
 
-                        // Workaround as DateTimePrompt only return as local time
-                        if (isRelativeTime)
+                        if (dateTime != null)
                         {
-                            dateTime = new DateTime(
-                            dateTime.Year,
-                            dateTime.Month,
-                            dateTime.Day,
-                            DateTime.Now.Hour,
-                            DateTime.Now.Minute,
-                            DateTime.Now.Second);
-                        }
+                            bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
+                            if (ContainsTime(dateTimeConvertType))
+                            {
+                                state.StartTime = TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone());
+                            }
 
-                        state.StartDate = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
-                        return await sc.EndDialogAsync();
+                            // Workaround as DateTimePrompt only return as local time
+                            if (isRelativeTime)
+                            {
+                                dateTime = new DateTime(
+                                dateTime.Year,
+                                dateTime.Month,
+                                dateTime.Day,
+                                DateTime.Now.Hour,
+                                DateTime.Now.Minute,
+                                DateTime.Now.Second);
+                            }
+
+                            state.StartDate = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
+                            return await sc.EndDialogAsync();
+                        }
                     }
                 }
 
@@ -834,8 +837,11 @@ namespace CalendarSkill
                     sc.Context.Activity.Properties.TryGetValue("OriginText", out var content);
 
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    int.TryParse(dateTimeResolutions.First().Value, out int duration);
-                    state.Duration = duration;
+                    if (dateTimeResolutions.First().Value != null)
+                    {
+                        int.TryParse(dateTimeResolutions.First().Value, out int duration);
+                        state.Duration = duration;
+                    }
                 }
 
                 if (state.Duration > 0)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -758,13 +758,16 @@ namespace CalendarSkill
                 if (sc.Result != null && state.StartTime == null)
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    var dateTime = DateTime.Parse(dateTimeResolutions.First().Value);
-                    var dateTimeConvertType = dateTimeResolutions.First().Timex;
-
-                    if (dateTime != null)
+                    if (dateTimeResolutions.First().Value != null)
                     {
-                        bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
-                        state.StartTime = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
+                        var dateTime = DateTime.Parse(dateTimeResolutions.First().Value);
+                        var dateTimeConvertType = dateTimeResolutions.First().Timex;
+
+                        if (dateTime != null)
+                        {
+                            bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
+                            state.StartTime = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
+                        }
                     }
                 }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -152,20 +152,10 @@ namespace CalendarSkill
                 }
                 else
                 {
-                    if (state.DialogName == "DeleteEvent")
+                    return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
                     {
-                        return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
-                        {
-                            Prompt = sc.Context.Activity.CreateReply(DeleteEventResponses.NoDeleteStartTime),
-                        });
-                    }
-                    else
-                    {
-                        return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
-                        {
-                            Prompt = sc.Context.Activity.CreateReply(DeleteEventResponses.NoUpdateStartTime),
-                        });
-                    }
+                        Prompt = sc.Context.Activity.CreateReply(DeleteEventResponses.NoDeleteStartTime),
+                    });
                 }
             }
             catch

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -186,7 +186,7 @@ namespace CalendarSkill
 
                 if (state.StartDate != null || state.StartTime != null)
                 {
-                    events = await GetEventsByTime(state.StartDate, state.StartTime, null, state.GetUserTimeZone(), calendarService);
+                    events = await GetEventsByTime(state.StartDate, state.StartTime, state.EndDate, state.EndTime, state.GetUserTimeZone(), calendarService);
                     state.StartDate = null;
                     state.StartTime = null;
                 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -261,11 +261,6 @@ namespace CalendarSkill
         public static async Task<List<EventModel>> GetEventsByTime(DateTime? startDate, DateTime? startTime, DateTime? endDate, DateTime? endTime, TimeZoneInfo userTimeZone, ICalendar calendarService)
         {
             // todo: check input datetime is utc
-            if (startDate == null)
-            {
-                return null;
-            }
-
             var rawEvents = new List<EventModel>();
             var resultEvents = new List<EventModel>();
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -125,7 +125,7 @@ namespace CalendarSkill
                         searchDate = state.StartDate.Value;
                     }
 
-                    var searchedEvents = await GetEventsByTime(searchDate, state.StartTime, state.EndDateTime, state.GetUserTimeZone(), calendarService);
+                    var searchedEvents = await GetEventsByTime(searchDate, state.StartTime, state.EndDate, state.EndTime, state.GetUserTimeZone(), calendarService);
 
                     if (searchedEvents.Count == 0)
                     {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
@@ -165,6 +165,12 @@ namespace CalendarSkill
         {
             try
             {
+                var state = await _accessor.GetAsync(sc.Context);
+                if (state.StartDate != null || state.StartTime != null)
+                {
+                    return await sc.ContinueDialogAsync();
+                }
+
                 if (((UpdateDateTimeDialogOptions)sc.Options).Reason == UpdateDateTimeDialogOptions.UpdateReason.NotFound)
                 {
                     return await sc.PromptAsync(Actions.DateTimePrompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(UpdateEventResponses.NoNewTime) });
@@ -186,7 +192,50 @@ namespace CalendarSkill
             try
             {
                 var state = await _accessor.GetAsync(sc.Context);
-                if (sc.Result != null)
+                if (state.StartDate != null || state.StartTime != null)
+                {
+                    var originalEvent = state.Events[0];
+
+                    if (state.StartDate != null && state.StartTime != null)
+                    {
+                        state.NewStartDateTime = DateTime.SpecifyKind(
+                            new DateTime(
+                                state.StartDate.Value.Year,
+                                state.StartDate.Value.Month,
+                                state.StartDate.Value.Day,
+                                state.StartTime.Value.Hour,
+                                state.StartTime.Value.Minute,
+                                state.StartTime.Value.Second),
+                            DateTimeKind.Utc);
+                    }
+                    else if (state.StartDate != null)
+                    {
+                        state.NewStartDateTime = DateTime.SpecifyKind(
+                            new DateTime(
+                                state.StartDate.Value.Year,
+                                state.StartDate.Value.Month,
+                                state.StartDate.Value.Day,
+                                originalEvent.StartTime.Hour,
+                                originalEvent.StartTime.Minute,
+                                originalEvent.StartTime.Second),
+                            DateTimeKind.Utc);
+                    }
+                    else
+                    {
+                        state.NewStartDateTime = DateTime.SpecifyKind(
+                            new DateTime(
+                                originalEvent.StartTime.Year,
+                                originalEvent.StartTime.Month,
+                                originalEvent.StartTime.Day,
+                                state.StartTime.Value.Hour,
+                                state.StartTime.Value.Minute,
+                                state.StartTime.Value.Second),
+                            DateTimeKind.Utc);
+                    }
+
+                    return await sc.ContinueDialogAsync();
+                }
+                else if (sc.Result != null)
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
                     var newStartTime = DateTime.Parse(dateTimeResolutions.First().Value);
@@ -241,7 +290,7 @@ namespace CalendarSkill
             {
                 var state = await _accessor.GetAsync(sc.Context);
 
-                if (state.StartDate != null || state.StartTime != null || state.Title != null)
+                if (state.OriginalStartDate != null || state.OriginalStartTime != null || state.Title != null)
                 {
                     return await sc.NextAsync();
                 }
@@ -255,20 +304,10 @@ namespace CalendarSkill
                 }
                 else
                 {
-                    if (state.DialogName == "DeleteEvent")
+                    return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
                     {
-                        return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
-                        {
-                            Prompt = sc.Context.Activity.CreateReply(UpdateEventResponses.NoDeleteStartTime),
-                        });
-                    }
-                    else
-                    {
-                        return await sc.PromptAsync(Actions.DateTimePromptForUpdateDelete, new PromptOptions
-                        {
-                            Prompt = sc.Context.Activity.CreateReply(UpdateEventResponses.NoUpdateStartTime),
-                        });
-                    }
+                        Prompt = sc.Context.Activity.CreateReply(UpdateEventResponses.NoUpdateStartTime),
+                    });
                 }
             }
             catch
@@ -287,11 +326,13 @@ namespace CalendarSkill
 
                 var calendarService = _serviceManager.InitCalendarService(state.APIToken, state.EventSource, state.GetUserTimeZone());
 
-                if (state.StartDate != null || state.StartTime != null)
+                if (state.OriginalStartDate != null || state.OriginalStartTime != null)
                 {
-                    events = await GetEventsByTime(state.StartDate, state.StartTime, null, state.GetUserTimeZone(), calendarService);
-                    state.StartDate = null;
-                    state.StartTime = null;
+                    events = await GetEventsByTime(state.OriginalStartDate, state.OriginalStartTime, state.OriginalEndDate, state.OriginalEndTime, state.GetUserTimeZone(), calendarService);
+                    state.OriginalStartDate = null;
+                    state.OriginalStartTime = null;
+                    state.OriginalEndDate = null;
+                    state.OriginalStartTime = null;
                 }
                 else if (state.Title != null)
                 {
@@ -320,7 +361,6 @@ namespace CalendarSkill
 
                     if (startTime != null)
                     {
-                        state.StartDateTime = startTime;
                         startTime = DateTime.SpecifyKind(startTime.Value, DateTimeKind.Local);
                         events = await calendarService.GetEventsByStartTime(startTime.Value);
                     }


### PR DESCRIPTION
Add StartDate, StartTime, EndDate, EndTime, OriginalStartDate, OriginalStartTime, OriginalEndDate, OriginalEndTime usage.
Known issue: The data returned from calendar API are not UTC time. The fix is in #192 . Need merge with it.