### PR TITLE
Enable Next/Previous intents in skill mode

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -27,6 +27,7 @@ namespace VirtualAssistant
         private EndpointService _endpointService;
         private IStatePropertyAccessor<OnboardingState> _onboardingState;
         private IStatePropertyAccessor<Dictionary<string, object>> _parametersAccessor;
+        private IStatePropertyAccessor<VirtualAssistantState> _virtualAssistantState;
         private MainResponses _responder = new MainResponses();
         private SkillRouter _skillRouter;
 
@@ -40,6 +41,7 @@ namespace VirtualAssistant
             _endpointService = endpointService;
             _onboardingState = _userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
             _parametersAccessor = _userState.CreateProperty<Dictionary<string, object>>("userInfo");
+            _virtualAssistantState = _conversationState.CreateProperty<VirtualAssistantState>(nameof(VirtualAssistantState));
             var dialogState = _conversationState.CreateProperty<DialogState>(nameof(DialogState));
 
             AddDialog(new OnboardingDialog(_services, _onboardingState));
@@ -67,6 +69,7 @@ namespace VirtualAssistant
         protected override async Task RouteAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var parameters = await _parametersAccessor.GetAsync(dc.Context, () => new Dictionary<string, object>());
+            var virtualAssistantState = await _virtualAssistantState.GetAsync(dc.Context, () => new VirtualAssistantState());
 
             // No dialog is currently on the stack and we haven't responded to the user
             // Check dispatch result
@@ -121,6 +124,23 @@ namespace VirtualAssistant
                                         break;
                                     }
 
+                                case General.Intent.Next:
+                                case General.Intent.Previous:
+                                    {
+                                        var lastExecutedIntent = virtualAssistantState.ExecutedIntents.Last();
+                                        if (lastExecutedIntent != null)
+                                        {
+                                            var matchedSkill = _skillRouter.IdentifyRegisteredSkill(lastExecutedIntent);
+                                            await RouteToSkillAsync(dc, new SkillDialogOptions()
+                                            {
+                                                SkillDefinition = matchedSkill,
+                                                Parameters = parameters,
+                                            });
+                                        }
+
+                                        break;
+                                    }
+
                                 case General.Intent.None:
                                 default:
                                     {
@@ -139,6 +159,7 @@ namespace VirtualAssistant
                 case Dispatch.Intent.l_ToDo:
                 case Dispatch.Intent.l_PointOfInterest:
                     {
+                        virtualAssistantState.ExecutedIntents.Add(intent.ToString());
                         var matchedSkill = _skillRouter.IdentifyRegisteredSkill(intent.ToString());
 
                         await RouteToSkillAsync(dc, new SkillDialogOptions()

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -127,7 +127,7 @@ namespace VirtualAssistant
                                 case General.Intent.Next:
                                 case General.Intent.Previous:
                                     {
-                                        var lastExecutedIntent = virtualAssistantState.ExecutedIntents.Last();
+                                        var lastExecutedIntent = virtualAssistantState.LastIntent;
                                         if (lastExecutedIntent != null)
                                         {
                                             var matchedSkill = _skillRouter.IdentifyRegisteredSkill(lastExecutedIntent);
@@ -159,7 +159,7 @@ namespace VirtualAssistant
                 case Dispatch.Intent.l_ToDo:
                 case Dispatch.Intent.l_PointOfInterest:
                     {
-                        virtualAssistantState.ExecutedIntents.Add(intent.ToString());
+                        virtualAssistantState.LastIntent = intent.ToString();
                         var matchedSkill = _skillRouter.IdentifyRegisteredSkill(intent.ToString());
 
                         await RouteToSkillAsync(dc, new SkillDialogOptions()

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace VirtualAssistant
+﻿namespace VirtualAssistant
 {
     public class VirtualAssistantState
     {
@@ -9,15 +7,15 @@ namespace VirtualAssistant
         /// </summary>
         public VirtualAssistantState()
         {
-            ExecutedIntents = new List<string>();
+            LastIntent = null;
         }
 
         /// <summary>
-        /// Gets or sets ExecutedIntents.
+        /// Gets or sets LastIntent.
         /// </summary>
         /// <value>
         /// ToDoTaskContent.
         /// </value>
-        public List<string> ExecutedIntents { get; set; }
+        public string LastIntent { get; set; }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace VirtualAssistant
+{
+    public class VirtualAssistantState
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VirtualAssistantState"/> class.
+        /// </summary>
+        public VirtualAssistantState()
+        {
+            ExecutedIntents = new List<string>();
+        }
+
+        /// <summary>
+        /// Gets or sets ExecutedIntents.
+        /// </summary>
+        /// <value>
+        /// ToDoTaskContent.
+        /// </value>
+        public List<string> ExecutedIntents { get; set; }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistantState.cs
@@ -3,14 +3,6 @@
     public class VirtualAssistantState
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="VirtualAssistantState"/> class.
-        /// </summary>
-        public VirtualAssistantState()
-        {
-            LastIntent = null;
-        }
-
-        /// <summary>
         /// Gets or sets LastIntent.
         /// </summary>
         /// <value>


### PR DESCRIPTION
Enable Next/Previous intents in skill mode 
## Description
Enable some scenarios like "show more" or "show previous" under skill mode.

## Related Issue
#264 

## Testing Steps
Launch Virtual Assistant and add more than 5 items to you to do list with utterances like "add a to do to call my mother". Then,
User: show my to do list.
Expect response: a adaptive of first 5 added tasks.
User: show next page.
Expect response: other tasks except the first 5 ones.
User: show previous page.
Expect response: the first 5 tasks.
