### PR TITLE
move skill error string to reply resource file and add proper speak and inputhint properties

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Bot.Solutions.Resources
 
         public static BotResponse ErrorMessage => GetBotResponse();
 
+        public static BotResponse ErrorMessage_SkillError => GetBotResponse();
+
         public static BotResponse SkillAuthenticationTitle => GetBotResponse();
 
         public static BotResponse SkillAuthenticationPrompt => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.de.json
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.de.json
@@ -49,6 +49,16 @@
     "inputHint": "acceptingInput"
   },
 
+  "ErrorMessage_SkillError": {
+    "replies": [
+      {
+        "text": "Entschuldigung, bei dem Versuch, mit der Fähigkeit zu kommunizieren, ist ein Fehler aufgetreten. Bitte versuche es erneut.",
+        "speak": "Entschuldigung, bei dem Versuch, mit der Fähigkeit zu kommunizieren, ist ein Fehler aufgetreten. Bitte versuche es erneut."
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+
   "SkillAuthenticationTitle": {
     "replies": [
       {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.fr.json
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.fr.json
@@ -49,6 +49,16 @@
     "inputHint": "acceptingInput"
   },
 
+  "ErrorMessage_SkillError": {
+    "replies": [
+      {
+        "text": "Désolé, une erreur s'est produite lors de la tentative de communication avec le bot de compétence. Veuillez réessayer.",
+        "speak": "Désolé, une erreur s'est produite lors de la tentative de communication avec le bot de compétence. Veuillez réessayer."
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+
   "SkillAuthenticationTitle": {
     "replies": [
       {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.it.json
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.it.json
@@ -49,6 +49,16 @@
     "inputHint": "acceptingInput"
   },
 
+  "ErrorMessage_SkillError": {
+    "replies": [
+      {
+        "text": "Siamo spiacenti, qualcosa è andato storto nella comunicazione con lo skill. Per favore riprova.",
+        "speak": "Siamo spiacenti, qualcosa è andato storto nella comunicazione con lo skill. Per favore riprova."
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+
   "SkillAuthenticationTitle": {
     "replies": [
       {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.json
@@ -49,6 +49,16 @@
     "inputHint": "acceptingInput"
   },
 
+  "ErrorMessage_SkillError": {
+    "replies": [
+      {
+        "text": "Sorry, something went wrong trying to communicate with the skill. Please try again.",
+        "speak": "Sorry, something went wrong trying to communicate with the skill. Please try again."
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+
   "SkillAuthenticationTitle": {
     "replies": [
       {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.zh.json
@@ -49,6 +49,16 @@
     "inputHint": "acceptingInput"
   },
 
+  "ErrorMessage_SkillError": {
+    "replies": [
+      {
+        "text": "很抱歉，对话技能出错了。请您再试一次！",
+        "speak": "很抱歉，对话技能出错了。请您再试一次！"
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+
   "SkillAuthenticationTitle": {
     "replies": [
       {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -8,7 +8,9 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
+using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Middleware;
+using Microsoft.Bot.Solutions.Resources;
 
 namespace Microsoft.Bot.Solutions.Skills
 {
@@ -158,9 +160,8 @@ namespace Microsoft.Bot.Solutions.Skills
                     // set up skill turn error handling
                     OnTurnError = async (context, exception) =>
                     {
-                        await context.SendActivityAsync(context.Activity.CreateReply($"Sorry, something went wrong trying to communicate with the skill. Please try again."));
+                        await context.SendActivityAsync(context.Activity.CreateReply(CommonResponses.ErrorMessage_SkillError));
 
-                        // Send error trace to emulator
                         await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
 
                         // Log exception in AppInsights


### PR DESCRIPTION
## Description
add speak and inputHint for skill error message

## Related Issue
#344 

## Testing Steps
add a statement in EmailSkill/EmailSkill.cs in OnTurnAsync method to throw an exception. Then send the message 'send an email' to the bot and look at the response. The error message should have the speak property the same as the message and also the inputHint being expectingInput.
