### PR TITLE
Support predict time from multiple date time results and fix a few bugs

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkillState.cs
@@ -14,18 +14,18 @@ namespace CalendarSkill
             UserInfo = new UserInformation();
             Title = null;
             Content = null;
-            StartDate = null;
+            StartDate = new List<DateTime>();
             StartDateString = null;
-            StartTime = null;
+            StartTime = new List<DateTime>();
             StartTimeString = null;
             StartDateTime = null;
-            EndDate = null;
-            EndTime = null;
+            EndDate = new List<DateTime>();
+            EndTime = new List<DateTime>();
             EndDateTime = null;
-            OriginalStartDate = null;
-            OriginalStartTime = null;
-            OriginalEndDate = null;
-            OriginalEndTime = null;
+            OriginalStartDate = new List<DateTime>();
+            OriginalStartTime = new List<DateTime>();
+            OriginalEndDate = new List<DateTime>();
+            OriginalEndTime = new List<DateTime>();
             Location = null;
             Attendees = new List<EventModel.Attendee>();
             APIToken = null;
@@ -56,31 +56,31 @@ namespace CalendarSkill
         public string Content { get; set; }
 
         // user time zone
-        public DateTime? StartDate { get; set; }
+        public List<DateTime> StartDate { get; set; }
 
         // user time zone
-        public DateTime? StartTime { get; set; }
+        public List<DateTime> StartTime { get; set; }
 
         // UTC
         public DateTime? StartDateTime { get; set; }
 
         // user time zone
-        public DateTime? EndDate { get; set; }
+        public List<DateTime> EndDate { get; set; }
 
         // user time zone
-        public DateTime? EndTime { get; set; }
+        public List<DateTime> EndTime { get; set; }
 
         // user time zone
-        public DateTime? OriginalStartDate { get; set; }
+        public List<DateTime> OriginalStartDate { get; set; }
 
         // user time zone
-        public DateTime? OriginalStartTime { get; set; }
+        public List<DateTime> OriginalStartTime { get; set; }
 
         // user time zone
-        public DateTime? OriginalEndDate { get; set; }
+        public List<DateTime> OriginalEndDate { get; set; }
 
         // user time zone
-        public DateTime? OriginalEndTime { get; set; }
+        public List<DateTime> OriginalEndTime { get; set; }
 
         // UTC
         public DateTime? EndDateTime { get; set; }
@@ -135,18 +135,18 @@ namespace CalendarSkill
             User = new User();
             Title = null;
             Content = null;
-            StartDate = null;
+            StartDate = new List<DateTime>();
             StartDateString = null;
-            StartTime = null;
+            StartTime = new List<DateTime>();
             StartTimeString = null;
             StartDateTime = null;
-            EndDate = null;
-            EndTime = null;
+            EndDate = new List<DateTime>();
+            EndTime = new List<DateTime>();
             EndDateTime = null;
-            OriginalStartDate = null;
-            OriginalStartTime = null;
-            OriginalEndDate = null;
-            OriginalEndTime = null;
+            OriginalStartDate = new List<DateTime>();
+            OriginalStartTime = new List<DateTime>();
+            OriginalEndDate = new List<DateTime>();
+            OriginalEndTime = new List<DateTime>();
             Location = null;
             Attendees = new List<EventModel.Attendee>();
             APIToken = null;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -192,7 +192,7 @@ namespace CalendarSkill
                     }
                 }
 
-                if (state.StartDate == null)
+                if (!state.StartDate.Any())
                 {
                     return await sc.BeginDialogAsync(Actions.UpdateStartDateForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotFound), cancellationToken);
                 }
@@ -667,34 +667,37 @@ namespace CalendarSkill
                 if (sc.Result != null)
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    var dateTimeConvertType = dateTimeResolutions.Last()?.Timex;
-                    var dateTimeValue = dateTimeResolutions.Last()?.Value;
-                    if (dateTimeValue != null)
+                    foreach (var resolution in dateTimeResolutions)
                     {
-                        var dateTime = DateTime.Parse(dateTimeValue);
-
-                        if (dateTime != null)
+                        var dateTimeConvertType = resolution?.Timex;
+                        var dateTimeValue = resolution?.Value;
+                        if (dateTimeValue != null)
                         {
-                            var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
-                            if (ContainsTime(dateTimeConvertType))
-                            {
-                                state.StartTime = TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone());
-                            }
+                            var dateTime = DateTime.Parse(dateTimeValue);
 
-                            // Workaround as DateTimePrompt only return as local time
-                            if (isRelativeTime)
+                            if (dateTime != null)
                             {
-                                dateTime = new DateTime(
-                                    dateTime.Year,
-                                    dateTime.Month,
-                                    dateTime.Day,
-                                    DateTime.Now.Hour,
-                                    DateTime.Now.Minute,
-                                    DateTime.Now.Second);
-                            }
+                                var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
+                                if (ContainsTime(dateTimeConvertType))
+                                {
+                                    state.StartTime.Add(TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()));
+                                }
 
