### PR TITLE
Remove default coordiantes for POI state

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-skills-pointofinterest.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-skills-pointofinterest.md
@@ -29,7 +29,7 @@ The following scenarios are currently supported by the Skill:
 
 ## Skill Parameters
 The following Parameters are accepted by the Skill and enable additional personalisation of responses to a given user:
-- IPA.Location
+- IPA.Location (*The skill will fail without this as it is missing a user's current coordinates*)
 
 ## Configuration File Information
 The following Configuration entries are required to be passed to the Skill and are provided through the Virtual Assistant appSettings.json file. These should be updated to reflect your LUIS deployment.

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
@@ -156,6 +156,8 @@ namespace PointOfInterestSkill
                 var service = _serviceManager.InitMapsService(GetAzureMapsKey());
                 var routeDirections = new RouteDirections();
 
+                state.CheckForValidCurrentCoordinates();
+
                 if (state.ActiveLocation == null)
                 {
                     // No ActiveLocation found

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
@@ -75,8 +75,11 @@ namespace PointOfInterestSkill
                 }
 
                 var state = await _accessor.GetAsync(sc.Context);
+
                 var service = _serviceManager.InitMapsService(GetAzureMapsKey(), sc.Context.Activity.Locale ?? "en-us");
                 var locationSet = new LocationSet();
+
+                state.CheckForValidCurrentCoordinates();
 
                 if (string.IsNullOrEmpty(state.SearchText) && string.IsNullOrEmpty(state.SearchAddress))
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkillState.cs
@@ -17,7 +17,7 @@ namespace PointOfInterestSkill
             DialogName = string.Empty;
             SearchText = string.Empty;
             SearchAddress = string.Empty;
-            CurrentCoordinates = new LatLng() { Latitude = 47.640568390488625, Longitude = -122.1293731033802 };
+            CurrentCoordinates = null;
             FoundLocations = null;
             ActiveRoute = null;
             SearchDescriptor = string.Empty;
@@ -62,6 +62,14 @@ namespace PointOfInterestSkill
             SearchDescriptor = string.Empty;
             FoundLocations = null;
             LastUtteredNumber = null;
+        }
+
+        public void CheckForValidCurrentCoordinates()
+        {
+            if (CurrentCoordinates == null)
+            {
+                throw new Exception("The bot state is missing any current coordinates. Make sure your event architecture is correctly configured.");
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I've removed the default coordinates in POI, a user will now be required to pass on their own `IPA.Location` event.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#199 

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
**New Conversation**
User: find me directions to Starbucks
Bot: *throws exception, trace shows current coordinates are missing&


**New Conversation**
User: /event:{ "Name": "IPA.Location", "Value": "34.05222222222222,-118.24277777777778" }
User: find me directions to Starbucks
Bot: here's what I found for you...
