### PR TITLE
Provide the ability to control userId in LinkedAccounts

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/HomeController.cs
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/HomeController.cs
@@ -10,6 +10,7 @@ namespace LinkedAccounts.Web.Controllers
     using System.Threading.Tasks;
     using LinkedAccounts.Web.Models;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
@@ -121,6 +122,18 @@ namespace LinkedAccounts.Web.Controllers
             return RedirectToAction("LinkedAccounts");
         }
 
+        
+        [HttpPost]
+        public async Task<IActionResult> ChangeUserId(LinkedAcountViewModel model)
+        {
+            if (ModelState.IsValid)
+            {                               
+                this.HttpContext.Session.SetString("ChangedUserId", model.UserId);                                
+            }
+
+            return RedirectToAction("LinkedAccounts");
+        }
+
         public IActionResult About()
         {
             ViewData["Message"] = "Your application description page.";
@@ -143,21 +156,29 @@ namespace LinkedAccounts.Web.Controllers
 
         private string GetUserId()
         {
-            var claimsIdentity = this.User?.Identity as System.Security.Claims.ClaimsIdentity;
-            
-            if(claimsIdentity == null)
+            // If the user has overriden (to work around emulator blocker)
+            if (!string.IsNullOrEmpty(HttpContext.Session.GetString("ChangedUserId")))            
             {
-                throw new InvalidOperationException("User is not logged in and needs to be.");
+                return HttpContext.Session.GetString("ChangedUserId");
             }
-
-            var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == AadObjectidentifierClaim)?.Value;
-
-            if(objectId == null)
+            else
             {
-                throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
-            }
+                var claimsIdentity = this.User?.Identity as System.Security.Claims.ClaimsIdentity;
 
-            return objectId;
+                if (claimsIdentity == null)
+                {
+                    throw new InvalidOperationException("User is not logged in and needs to be.");
+                }
+
+                var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == AadObjectidentifierClaim)?.Value;
+
+                if (objectId == null)
+                {
+                    throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
+                }
+
+                return objectId;
+            }
         }
 
         public const string AadObjectidentifierClaim = "http://schemas.microsoft.com/identity/claims/objectidentifier";

