### PR TITLE
Changed customassistant references to virtualassistant in URLs

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.de.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.de.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "Verlinkten Konten",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.es.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.es.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "Cuentas vinculadas",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.fr.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.fr.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "Comptes liés",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.it.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.it.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "Account collegati",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "Linked Accounts",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/Resources/Intro.zh.json
@@ -38,12 +38,12 @@
     {
       "type": "Action.OpenUrl",
       "title": "链接的帐户",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-linkedaccounts.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md"
     },
     {
       "type": "Action.OpenUrl",
       "title": "技能",
-      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/customassistant-skills.md"
+      "url": "https://github.com/Microsoft/AI/blob/master/solutions/Virtual-Assistant/docs/virtualassistant-skills.md"
     }
   ]
 }


### PR DESCRIPTION
## Description
All URLs in Intro jsons seem to be referring to customassistant in the URL which seems to have changed to virtualassistant. Changed them to virtualassistant.

## Related Issue
#238 

## Testing Steps
After starting the first conversation, when clicking on "Linked Accounts" or "Skills" we get 404