### PR TITLE
Updated inputHint to ignoringInput

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Microsoft.Bot.Solutions.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Microsoft.Bot.Solutions.csproj
@@ -61,7 +61,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Resources\CommonResponses.tt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <LastGenOutput>CommonResponses.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
     </None>

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.json
@@ -248,6 +248,6 @@
         "speak": "This is the best route to your destination."
       }
     ],
-    "inputHint": "expectingInput"
+    "inputHint": "ignoringInput"
   }
 }


### PR DESCRIPTION
## Description

- Updated inputHint to ignoringInput so the mic doesn't get open before the next prompt. 
- Updated solutions project so CommonResponses.tt doesn't get copied to the output folder.

## Testing Steps
using the microphone say:

1. Find a starbucks
2. Get option 1
3. The bot should not open the mic until the Shall we get started prompt is rendered.

For the tt file, simply rebuild the solution and ensure that there are not .tt files in the bin folders.