--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/LinkedAccountRepository.cs
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/LinkedAccountRepository.cs
@@ -13,6 +13,7 @@ namespace LinkedAccounts.Web.Controllers
     using Microsoft.Bot.Connector;
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
+    using System.Linq;
 
     public class LinkedAccountRepository : ILinkedAccountRepository
     {
@@ -74,7 +75,7 @@ namespace LinkedAccounts.Web.Controllers
                 link = await adapter.GetOauthSignInLinkAsync(context, connectionName, userId, finalRedirect);
 
                 // Add on code_challenge (SessionId) into the redirect
-                SessionController.Sessions.TryGetValue(userId, out string sessionId);
+                var sessionId = SessionController.Sessions.Single().Value;
 
                 if (!string.IsNullOrEmpty(sessionId))
                 {

--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Startup.cs
@@ -50,6 +50,15 @@ namespace LinkedAccounts.Web
 
             services.AddSingleton<ICredentialProvider>(new ConfigurationCredentialProvider(Configuration));
 
+            services.AddDistributedMemoryCache();
+
+            services.AddSession(options =>
+            {
+                // Set a short timeout for easy testing.
+                options.IdleTimeout = TimeSpan.FromSeconds(120);
+                options.Cookie.HttpOnly = true;
+            });
+
             services.AddMvc();
         }
 
@@ -70,12 +79,15 @@ namespace LinkedAccounts.Web
 
             app.UseAuthentication();
 
+            app.UseSession();
+
             app.UseMvc(routes =>
             {
                 routes.MapRoute(
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
             });
+
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Views/Home/LinkedAccounts.cshtml
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Views/Home/LinkedAccounts.cshtml
@@ -33,56 +33,65 @@ else
 {
     <div>
         <div class="linkedAccount-title">Linked Accounts</div>
-        <div class="linkedAccount-displayName">UserID: @Model.UserId</div>
-        <div class="linkedAccount-list">
-            <div class="linkedAccount-header">
-                <div class="linkedAccount-header-label linkedAccount-header-connectionName">Connection Name</div>
-                <div class="linkedAccount-header-label linkedAccount-header-displayName">Service Provider</div>
-                <div class="linkedAccount-header-label linkedAccount-header-status">Status</div>
-            </div>
 
-            @foreach (var account in Model.Status)
-            {
-            <div class="linkedAccount">
-                <div class="linkedAccount-label linkedAccount-connectionName">@account.ConnectionName</div>
-                <div class="linkedAccount-label linkedAccount-displayName">@account.ServiceProviderDisplayName</div>
-                @if (!account.HasToken)
+            <div class="linkedAccount-displayName">
+                User ID:
+                @using (Html.BeginForm("ChangeUserId", "Home", FormMethod.Post))
                 {
-                    <div class="linkedAccount-label linkedAccount-status">
-                        <div class="icon">
-                            <svg viewBox="0 0 34 34">
-                                <circle cx="16" cy="16" r="15" stroke="black" stroke-width="2" fill="gray" />
-                                Sorry, your browser does not support inline SVG.
-                            </svg>
-                        </div>
-                        <div class="online-status">
-                            Offline
-                        </div>
-                    </div>
-                    <div id="signin"></div>
-                    @Html.ActionLink("Sign In", "SignIn", "Home", account, new { @class = "button linkedAccount-action" })
-                }
-                else
-                {
-                    <div class="linkedAccount-label linkedAccount-status">
-                        <div class="icon">
-                            <svg viewBox="0 0 34 34">
-                                <circle cx="16" cy="16" r="15" stroke="black" stroke-width="2" fill="#22ee22" />
-                                Sorry, your browser does not support inline SVG.
-                            </svg>
-                        </div>
-                        <div class="online-status">
-                            Online
-                        </div>
-                    </div>
-                    @Html.ActionLink("Sign Out", "SignOut", "Home", account, new { @class = "button linkedAccount-action" })
+                    @Html.TextBoxFor(model => model.UserId, new { style = "width:300px;" })
+                    <button type="submit">Change</button>
                 }
             </div>
-            }
-        </div>
 
-        <div class="linkedAccount-actions">
-            @Html.ActionLink("Sign Out All", "SignOutAll", "Home", null, new { @class = "button" })
+            <div class="linkedAccount-list">
+                <div class="linkedAccount-header">
+                    <div class="linkedAccount-header-label linkedAccount-header-connectionName">Connection Name</div>
+                    <div class="linkedAccount-header-label linkedAccount-header-displayName">Service Provider</div>
+                    <div class="linkedAccount-header-label linkedAccount-header-status">Status</div>
+                </div>
+
+                @foreach (var account in Model.Status)
+                {
+                    <div class="linkedAccount">
+                        <div class="linkedAccount-label linkedAccount-connectionName">@account.ConnectionName</div>
+                        <div class="linkedAccount-label linkedAccount-displayName">@account.ServiceProviderDisplayName</div>
+                        @if (!account.HasToken)
+                        {
+                            <div class="linkedAccount-label linkedAccount-status">
+                                <div class="icon">
+                                    <svg viewBox="0 0 34 34">
+                                        <circle cx="16" cy="16" r="15" stroke="black" stroke-width="2" fill="gray"></circle>
+                                        Sorry, your browser does not support inline SVG.
+                                    </svg>
+                                </div>
+                                <div class="online-status">
+                                    Offline
+                                </div>
+                            </div>
+                            <div id="signin"></div>
+                            @Html.ActionLink("Sign In", "SignIn", "Home", account, new { @class = "button linkedAccount-action" })
+                        }
+                        else
+                        {
+                            <div class="linkedAccount-label linkedAccount-status">
+                                <div class="icon">
+                                    <svg viewBox="0 0 34 34">
+                                        <circle cx="16" cy="16" r="15" stroke="black" stroke-width="2" fill="#22ee22" />
+                                        Sorry, your browser does not support inline SVG.
+                                    </svg>
+                                </div>
+                                <div class="online-status">
+                                    Online
+                                </div>
+                            </div>
+                            @Html.ActionLink("Sign Out", "SignOut", "Home", account, new { @class = "button linkedAccount-action" })
+                        }
+                    </div>
+                }
+            </div>
+
+            <div class="linkedAccount-actions">
+                @Html.ActionLink("Sign Out All", "SignOutAll", "Home", null, new { @class = "button" })
+            </div>
         </div>
-    </div>
-}
+        }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Converted the UserId display to a TextBox enabling the user to paste in a different userId supporting demos in the Emulator (fixed UserId) and the new webchat ahead of it "logging in" and using the right userid.

## Testing Steps

- Start Linked Accounts
- Change the UserId (to anything)
- click the button, signin (should go green)
- change the userid to something else - signin circle should not be green
- switch back to previous userid - now green