-                            state.StartDate = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
-                            return await sc.EndDialogAsync(cancellationToken: cancellationToken);
+                                // Workaround as DateTimePrompt only return as local time
+                                if (isRelativeTime)
+                                {
+                                    dateTime = new DateTime(
+                                        dateTime.Year,
+                                        dateTime.Month,
+                                        dateTime.Day,
+                                        DateTime.Now.Hour,
+                                        DateTime.Now.Minute,
+                                        DateTime.Now.Second);
+                                }
+
+                                state.StartDate.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                                return await sc.EndDialogAsync(cancellationToken: cancellationToken);
+                            }
                         }
                     }
                 }
@@ -714,7 +717,7 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context, cancellationToken: cancellationToken);
-                if (state.StartTime == null)
+                if (!state.StartTime.Any())
                 {
                     if (((UpdateDateTimeDialogOptions)sc.Options).Reason == UpdateDateTimeDialogOptions.UpdateReason.NotFound)
                     {
@@ -742,32 +745,51 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context, cancellationToken: cancellationToken);
-                if (sc.Result != null && state.StartTime == null)
+                if (sc.Result != null && !state.StartTime.Any())
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    var dateTimeConvertType = dateTimeResolutions.First()?.Timex;
-                    var dateTimeValue = dateTimeResolutions.First()?.Value;
-                    if (dateTimeValue != null)
+                    foreach (var resolution in dateTimeResolutions)
                     {
-                        var dateTime = DateTime.Parse(dateTimeValue);
-
-                        if (dateTime != null)
+                        var dateTimeConvertType = resolution?.Timex;
+                        var dateTimeValue = resolution?.Value;
+                        if (dateTimeValue != null)
                         {
-                            var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
-                            state.StartTime = isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime;
+                            var dateTime = DateTime.Parse(dateTimeValue);
+
+                            if (dateTime != null)
+                            {
+                                var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
+                                state.StartTime.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                            }
                         }
                     }
                 }
 
-                if (state.StartTime != null)
+                if (state.StartTime.Any())
                 {
-                    state.StartDateTime = new DateTime(
-                        state.StartDate.Value.Year,
-                        state.StartDate.Value.Month,
-                        state.StartDate.Value.Day,
-                        state.StartTime.Value.Hour,
-                        state.StartTime.Value.Minute,
-                        state.StartTime.Value.Second);
+                    var userNow = TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone());
+                    var startDate = state.StartDate.Last();
+                    foreach (var startTime in state.StartTime)
+                    {
+                        var startDateTime = new DateTime(
+                            startDate.Year,
+                            startDate.Month,
+                            startDate.Day,
+                            startTime.Hour,
+                            startTime.Minute,
+                            startTime.Second);
+                        if (state.StartDateTime == null)
+                        {
+                            state.StartDateTime = startDateTime;
+                        }
+
+                        if (startDateTime >= userNow)
+                        {
+                            state.StartDateTime = startDateTime;
+                            break;
+                        }
+                    }
+
                     state.StartDateTime = TimeZoneInfo.ConvertTimeToUtc(state.StartDateTime.Value, state.GetUserTimeZone());
                     return await sc.EndDialogAsync(cancellationToken: cancellationToken);
                 }
@@ -787,7 +809,7 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context, cancellationToken: cancellationToken);
-                if (state.Duration > 0 || state.EndTime != null || state.EndDate != null)
+                if (state.Duration > 0 || state.EndTime.Any() || state.EndDate.Any())
                 {
                     return await sc.NextAsync(cancellationToken: cancellationToken);
                 }
