### PR TITLE
Add support for proactive messaging

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -24,25 +24,27 @@ namespace VirtualAssistant
         private BotConfiguration _botConfig;
         private UserState _userState;
         private ConversationState _conversationState;
+        private EndpointService _endpointService;
         private IStatePropertyAccessor<OnboardingState> _onboardingState;
         private IStatePropertyAccessor<Dictionary<string, object>> _parametersAccessor;
         private MainResponses _responder = new MainResponses();
         private SkillRouter _skillRouter;
 
-        public MainDialog(BotServices services, BotConfiguration botConfig, ConversationState conversationState, UserState userState)
+        public MainDialog(BotServices services, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService)
             : base(nameof(MainDialog))
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _botConfig = botConfig;
             _conversationState = conversationState;
             _userState = userState;
+            _endpointService = endpointService;
             _onboardingState = _userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
             _parametersAccessor = _userState.CreateProperty<Dictionary<string, object>>("userInfo");
             var dialogState = _conversationState.CreateProperty<DialogState>(nameof(DialogState));
 
             AddDialog(new OnboardingDialog(_services, _onboardingState));
             AddDialog(new EscalateDialog(_services));
-            AddDialog(new CustomSkillDialog(_services.SkillConfigurations, dialogState));
+            AddDialog(new CustomSkillDialog(_services.SkillConfigurations, dialogState, endpointService));
 
             // Initialize skill dispatcher
             _skillRouter = new SkillRouter(_services.SkillDefinitions);

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/CustomSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/CustomSkillDialog.cs
@@ -1,20 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Skills;
 
 namespace VirtualAssistant
 {
     public class CustomSkillDialog : ComponentDialog
     {
-        public CustomSkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor)
+        public CustomSkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService)
             : base(nameof(CustomSkillDialog))
         {
-            AddDialog(new SkillDialog(skills, accessor));
+            AddDialog(new SkillDialog(skills, accessor, endpointService));
         }
 
         protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -21,23 +21,27 @@ namespace VirtualAssistant
         private readonly BotConfiguration _botConfig;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
+        private readonly EndpointService _endpointService;
         private DialogSet _dialogs;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VirtualAssistant"/> class.
         /// </summary>
+        /// <param name="botConfig">Bot configuration.</param>
         /// <param name="botServices">Bot services.</param>
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
-        public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState)
+        /// <param name="endpointService">Bot endpoint service.</param>
+        public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
+            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _botConfig = botConfig;
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(VirtualAssistant)));
-            _dialogs.Add(new MainDialog(_services, _botConfig, _conversationState, _userState));
+            _dialogs.Add(new MainDialog(_services, _botConfig, _conversationState, _userState, _endpointService));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/InProcAdapter.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/InProcAdapter.cs
@@ -1,12 +1,12 @@
-﻿namespace Microsoft.Bot.Solutions.Skills
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Schema;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
 
+namespace Microsoft.Bot.Solutions.Skills
+{
     /// <summary>
     /// We want to invoke skills "in process" rather than invoking through DirectLine/Connector which his heavyweight and overlays additional security
     /// BUT we want to preserve standard BF communication protocols so leverage the Adapter pattern to interact with Skills.
@@ -54,14 +54,10 @@
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var activity = new Activity().ApplyConversationReference(reference, true);
-
-            using (var context = new TurnContext(this, activity))
+            using (var context = new TurnContext(this, reference.GetContinuationActivity()))
             {
                 await RunPipelineAsync(context, callback, cancellationToken);
             }
-
-            await base.ContinueConversationAsync(botId, reference, callback, cancellationToken);
         }
 
         public Activity GetNextReply()

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Bot.Solutions.Skills
                     else
                     {
                         // if the conversation id from the activity is differnt from the context activity, it's proactive message
-                        await dc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, firstActivity.GetConversationReference(), CreateCallback(queue), default(CancellationToken));
+                        await dc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, firstActivity.GetConversationReference(), CreateCallback(queue.ToArray()), default(CancellationToken));
                     }
                 }
 
@@ -292,13 +292,12 @@ namespace Microsoft.Bot.Solutions.Skills
             }
         }
 
-        // Creates the turn logic to use for the proactive message.
-        private BotCallbackHandler CreateCallback(List<Activity> activities)
+        private BotCallbackHandler CreateCallback(Activity[] activities)
         {
             return async (turnContext, token) =>
             {
-                // Send the user a proactive confirmation message.
-                await turnContext.SendActivitiesAsync(activities.ToArray());
+                // Send back the activities in the proactive context
+                await turnContext.SendActivitiesAsync(activities, token);
             };
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Middleware;
@@ -19,17 +20,19 @@ namespace Microsoft.Bot.Solutions.Skills
         // Fields
         private Dictionary<string, ISkillConfiguration> _skills;
         private IStatePropertyAccessor<DialogState> _accessor;
+        private EndpointService _endpointService;
         private DialogSet _dialogs;
         private InProcAdapter _inProcAdapter;
         private IBot _activatedSkill;
         private bool _skillInitialized;
         private bool _useCachedTokens;
 
-        public SkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, bool useCachedTokens = true)
+        public SkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService, bool useCachedTokens = true)
             : base(nameof(SkillDialog))
         {
             _skills = skills;
             _accessor = accessor;
+            _endpointService = endpointService;
             _useCachedTokens = useCachedTokens;
             _dialogs = new DialogSet(_accessor);
         }
@@ -255,7 +258,17 @@ namespace Microsoft.Bot.Solutions.Skills
                 // send skill queue to User
                 if (queue.Count > 0)
                 {
-                    await dc.Context.SendActivitiesAsync(queue.ToArray());
+                    var firstActivity = queue[0];
+                    if (firstActivity.Conversation.Id == dc.Context.Activity.Conversation.Id)
+                    {
+                        // if the conversation id from the activity is the same as the context activity, it's reactive message
+                        await dc.Context.SendActivitiesAsync(queue.ToArray());
+                    }
+                    else
+                    {
+                        // if the conversation id from the activity is differnt from the context activity, it's proactive message
+                        await dc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, firstActivity.GetConversationReference(), CreateCallback(queue), default(CancellationToken));
+                    }
                 }
 
                 // handle ending the skill conversation
@@ -277,6 +290,16 @@ namespace Microsoft.Bot.Solutions.Skills
                 await dc.EndDialogAsync();
                 throw;
             }
+        }
+
+        // Creates the turn logic to use for the proactive message.
+        private BotCallbackHandler CreateCallback(List<Activity> activities)
+        {
+            return async (turnContext, token) =>
+            {
+                // Send the user a proactive confirmation message.
+                await turnContext.SendActivitiesAsync(activities.ToArray());
+            };
         }
 
         private class Events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Currently the VA doesn't support proactive messaging sending from skill. The InProcAdapter would pass anything back to the user using Context.SendActivityAsync and it'll override the conversation reference in the activities using the context's activity information.


## Testing Steps
This change lays the foundation for skills to support proactive messaging so there's no testing for proactive scenarios at this point. However I'm able to verify that all current scenarios stays unaffected.
