### PR TITLE
remove configureawait and async suffix rules

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/VirtualAssistant.ruleset
+++ b/solutions/Virtual-Assistant/src/csharp/VirtualAssistant.ruleset
@@ -5,8 +5,8 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
-    <Rule Id="UseConfigureAwait" Action="Warning" />
     <Rule Id="AvoidAsyncVoid" Action="Warning" />
+    <Rule Id="UseAsyncSuffix" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
@@ -23,8 +23,5 @@
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1609" Action="Warning" />
     <Rule Id="SA1633" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
-    <Rule Id="AvoidAsyncVoid" Action="Warning" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
ConfigureAwait rule doesn't really apply to our project
AsyncSuffix rule doesn't fit our app because e.g. waterfall dialog steps being Async function but not great to add Async as suffix for all of them