@@ -812,27 +834,37 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context, cancellationToken: cancellationToken);
-                if (state.EndDate != null || state.EndTime != null)
+                if (state.EndDate.Any() || state.EndTime.Any())
                 {
-                    var startDate = state.StartDate == null ? TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone()) : state.StartDate;
-                    var endDate = state.EndDate;
-                    var endTime = state.EndTime;
-                    state.EndDateTime = endDate == null
-                        ? new DateTime(
-                            startDate.Value.Year,
-                            startDate.Value.Month,
-                            startDate.Value.Day,
-                            endTime.Value.Hour,
-                            endTime.Value.Minute,
-                            endTime.Value.Second)
-                        : new DateTime(
-                            endDate.Value.Year,
-                            endDate.Value.Month,
-                            endDate.Value.Day,
-                            23,
-                            59,
-                            59);
-                    state.EndDateTime = TimeZoneInfo.ConvertTimeToUtc(state.EndDateTime.Value, state.GetUserTimeZone());
+                    var startDate = !state.StartDate.Any() ? TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone()) : state.StartDate.Last();
+                    var endDate = startDate;
+                    if (state.EndDate.Any())
+                    {
+                        endDate = state.EndDate.Last();
+                    }
+
+                    if (state.EndTime.Any())
+                    {
+                        foreach (var endtime in state.EndTime)
+                        {
+                            var endDateTime = new DateTime(
+                                endDate.Year,
+                                endDate.Month,
+                                endDate.Day,
+                                endtime.Hour,
+                                endtime.Minute,
+                                endtime.Second);
+                            if (state.EndDateTime == null || endDateTime >= state.StartDateTime)
+                            {
+                                state.EndDateTime = endDateTime;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        state.EndDateTime = new DateTime(endDate.Year, endDate.Month, endDate.Day, 23, 59, 59);
+                    }
+
                     var ts = state.StartDateTime.Value.Subtract(state.EndDateTime.Value).Duration();
                     state.Duration = (int)ts.TotalSeconds;
                 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -177,6 +177,7 @@ namespace CalendarSkill
 
                 var calendarAPI = GraphClientHelper.GetCalendarService(state.APIToken, state.EventSource, ServiceManager.GetGoogleClient());
                 var calendarService = ServiceManager.InitCalendarService(calendarAPI, state.EventSource);
+                var searchByEntities = state.StartDate != null || state.StartTime != null || state.Title != null;
 
                 if (state.StartDate != null || state.StartTime != null)
                 {
@@ -225,7 +226,16 @@ namespace CalendarSkill
 
                 if (events.Count <= 0)
                 {
-                    return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                    if (searchByEntities)
+                    {
+                        await sc.Context.SendActivityAsync(sc.Context.Activity.CreateReply(DeleteEventResponses.EventWithStartTimeNotFound));
+                        state.Clear();
+                        return await sc.CancelAllDialogsAsync();
+                    }
+                    else
+                    {
+                        return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                    }
                 }
                 else if (events.Count > 1)
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -141,7 +141,7 @@ namespace CalendarSkill
             {
                 var state = await Accessor.GetAsync(sc.Context);
 
-                if (state.StartDate != null || state.StartTime != null || state.Title != null)
+                if (state.StartDate.Any() || state.StartTime.Any() || state.Title != null)
                 {
                     return await sc.NextAsync();
                 }
@@ -177,13 +177,13 @@ namespace CalendarSkill
 
                 var calendarAPI = GraphClientHelper.GetCalendarService(state.APIToken, state.EventSource, ServiceManager.GetGoogleClient());
                 var calendarService = ServiceManager.InitCalendarService(calendarAPI, state.EventSource);
-                var searchByEntities = state.StartDate != null || state.StartTime != null || state.Title != null;
+                var searchByEntities = state.StartDate.Any() || state.StartTime.Any() || state.Title != null;
 
-                if (state.StartDate != null || state.StartTime != null)
+                if (state.StartDate.Any() || state.StartTime.Any())
                 {
                     events = await GetEventsByTime(state.StartDate, state.StartTime, state.EndDate, state.EndTime, state.GetUserTimeZone(), calendarService);
-                    state.StartDate = null;
-                    state.StartTime = null;
+                    state.StartDate = new List<DateTime>();
+                    state.StartTime = new List<DateTime>();
                 }
                 else if (state.Title != null)
                 {
@@ -192,7 +192,6 @@ namespace CalendarSkill
                 }
                 else
                 {
-                    DateTime? startTime = null;
                     sc.Context.Activity.Properties.TryGetValue("OriginText", out var content);
                     var userInput = content != null ? content.ToString() : sc.Context.Activity.Text;
                     try
@@ -200,22 +199,32 @@ namespace CalendarSkill
                         IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
                         if (dateTimeResolutions.Count > 0)
                         {
-                            startTime = DateTime.Parse(dateTimeResolutions.First().Value);
-                            var dateTimeConvertType = dateTimeResolutions.First().Timex;
-                            bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
-                            startTime = isRelativeTime ? TimeZoneInfo.ConvertTime(startTime.Value, TimeZoneInfo.Local, state.GetUserTimeZone()) : startTime;
+                            foreach (var resolution in dateTimeResolutions)
+                            {
+                                var startTimeValue = DateTime.Parse(resolution.Value);
+                                if (startTimeValue == null)
+                                {
+                                    continue;
+                                }
+
+                                var dateTimeConvertType = resolution.Timex;
+                                bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
+                                startTimeValue = isRelativeTime ? TimeZoneInfo.ConvertTime(startTimeValue, TimeZoneInfo.Local, state.GetUserTimeZone()) : startTimeValue;
+
+                                startTimeValue = TimeConverter.ConvertLuisLocalToUtc(startTimeValue, state.GetUserTimeZone());
+                                events = await calendarService.GetEventsByStartTime(startTimeValue);
+                                if (events != null && events.Count > 0)
+                                {
+                                    break;
+                                }
+                            }
                         }
                     }
                     catch
                     {
                     }
 
-                    if (startTime != null)
-                    {
-                        startTime = TimeConverter.ConvertLuisLocalToUtc(startTime.Value, state.GetUserTimeZone());
-                        events = await calendarService.GetEventsByStartTime(startTime.Value);
-                    }
-                    else
+                    if (events == null || events.Count <= 0)
                     {
                         state.Title = userInput;
                         events = await calendarService.GetEventsByTitle(userInput);

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -20,6 +20,7 @@ using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.DateTime;
 using Newtonsoft.Json.Linq;
 using static Microsoft.Recognizers.Text.Culture;
+using Microsoft.Bot.Builder.AI.Luis;
 
 namespace CalendarSkill
 {
@@ -394,7 +395,8 @@ namespace CalendarSkill
 
                             if (entity.FromDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.FromDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.StartDate = date;
@@ -404,7 +406,8 @@ namespace CalendarSkill
 
                             if (entity.ToDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.ToDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.EndDate = date;
@@ -413,13 +416,14 @@ namespace CalendarSkill
 
                             if (entity.FromTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (time != null)
                                 {
                                     state.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (time != null)
                                 {
                                     state.EndTime = time;
@@ -428,7 +432,8 @@ namespace CalendarSkill
 
                             if (entity.ToTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.ToTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (time != null)
                                 {
                                     state.EndTime = time;
@@ -467,7 +472,8 @@ namespace CalendarSkill
 
                             if (entity.FromDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.FromDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.StartDate = date;
@@ -476,7 +482,8 @@ namespace CalendarSkill
 
                             if (entity.FromTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (time != null)
                                 {
                                     state.StartTime = time;
@@ -500,7 +507,8 @@ namespace CalendarSkill
 
                             if (entity.FromDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.FromDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.OriginalStartDate = date;
@@ -509,7 +517,8 @@ namespace CalendarSkill
 
                             if (entity.ToDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.ToDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.StartDate = date;
@@ -518,13 +527,14 @@ namespace CalendarSkill
 
                             if (entity.FromTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (time != null)
                                 {
                                     state.OriginalStartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (time != null)
                                 {
                                     state.OriginalEndTime = time;
@@ -533,13 +543,14 @@ namespace CalendarSkill
 
                             if (entity.ToTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.ToTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (time != null)
                                 {
                                     state.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(entity.ToTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (time != null)
                                 {
                                     state.EndTime = time;
@@ -564,7 +575,8 @@ namespace CalendarSkill
                         {
                             if (entity.FromDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.FromDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.StartDate = date;
@@ -573,7 +585,8 @@ namespace CalendarSkill
 
                             if (entity.ToDate != null)
                             {
-                                var date = GetDateFromDateTimeString(entity.ToDate[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (date != null)
                                 {
                                     state.EndDate = date;
@@ -582,13 +595,14 @@ namespace CalendarSkill
 
                             if (entity.FromTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (time != null)
                                 {
                                     state.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(entity.FromTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (time != null)
                                 {
                                     state.EndTime = time;
@@ -597,7 +611,8 @@ namespace CalendarSkill
 
                             if (entity.ToTime != null)
                             {
-                                var time = GetTimeFromDateTimeString(entity.ToTime[0], dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
                                 if (time != null)
                                 {
                                     state.EndTime = time;
@@ -700,6 +715,11 @@ namespace CalendarSkill
         private string GetLocationFromEntity(Calendar._Entities entity)
         {
             return entity.Location[0];
+        }
+
+        private string GetDateTimeStringFromInstanceData(string inputString, InstanceData data)
+        {
+            return inputString.Substring(data.StartIndex, data.EndIndex - data.StartIndex);
         }
 
         private DateTime? GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -274,31 +274,89 @@ namespace CalendarSkill
             return false;
         }
 
-        protected async Task<List<EventModel>> GetEventsByTime(DateTime? startDate, DateTime? startTime, DateTime? endDate, DateTime? endTime, TimeZoneInfo userTimeZone, ICalendar calendarService)
+        protected async Task<List<EventModel>> GetEventsByTime(List<DateTime> startDateList, List<DateTime> startTimeList, List<DateTime> endDateList, List<DateTime> endTimeList, TimeZoneInfo userTimeZone, ICalendar calendarService)
         {
             // todo: check input datetime is utc
             var rawEvents = new List<EventModel>();
             var resultEvents = new List<EventModel>();
 
-            bool searchByStartTime = startTime != null && endDate == null && endTime == null;
+            DateTime? startDate = null;
+            if (startDateList.Any())
+            {
+                startDate = startDateList.Last();
+            }
+
+            DateTime? endDate = null;
+            if (endDateList.Any())
+            {
+                endDate = endDateList.Last();
+            }
+
+            bool searchByStartTime = startTimeList.Any() && endDate == null && !endTimeList.Any();
 
             startDate = startDate ?? TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, userTimeZone);
             endDate = endDate ?? startDate ?? TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, userTimeZone);
 
-            var searchStartTime = startTime == null ? new DateTime(startDate.Value.Year, startDate.Value.Month, startDate.Value.Day) :
-                new DateTime(startDate.Value.Year, startDate.Value.Month, startDate.Value.Day, startTime.Value.Hour, startTime.Value.Minute, startTime.Value.Second);
-            searchStartTime = TimeZoneInfo.ConvertTimeToUtc(searchStartTime, userTimeZone);
-            var searchEndTime = endTime == null ? new DateTime(endDate.Value.Year, endDate.Value.Month, endDate.Value.Day, 23, 59, 59) :
-                new DateTime(endDate.Value.Year, endDate.Value.Month, endDate.Value.Day, endTime.Value.Hour, endTime.Value.Minute, endTime.Value.Second);
-            searchEndTime = TimeZoneInfo.ConvertTimeToUtc(searchEndTime, userTimeZone);
+            var searchStartTimeList = new List<DateTime>();
+            var searchEndTimeList = new List<DateTime>();
 
-            if (searchByStartTime)
+            if (startTimeList.Any())
             {
-                rawEvents = await calendarService.GetEventsByStartTime(searchStartTime);
+                foreach (var time in startTimeList)
+                {
+                    searchStartTimeList.Add(TimeZoneInfo.ConvertTimeToUtc(
+                        new DateTime(startDate.Value.Year, startDate.Value.Month, startDate.Value.Day, time.Hour, time.Minute, time.Second),
+                        userTimeZone));
+                }
             }
             else
             {
-                rawEvents = await calendarService.GetEventsByTime(searchStartTime, searchEndTime);
+                searchStartTimeList.Add(TimeZoneInfo.ConvertTimeToUtc(
+                    new DateTime(startDate.Value.Year, startDate.Value.Month, startDate.Value.Day), userTimeZone));
+            }
+
+            if (endTimeList.Any())
+            {
+                foreach (var time in endTimeList)
+                {
+                    searchEndTimeList.Add(TimeZoneInfo.ConvertTimeToUtc(
+                        new DateTime(endDate.Value.Year, endDate.Value.Month, endDate.Value.Day, time.Hour, time.Minute, time.Second),
+                        userTimeZone));
+                }
+            }
+            else
+            {
+                searchEndTimeList.Add(TimeZoneInfo.ConvertTimeToUtc(
+                    new DateTime(endDate.Value.Year, endDate.Value.Month, endDate.Value.Day, 23, 59, 59), userTimeZone));
+            }
+
+            DateTime? searchStartTime = null;
+
+            if (searchByStartTime)
+            {
+                foreach (var startTime in searchStartTimeList)
+                {
+                    rawEvents = await calendarService.GetEventsByStartTime(startTime);
+                    if (rawEvents.Any())
+                    {
+                        searchStartTime = startTime;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                for (var i = 0; i < searchStartTimeList.Count(); i++)
+                {
+                    rawEvents = await calendarService.GetEventsByTime(
+                        searchStartTimeList[i],
+                        searchEndTimeList.Count() > i ? searchEndTimeList[i] : searchEndTimeList[0]);
+                    if (rawEvents.Any())
+                    {
+                        searchStartTime = searchStartTimeList[i];
+                        break;
+                    }
+                }
             }
 
             foreach (var item in rawEvents)
@@ -722,14 +780,14 @@ namespace CalendarSkill
             return inputString.Substring(data.StartIndex, data.EndIndex - data.StartIndex);
         }
 
-        private DateTime? GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone)
+        private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone)
         {
             var culture = local ?? English;
             List<DateTimeResolution> results = RecognizeDateTime(date, culture);
+            var dateTimeResults = new List<DateTime>();
             if (results != null)
             {
-                var result = results[results.Count - 1];
-                if (result.Value != null)
+                foreach (var result in results)
                 {
                     var dateTime = DateTime.Parse(result.Value);
                     var dateTimeConvertType = result.Timex;
@@ -737,50 +795,56 @@ namespace CalendarSkill
                     if (dateTime != null)
                     {
                         bool isRelativeTime = IsRelativeTime(date, result.Value, result.Timex);
-                        return isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime;
+                        dateTimeResults.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime);
                     }
                 }
             }
 
-            return null;
+            return dateTimeResults;
         }
 
-        private DateTime? GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart = true)
+        private List<DateTime> GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart = true)
         {
             var culture = local ?? English;
-            List<DateTimeResolution> result = RecognizeDateTime(time, culture);
-            if (result != null)
+            List<DateTimeResolution> results = RecognizeDateTime(time, culture);
+            var dateTimeResults = new List<DateTime>();
+            if (results != null)
             {
-                if (result[0].Value != null)
+                foreach (var result in results)
                 {
-                    if (!isStart)
+                    if (result.Value != null)
                     {
-                        return null;
+                        if (!isStart)
+                        {
+                            break;
+                        }
+
+                        var dateTime = DateTime.Parse(result.Value);
+                        var dateTimeConvertType = result.Timex;
+
+                        if (dateTime != null)
+                        {
+                            bool isRelativeTime = IsRelativeTime(time, result.Value, result.Timex);
+                            dateTimeResults.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime);
+                        }
                     }
-
-                    var dateTime = DateTime.Parse(result[0].Value);
-                    var dateTimeConvertType = result[0].Timex;
-
-                    if (dateTime != null)
+                    else
                     {
-                        bool isRelativeTime = IsRelativeTime(time, result[0].Value, result[0].Timex);
-                        return isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime;
+                        var startTime = DateTime.Parse(result.Start);
+                        var endTime = DateTime.Parse(result.End);
+                        if (isStart)
+                        {
+                            dateTimeResults.Add(startTime);
+                        }
+                        else
+                        {
+                            dateTimeResults.Add(endTime);
+                        }
                     }
-                }
-                else
-                {
-                    var startTime = DateTime.Parse(result[0].Start);
-                    var endTime = DateTime.Parse(result[0].End);
-                    if (isStart)
-                    {
-                        return startTime;
-                    }
-
-                    return endTime;
                 }
             }
 
-            return null;
+            return dateTimeResults;
         }
 
         protected List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -124,18 +124,18 @@ namespace CalendarSkill
 
                     var searchDate = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, state.GetUserTimeZone());
 
-                    if (state.StartDate != null)
+                    if (state.StartDate.Any())
                     {
-                        searchDate = state.StartDate.Value;
+                        searchDate = state.StartDate.Last();
                     }
 
-                    var results = await GetEventsByTime(searchDate, state.StartTime, state.EndDate, state.EndTime, state.GetUserTimeZone(), calendarService);
+                    var results = await GetEventsByTime(new List<DateTime>() { searchDate }, state.StartTime, state.EndDate, state.EndTime, state.GetUserTimeZone(), calendarService);
                     var searchedEvents = new List<EventModel>();
-                    bool searchTodayMeeting = state.StartDate != null &&
-                        state.StartTime == null &&
-                        state.EndDate == null &&
-                        state.EndTime == null &&
-                        EventModel.IsSameDate(state.StartDate.Value, TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone()));
+                    bool searchTodayMeeting = state.StartDate.Any() &&
+                        !state.StartTime.Any() &&
+                        !state.EndDate.Any() &&
+                        !state.EndTime.Any() &&
+                        EventModel.IsSameDate(searchDate, TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone()));
                     foreach (var item in results)
                     {
                         if (!searchTodayMeeting || item.StartTime >= DateTime.UtcNow)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
@@ -336,6 +336,7 @@ namespace CalendarSkill
                 var events = new List<EventModel>();
                 var calendarAPI = GraphClientHelper.GetCalendarService(state.APIToken, state.EventSource, ServiceManager.GetGoogleClient());
                 var calendarService = ServiceManager.InitCalendarService(calendarAPI, state.EventSource);
+                var searchByEntities = state.OriginalStartDate != null || state.OriginalStartTime != null || state.Title != null;
 
                 if (state.OriginalStartDate != null || state.OriginalStartTime != null)
                 {
@@ -385,7 +386,16 @@ namespace CalendarSkill
                 state.Events = events;
                 if (events.Count <= 0)
                 {
-                    return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                    if (searchByEntities)
+                    {
+                        await sc.Context.SendActivityAsync(sc.Context.Activity.CreateReply(UpdateEventResponses.EventWithStartTimeNotFound));
+                        state.Clear();
+                        return await sc.CancelAllDialogsAsync();
+                    }
+                    else
+                    {
+                        return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                    }
                 }
                 else if (events.Count > 1)
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
@@ -128,7 +128,6 @@ namespace CalendarSkill
                 var confirmResult = (bool)sc.Result;
                 if (confirmResult)
                 {
-
                     var newStartTime = (DateTime)state.NewStartDateTime;
                     var origin = state.Events[0];
                     var updateEvent = new EventModel(origin.Source);
@@ -164,7 +163,7 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context);
-                if (state.StartDate != null || state.StartTime != null || state.MoveTimeSpan != 0)
+                if (state.StartDate.Any() || state.StartTime.Any() || state.MoveTimeSpan != 0)
                 {
                     return await sc.ContinueDialogAsync();
                 }
@@ -190,40 +189,43 @@ namespace CalendarSkill
             try
             {
                 var state = await Accessor.GetAsync(sc.Context);
-                if (state.StartDate != null || state.StartTime != null || state.MoveTimeSpan != 0)
+                if (state.StartDate.Any() || state.StartTime.Any() || state.MoveTimeSpan != 0)
                 {
                     var originalEvent = state.Events[0];
                     var originalStartDateTime = TimeConverter.ConvertUtcToUserTime(originalEvent.StartTime, state.GetUserTimeZone());
+                    var userNow = TimeConverter.ConvertUtcToUserTime(DateTime.UtcNow, state.GetUserTimeZone());
 
-                    if (state.StartDate != null && state.StartTime != null)
+                    if (state.StartDate.Any() || state.StartTime.Any())
                     {
-                        state.NewStartDateTime = new DateTime(
-                            state.StartDate.Value.Year,
-                            state.StartDate.Value.Month,
-                            state.StartDate.Value.Day,
-                            state.StartTime.Value.Hour,
-                            state.StartTime.Value.Minute,
-                            state.StartTime.Value.Second);
-                    }
-                    else if (state.StartDate != null && state.StartTime == null)
-                    {
-                        state.NewStartDateTime = new DateTime(
-                            state.StartDate.Value.Year,
-                            state.StartDate.Value.Month,
-                            state.StartDate.Value.Day,
-                            originalStartDateTime.Hour,
-                            originalStartDateTime.Minute,
-                            originalStartDateTime.Second);
-                    }
-                    else if (state.StartDate == null && state.StartTime != null)
-                    {
-                        state.NewStartDateTime = new DateTime(
-                            originalStartDateTime.Year,
-                            originalStartDateTime.Month,
-                            originalStartDateTime.Day,
-                            state.StartTime.Value.Hour,
-                            state.StartTime.Value.Minute,
-                            state.StartTime.Value.Second);
+                        var newStartDate = state.StartDate.Any() ?
+                            state.StartDate.Last() :
+                            originalStartDateTime;
+
+                        var newStartTime = new List<DateTime>();
+                        if (state.StartTime.Any())
+                        {
+                            foreach (var time in state.StartTime)
+                            {
+                                var newStartDateTime = new DateTime(
+                                    newStartDate.Year,
+                                    newStartDate.Month,
+                                    newStartDate.Day,
+                                    time.Hour,
+                                    time.Minute,
+                                    time.Second);
+
+                                if (state.NewStartDateTime == null)
+                                {
+                                    state.NewStartDateTime = newStartDateTime;
+                                }
+
+                                if (newStartDateTime >= userNow)
+                                {
+                                    state.NewStartDateTime = newStartDateTime;
+                                    break;
+                                }
+                            }
+                        }
                     }
                     else if (state.MoveTimeSpan != 0)
                     {
@@ -241,19 +243,41 @@ namespace CalendarSkill
                 else if (sc.Result != null)
                 {
                     IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
-                    var newStartTime = DateTime.Parse(dateTimeResolutions.First().Value);
 
-                    var dateTimeConvertType = dateTimeResolutions.First().Timex;
+                    DateTime? newStartTime = null;
 
-                    if (newStartTime != null)
+                    foreach (var resolution in dateTimeResolutions)
                     {
+                        var utcNow = DateTime.UtcNow;
+                        var dateTimeConvertType = resolution.Timex;
+                        var dateTimeValue = DateTime.Parse(resolution.Value);
+                        if (dateTimeValue == null)
+                        {
+                            continue;
+                        }
+
                         var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
                         if (isRelativeTime)
                         {
-                            newStartTime = DateTime.SpecifyKind(newStartTime, DateTimeKind.Local);
+                            dateTimeValue = DateTime.SpecifyKind(dateTimeValue, DateTimeKind.Local);
                         }
 
-                        state.NewStartDateTime = isRelativeTime ? TimeConverter.ConvertLuisLocalToUtc(newStartTime, state.GetUserTimeZone()) : TimeZoneInfo.ConvertTimeToUtc(newStartTime, state.GetUserTimeZone());
+                        dateTimeValue = isRelativeTime ? TimeConverter.ConvertLuisLocalToUtc(dateTimeValue, state.GetUserTimeZone()) : TimeZoneInfo.ConvertTimeToUtc(dateTimeValue, state.GetUserTimeZone());
+                        if (newStartTime == null)
+                        {
+                            newStartTime = dateTimeValue;
+                        }
+
+                        if (dateTimeValue >= utcNow)
+                        {
+                            newStartTime = dateTimeValue;
+                            break;
+                        }
+                    }
+
+                    if (newStartTime != null)
+                    {
+                        state.NewStartDateTime = newStartTime;
 
                         return await sc.ContinueDialogAsync();
                     }
@@ -301,7 +325,7 @@ namespace CalendarSkill
             {
                 var state = await Accessor.GetAsync(sc.Context);
 
-                if (state.OriginalStartDate != null || state.OriginalStartTime != null || state.Title != null)
+                if (state.OriginalStartDate.Any() || state.OriginalStartTime.Any() || state.Title != null)
                 {
                     return await sc.NextAsync();
                 }
@@ -336,15 +360,15 @@ namespace CalendarSkill
                 var events = new List<EventModel>();
                 var calendarAPI = GraphClientHelper.GetCalendarService(state.APIToken, state.EventSource, ServiceManager.GetGoogleClient());
                 var calendarService = ServiceManager.InitCalendarService(calendarAPI, state.EventSource);
-                var searchByEntities = state.OriginalStartDate != null || state.OriginalStartTime != null || state.Title != null;
+                var searchByEntities = state.OriginalStartDate.Any() || state.OriginalStartTime.Any() || state.Title != null;
 
-                if (state.OriginalStartDate != null || state.OriginalStartTime != null)
+                if (state.OriginalStartDate.Any() || state.OriginalStartTime.Any())
                 {
                     events = await GetEventsByTime(state.OriginalStartDate, state.OriginalStartTime, state.OriginalEndDate, state.OriginalEndTime, state.GetUserTimeZone(), calendarService);
-                    state.OriginalStartDate = null;
-                    state.OriginalStartTime = null;
-                    state.OriginalEndDate = null;
-                    state.OriginalStartTime = null;
+                    state.OriginalStartDate = new List<DateTime>();
+                    state.OriginalStartTime = new List<DateTime>();
+                    state.OriginalEndDate = new List<DateTime>();
+                    state.OriginalStartTime = new List<DateTime>();
                 }
                 else if (state.Title != null)
                 {
@@ -353,7 +377,6 @@ namespace CalendarSkill
                 }
                 else
                 {
-                    DateTime? startTime = null;
                     sc.Context.Activity.Properties.TryGetValue("OriginText", out var content);
                     var userInput = content != null ? content.ToString() : sc.Context.Activity.Text;
                     try
@@ -361,22 +384,32 @@ namespace CalendarSkill
                         IList<DateTimeResolution> dateTimeResolutions = sc.Result as List<DateTimeResolution>;
                         if (dateTimeResolutions.Count > 0)
                         {
-                            startTime = DateTime.Parse(dateTimeResolutions.First().Value);
-                            var dateTimeConvertType = dateTimeResolutions.First().Timex;
-                            bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
-                            startTime = isRelativeTime ? TimeZoneInfo.ConvertTime(startTime.Value, TimeZoneInfo.Local, state.GetUserTimeZone()) : startTime;
+                            foreach (var resolution in dateTimeResolutions)
+                            {
+                                var startTimeValue = DateTime.Parse(resolution.Value);
+                                if (startTimeValue == null)
+                                {
+                                    continue;
+                                }
+
+                                var dateTimeConvertType = resolution.Timex;
+                                bool isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeResolutions.First().Value, dateTimeResolutions.First().Timex);
+                                startTimeValue = isRelativeTime ? TimeZoneInfo.ConvertTime(startTimeValue, TimeZoneInfo.Local, state.GetUserTimeZone()) : startTimeValue;
+
+                                startTimeValue = TimeConverter.ConvertLuisLocalToUtc(startTimeValue, state.GetUserTimeZone());
+                                events = await calendarService.GetEventsByStartTime(startTimeValue);
+                                if (events != null && events.Count > 0)
+                                {
+                                    break;
+                                }
+                            }
                         }
                     }
                     catch
                     {
                     }
 
-                    if (startTime != null)
-                    {
-                        startTime = TimeConverter.ConvertLuisLocalToUtc(startTime.Value, state.GetUserTimeZone());
-                        events = await calendarService.GetEventsByStartTime(startTime.Value);
-                    }
-                    else
+                    if (events == null || events.Count <= 0)
                     {
                         state.Title = userInput;
                         events = await calendarService.GetEventsByTitle(userInput);


### PR DESCRIPTION
## Description
1. When user input a time like "3:00", bot will get two results: 3:00 am and 3:00 pm. In order to predict user will choose which time or add a step to ask user, save all results in state then handle them in the flow. Now when bot get multiple results, bot will predict user want to create or update the meeting to the time after now. And when search meetings, bot will search meeting by all results one by one until get meetings.
2. fix the bug: the Chinese time in entity will be separate with space. Like "上午9点" -> "上午 9 点"
3. tune the update and delete flow. Now if bot can't find the target meeting will end the flow. Like user says "update my meeting at 6 pm". But if user only says "update my meeting" and says the start time in next steps, bot will ask user to try again until find the meeting or user cancel the dialog.

## Testing Steps
1. 
- "show my meetings at 6:00" bot can find meetings at 6 pm if there is no meeting at 6 pm
- "update my meetings at 5:00 to 6:00" if current time is between 6 am and 6 pm, bot will move the meeting to 6 pm, or will move to 6 am. Also can find meeting at 5 pm when there is no meeting at 5 am.
- delete flow is same.
2. "帮我预定一个会议室从上午10时自下午4点"
3. "update my meeting at 6pm", when there is no meeting the flow will end.