### PR TITLE
POI Skill: clearing previous LUIS entities 

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/CancelRouteDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/CancelRouteDialog.cs
@@ -46,6 +46,8 @@ namespace PointOfInterestSkill
                     await sc.Context.SendActivityAsync(replyMessage);
                 }
 
+                state.ClearLuisResults();
+
                 return await sc.EndDialogAsync();
             }
             catch

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
@@ -182,6 +182,8 @@ namespace PointOfInterestSkill
                     return await sc.PromptAsync(Action.ConfirmPrompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(RouteResponses.PromptToStartRoute, ResponseBuilder) });
                 }
 
+                state.ClearLuisResults();
+
                 return await sc.EndDialogAsync();
             }
             catch

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
@@ -107,6 +107,8 @@ namespace PointOfInterestSkill
                     return await sc.PromptAsync(Action.ConfirmPrompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(POISharedResponses.PromptToGetRoute, ResponseBuilder) });
                 }
 
+                state.ClearLuisResults();
+
                 return await sc.EndDialogAsync(true);
             }
             catch
@@ -356,7 +358,7 @@ namespace PointOfInterestSkill
 
                     if (entities.DESCRIPTOR != null && entities.DESCRIPTOR.Length != 0)
                     {
-                        state.SearchDescriptor = string.Join(" ", entities.DESCRIPTOR);
+                        state.SearchDescriptor = entities.DESCRIPTOR[0];
                     }
 
                     if (entities.number != null && entities.number.Length != 0)

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkillState.cs
@@ -62,6 +62,17 @@ namespace PointOfInterestSkill
             LastUtteredNumber = null;
         }
 
+        /// <summary>
+        /// Clear LUIS results in state for next dialog turn.
+        /// </summary>
+        public void ClearLuisResults()
+        {
+            SearchText = string.Empty;
+            SearchAddress = string.Empty;
+            SearchDescriptor = string.Empty;
+            LastUtteredNumber = null;
+        }
+
         public void CheckForValidCurrentCoordinates()
         {
             if (CurrentCoordinates == null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Original issue filed was related to "option #" utterances being used inconsistently, it is related to LUIS results from previous utterances not being cleared. For example, the business logic chose the entity "Starbucks" from a previous utterance before "Option 1." 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#292 by @gabog 

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
![image](https://user-images.githubusercontent.com/43043272/48745683-390c8d80-ec21-11e8-8791-53176e328753.png)
![image](https://user-images.githubusercontent.com/43043272/48745691-3f026e80-ec21-11e8-8f3b-d17f0f5053df.png)
![image](https://user-images.githubusercontent.com/43043272/48745697-445fb900-ec21-11e8-82c1-297d912e1766.png)