### PR TITLE
Email: LU cannot recognize the user selection like "the first one"

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/General.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/General.cs
@@ -8,6 +8,8 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Solutions.Util;
+
 namespace Luis
 {
     public class General: IRecognizerConvert
@@ -63,7 +65,7 @@ namespace Luis
         public virtual (Intent intent, double score) TopIntent()
         {
             Intent maxIntent = Intent.None;
-            var max = 0.0;
+            var max = Util.ScoreThreshold;
             foreach (var entry in Intents)
             {
                 if (entry.Value.Score > max)

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Util/Util.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Util/Util.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Solutions.Util
+{
+    public class Util
+    {
+        public static readonly double ScoreThreshold = 0.5f;
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -16,7 +16,6 @@ using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
-using Microsoft.Bot.Solutions.Util;
 
 namespace CalendarSkill
 {
@@ -223,29 +222,26 @@ namespace CalendarSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
+                    // check intent
+                    switch (topIntent)
                     {
-                        // check intent
-                        switch (topIntent)
-                        {
-                            case General.Intent.Cancel:
-                                {
-                                    result = await OnCancel(dc);
-                                    break;
-                                }
+                        case General.Intent.Cancel:
+                            {
+                                result = await OnCancel(dc);
+                                break;
+                            }
 
-                            case General.Intent.Help:
-                                {
-                                    // result = await OnHelp(dc);
-                                    break;
-                                }
+                        case General.Intent.Help:
+                            {
+                                // result = await OnHelp(dc);
+                                break;
+                            }
 
-                            case General.Intent.Logout:
-                                {
-                                    result = await OnLogout(dc);
-                                    break;
-                                }
-                        }
+                        case General.Intent.Logout:
+                            {
+                                result = await OnLogout(dc);
+                                break;
+                            }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -16,6 +16,7 @@ using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Bot.Solutions.Util;
 
 namespace CalendarSkill
 {
@@ -222,7 +223,7 @@ namespace CalendarSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    if (luisResult.TopIntent().score > 0.5)
+                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
                     {
                         // check intent
                         switch (topIntent)

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -15,7 +15,6 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
-using Microsoft.Bot.Solutions.Util;
 
 namespace EmailSkill
 {
@@ -210,29 +209,25 @@ namespace EmailSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    // check intent
-                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
+                    switch (topIntent)
                     {
-                        switch (topIntent)
-                        {
-                            case General.Intent.Cancel:
-                                {
-                                    result = await OnCancel(dc);
-                                    break;
-                                }
+                        case General.Intent.Cancel:
+                            {
+                                result = await OnCancel(dc);
+                                break;
+                            }
 
-                            case General.Intent.Help:
-                                {
-                                    // result = await OnHelp(dc);
-                                    break;
-                                }
+                        case General.Intent.Help:
+                            {
+                                // result = await OnHelp(dc);
+                                break;
+                            }
 
-                            case General.Intent.Logout:
-                                {
-                                    result = await OnLogout(dc);
-                                    break;
-                                }
-                        }
+                        case General.Intent.Logout:
+                            {
+                                result = await OnLogout(dc);
+                                break;
+                            }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -15,6 +15,7 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Bot.Solutions.Util;
 
 namespace EmailSkill
 {
@@ -210,7 +211,7 @@ namespace EmailSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.5)
+                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
                     {
                         switch (topIntent)
                         {

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
@@ -55,16 +55,6 @@ namespace EmailSkill
                 throw new Exception("You must configure an authentication connection in your bot file before using this component.");
             }
 
-            foreach (var connection in services.AuthenticationConnections)
-            {
-                AddDialog(new OAuthPrompt(connection.Key, new OAuthPromptSettings
-                {
-                    ConnectionName = connection.Value,
-                    Text = $"Please login with your {connection.Key} account.",
-                    Timeout = 30000,
-                }, AuthPromptValidator));
-            }
-
             AddDialog(new EventPrompt(SkillModeAuth, "tokens/response", TokenResponseValidator));
             AddDialog(new MultiProviderAuthDialog(services));
             AddDialog(new TextPrompt(Action.Prompt));
@@ -918,12 +908,12 @@ namespace EmailSkill
                     }
                 }
 
-                if (entity.number != null && entity.ordinal != null)
+                if (entity.number != null && entity.ordinal == null)
                 {
                     try
                     {
                         var emailList = state.MessageList;
-                        var value = entity.ordinal[0];
+                        var value = entity.number[0];
                         if (Math.Abs(value - (int)value) < double.Epsilon)
                         {
                             var num = (int)value;

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Startup.cs
@@ -50,7 +50,7 @@ namespace EmailSkill
             var parameters = Configuration.GetSection("Parameters")?.Get<string[]>();
             var configuration = Configuration.GetSection("Configuration")?.GetChildren()?.ToDictionary(x => x.Key, y => y.Value as object);
             var supportedProviders = Configuration.GetSection("SupportedProviders")?.Get<string[]>();
-            var connectedServices = new SkillConfiguration(botConfig, supportedProviders, parameters, configuration);
+            ISkillConfiguration connectedServices = new SkillConfiguration(botConfig, supportedProviders, parameters, configuration);
             services.AddSingleton(sp => connectedServices);
 
             // Initialize Bot State

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -14,7 +14,6 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
-using Microsoft.Bot.Solutions.Util;
 using PointOfInterestSkill.Dialogs.Main.Resources;
 using PointOfInterestSkill.Dialogs.Route.Resources;
 using PointOfInterestSkill.Dialogs.Shared.Resources;
@@ -280,29 +279,25 @@ namespace PointOfInterestSkill
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
                     var topIntent = luisResult.TopIntent().intent;
 
-                    // check intent
-                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
+                    switch (topIntent)
                     {
-                        switch (topIntent)
-                        {
-                            case General.Intent.Cancel:
-                                {
-                                    result = await OnCancel(dc);
-                                    break;
-                                }
+                        case General.Intent.Cancel:
+                            {
+                                result = await OnCancel(dc);
+                                break;
+                            }
 
-                            case General.Intent.Help:
-                                {
-                                    // result = await OnHelp(dc);
-                                    break;
-                                }
+                        case General.Intent.Help:
+                            {
+                                // result = await OnHelp(dc);
+                                break;
+                            }
 
-                            case General.Intent.Logout:
-                                {
-                                    result = await OnLogout(dc);
-                                    break;
-                                }
-                        }
+                        case General.Intent.Logout:
+                            {
+                                result = await OnLogout(dc);
+                                break;
+                            }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -14,6 +14,7 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Bot.Solutions.Util;
 using PointOfInterestSkill.Dialogs.Main.Resources;
 using PointOfInterestSkill.Dialogs.Route.Resources;
 using PointOfInterestSkill.Dialogs.Shared.Resources;
@@ -280,7 +281,7 @@ namespace PointOfInterestSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.5)
+                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
                     {
                         switch (topIntent)
                         {

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockEmailIntent.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockEmailIntent.cs
@@ -54,7 +54,7 @@ namespace EmailSkillTest.Flow.Fakes
             }
             else if (userInput == "TestName")
             {
-                this.Entities.ContactName = new string[] { "Test test" };
+                this.Entities.ContactName = new string[] { "Test Test" };
                 return (Email.Intent.None, 0.90);
             }
             else if (userInput == "TestContent")
@@ -97,6 +97,11 @@ namespace EmailSkillTest.Flow.Fakes
                 this.Entities.ordinal = new double[] { 1 };
                 return (Email.Intent.SelectItem, 0.90);
             }
+            else if (userInput == "1")
+            {
+                this.Entities.number = new double[] { 1 };
+                return (Email.Intent.SelectItem, 0.90);
+            }
 
             return (Email.Intent.None, 0.0);
         }
@@ -109,7 +114,12 @@ namespace EmailSkillTest.Flow.Fakes
             }
             else if (userInput == "TestName")
             {
-                this.Entities.ContactName = new string[] { "Test test" };
+                this.Entities.ContactName = new string[] { "Test Test" };
+                return (Email.Intent.None, 0.90);
+            }
+            else if (userInput == "TestDupName")
+            {
+                this.Entities.ContactName = new string[] { "TestDup Test" };
                 return (Email.Intent.None, 0.90);
             }
             else if (userInput == "TestSubjcet")
@@ -121,6 +131,16 @@ namespace EmailSkillTest.Flow.Fakes
             {
                 this.Entities.Message = new string[] { "Test message" };
                 return (Email.Intent.None, 0.90);
+            }
+            else if (userInput == "The first one")
+            {
+                this.Entities.ordinal = new double[] { 1 };
+                return (Email.Intent.SelectItem, 0.90);
+            }
+            else if (userInput == "1")
+            {
+                this.Entities.number = new double[] { 1 };
+                return (Email.Intent.SelectItem, 0.90);
             }
 
             return (Email.Intent.None, 0.0);

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockUserService.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockUserService.cs
@@ -20,12 +20,32 @@ namespace EmailSkillTest.Flow.Fakes
 
         public async Task<List<Person>> GetPeopleAsync(string name)
         {
-            return this.People;
+            List<Person> result = new List<Person>();
+
+            foreach (var person in this.People)
+            {
+                if (person.DisplayName == name)
+                {
+                    result.Add(person);
+                }
+            }
+
+            return result;
         }
 
         public async Task<List<User>> GetUserAsync(string name)
         {
-            return this.Users;
+            List<User> result = new List<User>();
+
+            foreach (var user in this.Users)
+            {
+                if (user.DisplayName == name)
+                {
+                    result.Add(user);
+                }
+            }
+
+            return result;
         }
 
         private List<Person> FakePeople()
@@ -60,6 +80,20 @@ namespace EmailSkillTest.Flow.Fakes
                 UserPrincipalName = "test@test.com",
                 Mail = emailAddressStr,
                 DisplayName = "Test Test",
+            });
+
+            users.Add(new User()
+            {
+                UserPrincipalName = "testdup1@test.com",
+                Mail = emailAddressStr,
+                DisplayName = "TestDup Test",
+            });
+
+            users.Add(new User()
+            {
+                UserPrincipalName = "testdup2@test.com",
+                Mail = emailAddressStr,
+                DisplayName = "TestDup Test",
             });
 
             return users;

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/SendEmailFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/SendEmailFlowTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
+using EmailSkill.Dialogs.ConfirmRecipient.Resources;
 using EmailSkill.Dialogs.SendEmail.Resources;
 using EmailSkill.Dialogs.Shared.Resources;
 using Microsoft.Bot.Schema;
@@ -34,6 +35,44 @@ namespace EmailSkillTest.Flow
                 .StartTestAsync();
         }
 
+        [TestMethod]
+        public async Task Test_NotSendingEmailWithMultiUserSelect_Ordinal()
+        {
+            await this.GetTestFlow()
+                .Send("Send Email")
+                .AssertReplyOneOf(this.CollectRecipientsMessage())
+                .Send("TestDupName")
+                .AssertReply(this.CollectRecipients())
+                .Send("The first one")
+                .AssertReply(this.CollectSubjcetMessageDup())
+                .Send("TestSubjcet")
+                .AssertReplyOneOf(this.CollectEmailContentMessage())
+                .Send("TestContent")
+                .AssertReply(this.AssertComfirmBeforeSendingPrompt())
+                .Send("No")
+                .AssertReplyOneOf(this.NotSendingMessage())
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Test_NotSendingEmailWithMultiUserSelect_Number()
+        {
+            await this.GetTestFlow()
+                .Send("Send Email")
+                .AssertReplyOneOf(this.CollectRecipientsMessage())
+                .Send("TestDupName")
+                .AssertReply(this.CollectRecipients())
+                .Send("1")
+                .AssertReply(this.CollectSubjcetMessageDup())
+                .Send("TestSubjcet")
+                .AssertReplyOneOf(this.CollectEmailContentMessage())
+                .Send("TestContent")
+                .AssertReply(this.AssertComfirmBeforeSendingPrompt())
+                .Send("No")
+                .AssertReplyOneOf(this.NotSendingMessage())
+                .StartTestAsync();
+        }
+
         private string[] NotSendingMessage()
         {
             return this.ParseReplies(EmailSharedResponses.ActionEnded.Replies, new StringDictionary());
@@ -52,6 +91,41 @@ namespace EmailSkillTest.Flow
         private string[] CollectRecipientsMessage()
         {
             return this.ParseReplies(EmailSharedResponses.NoRecipients.Replies, new StringDictionary());
+        }
+
+        private Action<IActivity> CollectRecipients()
+        {
+            return activity =>
+            {
+                var messageActivity = activity.AsMessageActivity();
+                var recipientConfirmedMessage = this.ParseReplies(ConfirmRecipientResponses.ConfirmRecipientLastPage.Replies, new StringDictionary());
+
+                Assert.IsTrue(recipientConfirmedMessage.Length == 1);
+                Assert.IsTrue(messageActivity.Text.StartsWith(recipientConfirmedMessage[0]));
+            };
+        }
+
+        private Action<IActivity> CollectSubjcetMessageDup()
+        {
+            return activity =>
+            {
+                var messageActivity = activity.AsMessageActivity();
+                var recipientConfirmedMessage = this.ParseReplies(EmailSharedResponses.RecipientConfirmed.Replies, new StringDictionary() { { "UserName", "TestDup Test" } });
+                var noSubjectMessage = this.ParseReplies(SendEmailResponses.NoSubject.Replies, new StringDictionary());
+
+                string[] subjectVerifyInfo = new string[recipientConfirmedMessage.Length * noSubjectMessage.Length];
+                int index = -1;
+                foreach (var confirmNsg in recipientConfirmedMessage)
+                {
+                    foreach (var noSubjectMsg in noSubjectMessage)
+                    {
+                        index++;
+                        subjectVerifyInfo[index] = confirmNsg + " " + noSubjectMsg;
+                    }
+                }
+
+                CollectionAssert.Contains(subjectVerifyInfo, messageActivity.Text);
+            };
         }
 
         private Action<IActivity> CollectSubjcetMessage()

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/ShowEmailFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/ShowEmailFlowTests.cs
@@ -18,13 +18,28 @@ namespace EmailSkillTest.Flow
         }
 
         [TestMethod]
-        public async Task Test_NotSendingEmail()
+        public async Task Test_NotSendingEmailWithOrdinalSelection()
         {
             await this.GetTestFlow()
                 .Send("Show Emails")
                 .AssertReply(this.ShowEmailList())
                 .AssertReplyOneOf(this.ReadOutPrompt())
                 .Send("The first one")
+                .AssertReply(this.AssertSelectOneOfTheMessage())
+                .AssertReplyOneOf(this.ReadOutMorePrompt())
+                .Send("No")
+                .AssertReplyOneOf(this.ActionEndMessage())
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Test_NotSendingEmailWithNumberSelection()
+        {
+            await this.GetTestFlow()
+                .Send("Show Emails")
+                .AssertReply(this.ShowEmailList())
+                .AssertReplyOneOf(this.ReadOutPrompt())
+                .Send("1")
                 .AssertReply(this.AssertSelectOneOfTheMessage())
                 .AssertReplyOneOf(this.ReadOutMorePrompt())
                 .Send("No")

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -13,6 +13,7 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Bot.Solutions.Util;
 using ToDoSkill.Dialogs.Main.Resources;
 using ToDoSkill.Dialogs.Shared.Resources;
 
@@ -199,7 +200,7 @@ namespace ToDoSkill
                     var topIntent = luisResult.TopIntent().intent;
 
                     // check intent
-                    if (luisResult.TopIntent().score > 0.5)
+                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
                     {
                         switch (topIntent)
                         {

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -13,7 +13,6 @@ using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Skills;
-using Microsoft.Bot.Solutions.Util;
 using ToDoSkill.Dialogs.Main.Resources;
 using ToDoSkill.Dialogs.Shared.Resources;
 
@@ -199,29 +198,25 @@ namespace ToDoSkill
                     state.GeneralLuisResult = luisResult;
                     var topIntent = luisResult.TopIntent().intent;
 
-                    // check intent
-                    if (luisResult.TopIntent().score > Util.ScoreThreshold)
+                    switch (topIntent)
                     {
-                        switch (topIntent)
-                        {
-                            case General.Intent.Cancel:
-                                {
-                                    result = await OnCancel(dc);
-                                    break;
-                                }
+                        case General.Intent.Cancel:
+                            {
+                                result = await OnCancel(dc);
+                                break;
+                            }
 
-                            case General.Intent.Help:
-                                {
-                                    // result = await OnHelp(dc);
-                                    break;
-                                }
+                        case General.Intent.Help:
+                            {
+                                // result = await OnHelp(dc);
+                                break;
+                            }
 
-                            case General.Intent.Logout:
-                                {
-                                    result = await OnLogout(dc);
-                                    break;
-                                }
-                        }
+                        case General.Intent.Logout:
+                            {
+                                result = await OnLogout(dc);
+                                break;
+                            }
                     }
                 }
             }


### PR DESCRIPTION
## Description
Fix Email issue: LU cannot recognize the user selection like "the first one".
Add related UT cases.

## Related Issue
Email: LU cannot recognize the user selection like "the first one" "1" #254

## Testing Steps
User: Show emails
Bot: (Email list) which one do you want to read?
User: 1
Bot: (The first one is selected)

User: Send an email to test
Bot: (Multi user showed) which one do you want to sent to?
User: The first one
Bot: (The first one is selected)
