### PR TITLE
Fixes for cross platform compilation (Visual Studio on Windows and OsX)

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainResponses.cs
@@ -58,11 +58,12 @@ namespace VirtualAssistant
             Register(new DictionaryRenderer(_responseTemplates));
         }
 
-        public static IMessageActivity BuildIntroCard(ITurnContext turnContext, dynamic data)
-        {
-            var introCard = File.ReadAllText(@".\Dialogs\Main\Resources\Intro.json");
-            var card = AdaptiveCard.FromJson(introCard).Card;
-            var attachment = new Attachment(AdaptiveCard.ContentType, content: card);
+		public static IMessageActivity BuildIntroCard(ITurnContext turnContext, dynamic data)
+		{
+			var introPath = Path.Combine("Dialogs", "Main", "Resources", "Intro.json");
+			var introCard = File.ReadAllText(introPath);
+			var card = AdaptiveCard.FromJson(introCard).Card;
+			var attachment = new Attachment(AdaptiveCard.ContentType, content: card);
 
             return MessageFactory.Attachment(attachment, ssml: card.Speak, inputHint: InputHints.AcceptingInput);
         }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
@@ -1,114 +1,113 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
-  </PropertyGroup>
-
-  <PropertyGroup>
-      <AssemblyName>VirtualAssistant</AssemblyName>
-    <RootNamespace>VirtualAssistant</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <CodeAnalysisRuleSet>..\VirtualAssistant.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <CodeAnalysisRuleSet>..\VirtualAssistant.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Google.Apis" Version="1.36.1" />
-    <PackageReference Include="Google.Apis.Gmail.v1" Version="1.36.1.1342" />
-    <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
-    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.35.2.1363" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Graph" Version="1.11.0" />
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
-    <PackageReference Include="MimeKit" Version="2.0.7" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="Dialogs\Escalate\Resources\EscalateStrings - Copy.Designer.cs">
-      <DependentUpon>EscalateStrings.resx</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </Compile>
-    <Compile Update="Dialogs\Escalate\Resources\EscalateStrings - Copy.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>EscalateStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\Escalate\Resources\EscalateStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>EscalateStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\Main\Resources\MainStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>MainStrings.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.fr.resx">
-      <Generator></Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>EscalateStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Main\Resources\MainStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>MainStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.fr.resx">
-      <Generator></Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>OnboardingStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Dialogs\Shared\Resources\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
-    <ProjectReference Include="..\skills\calendarskill\CalendarSkill.csproj" />
-    <ProjectReference Include="..\skills\emailskill\EmailSkill.csproj" />
-    <ProjectReference Include="..\skills\pointofinterestskill\PointOfInterestSkill.csproj" />
-    <ProjectReference Include="..\skills\todoskill\ToDoSkill.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="*.bot">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="xcopy &quot;$(SolutionDir)skills\CalendarSkill\bin\$(ConfigurationName)\netcoreapp2.1\*.*&quot; &quot;$(TargetDir)&quot;  /S /Y&#xD;&#xA;xcopy &quot;$(SolutionDir)skills\EmailSkill\bin\$(ConfigurationName)\netcoreapp2.1\*.*&quot; &quot;$(TargetDir)&quot;  /S /Y&#xD;&#xA;xcopy &quot;$(SolutionDir)skills\PointOfInterestSkill\bin\$(ConfigurationName)\netcoreapp2.1\*.*&quot; &quot;$(TargetDir)&quot;  /S /Y&#xD;&#xA;xcopy &quot;$(SolutionDir)skills\ToDoSkill\bin\$(ConfigurationName)\netcoreapp2.1\*.*&quot; &quot;$(TargetDir)&quot;  /S /Y" />
-  </Target>
-
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyName>VirtualAssistant</AssemblyName>
+        <RootNamespace>VirtualAssistant</RootNamespace>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <CodeAnalysisRuleSet>..\VirtualAssistant.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <CodeAnalysisRuleSet>..\VirtualAssistant.ruleset</CodeAnalysisRuleSet>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Google.Apis" Version="1.36.1" />
+        <PackageReference Include="Google.Apis.Gmail.v1" Version="1.36.1.1342" />
+        <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
+        <PackageReference Include="Google.Apis.Calendar.v3" Version="1.35.2.1363" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+        <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+        <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
+        <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+        <PackageReference Include="Microsoft.Graph" Version="1.11.0" />
+        <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
+        <PackageReference Include="MimeKit" Version="2.0.7" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Update="Dialogs\Escalate\Resources\EscalateStrings - Copy.Designer.cs">
+            <DependentUpon>EscalateStrings.resx</DependentUpon>
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+        </Compile>
+        <Compile Update="Dialogs\Escalate\Resources\EscalateStrings - Copy.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>EscalateStrings.resx</DependentUpon>
+        </Compile>
+        <Compile Update="Dialogs\Escalate\Resources\EscalateStrings.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>EscalateStrings.resx</DependentUpon>
+        </Compile>
+        <Compile Update="Dialogs\Main\Resources\MainStrings.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>MainStrings.resx</DependentUpon>
+        </Compile>
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.fr.resx">
+            <Generator>
+            </Generator>
+        </EmbeddedResource>
+        <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.resx">
+            <Generator>PublicResXFileCodeGenerator</Generator>
+            <LastGenOutput>EscalateStrings.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="Dialogs\Main\Resources\MainStrings.resx">
+            <Generator>PublicResXFileCodeGenerator</Generator>
+            <LastGenOutput>MainStrings.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.fr.resx">
+            <Generator>
+            </Generator>
+        </EmbeddedResource>
+        <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.resx">
+            <Generator>PublicResXFileCodeGenerator</Generator>
+            <LastGenOutput>OnboardingStrings.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+    </ItemGroup>
+    <ItemGroup>
+        <WCFMetadata Include="Connected Services" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Dialogs\Shared\Resources\" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+        <ProjectReference Include="..\skills\calendarskill\CalendarSkill.csproj" />
+        <ProjectReference Include="..\skills\emailskill\EmailSkill.csproj" />
+        <ProjectReference Include="..\skills\pointofinterestskill\PointOfInterestSkill.csproj" />
+        <ProjectReference Include="..\skills\todoskill\ToDoSkill.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="*.bot">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+        <CalendarSkillFiles Include="$(SolutionDir)skills\CalendarSkill\bin\$(ConfigurationName)\netcoreapp2.1\**\*.*" />
+        <EmailSkillFiles Include="$(SolutionDir)skills\EmailSkill\bin\$(ConfigurationName)\netcoreapp2.1\**\*.*" />
+        <PointOfInterestSkillFiles Include="$(SolutionDir)skills\PointOfInterestSkill\bin\$(ConfigurationName)\netcoreapp2.1\**\*.*" />
+        <TodoSkillFiles Include="$(SolutionDir)skills\ToDoSkill\bin\$(ConfigurationName)\netcoreapp2.1\**\*.*" />
+    </ItemGroup>
+    <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+        <Copy SourceFiles="@(CalendarSkillFiles)" DestinationFolder="$(TargetDir)" />
+        <Copy SourceFiles="@(EmailSkillFiles)" DestinationFolder="$(TargetDir)" />
+        <Copy SourceFiles="@(PointOfInterestSkillFiles)" DestinationFolder="$(TargetDir)" />
+        <Copy SourceFiles="@(TodoSkillFiles)" DestinationFolder="$(TargetDir)" />
+    </Target>
 </Project>

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Resources/CommonResponses.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Bot.Solutions.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static CommonResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(CommonResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Resources");
-            _responseManager = new ResponseManager(resDir, "CommonResponses");
-        }
+		static CommonResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(CommonResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Resources");
+			_responseManager = new ResponseManager(resDir, "CommonResponses");
+		}
 
         // Generated accessors
         public static BotResponse ConfirmUserInfo => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.CreateEvent.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static CreateEventResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(CreateEventResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\CreateEvent\Resources");
-            _responseManager = new ResponseManager(resDir, "CreateEventResponses");
-        }
+		static CreateEventResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(CreateEventResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "CreateEvent", "Resources");
+			_responseManager = new ResponseManager(resDir, "CreateEventResponses");
+		}
 
         // Generated accessors
         public static BotResponse NoTitle => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/Resources/DeleteEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/Resources/DeleteEventResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.DeleteEvent.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static DeleteEventResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(DeleteEventResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\DeleteEvent\Resources");
-            _responseManager = new ResponseManager(resDir, "DeleteEventResponses");
-        }
+		static DeleteEventResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(DeleteEventResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "DeleteEvent", "Resources");
+			_responseManager = new ResponseManager(resDir, "DeleteEventResponses");
+		}
 
         // Generated accessors
         public static BotResponse ConfirmDelete => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/Resources/CalendarMainResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/Resources/CalendarMainResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.Main.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static CalendarMainResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(CalendarMainResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Main\Resources");
-            _responseManager = new ResponseManager(resDir, "CalendarMainResponses");
-        }
+		static CalendarMainResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(CalendarMainResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Main", "Resources");
+			_responseManager = new ResponseManager(resDir, "CalendarMainResponses");
+		}
 
         // Generated accessors
         public static BotResponse CalendarWelcomeMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/NextMeeting/Resources/NextMeetingResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/NextMeeting/Resources/NextMeetingResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.NextMeeting.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static NextMeetingResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(NextMeetingResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\NextMeeting\Resources");
-            _responseManager = new ResponseManager(resDir, "NextMeetingResponses");
-        }
+		static NextMeetingResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(NextMeetingResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "NextMeeting", "Resources");
+			_responseManager = new ResponseManager(resDir, "NextMeetingResponses");
+		}
 
         // Generated accessors
         public static BotResponse ShowNoMeetingMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Resources/CalendarSharedResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.Shared.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static CalendarSharedResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(CalendarSharedResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Shared\Resources");
-            _responseManager = new ResponseManager(resDir, "CalendarSharedResponses");
-        }
+		static CalendarSharedResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(CalendarSharedResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Shared", "Resources");
+			_responseManager = new ResponseManager(resDir, "CalendarSharedResponses");
+		}
 
         // Generated accessors
         public static BotResponse DidntUnderstandMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/Resources/SummaryResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/Resources/SummaryResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.Summary.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static SummaryResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(SummaryResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Summary\Resources");
-            _responseManager = new ResponseManager(resDir, "SummaryResponses");
-        }
+		static SummaryResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(SummaryResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Summary", "Resources");
+			_responseManager = new ResponseManager(resDir, "SummaryResponses");
+		}
 
         // Generated accessors
         public static BotResponse CalendarNoMoreEvent => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/Resources/UpdateEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/Resources/UpdateEventResponses.cs
@@ -14,12 +14,12 @@ namespace CalendarSkill.Dialogs.UpdateEvent.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static UpdateEventResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(UpdateEventResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\UpdateEvent\Resources");
-            _responseManager = new ResponseManager(resDir, "UpdateEventResponses");
-        }
+		static UpdateEventResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(UpdateEventResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "UpdateEvent", "Resources");
+			_responseManager = new ResponseManager(resDir, "UpdateEventResponses");
+		}
 
         // Generated accessors
         public static BotResponse NotEventOrganizer => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/ServiceClients/TimeZoneConverter.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/ServiceClients/TimeZoneConverter.cs
@@ -32,10 +32,10 @@ namespace CalendarSkill
             throw new InvalidTimeZoneException();
         }
 
-        private static void LoadData()
-        {
-            var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var resDir = Path.Combine(dir, @"ServiceClients\WindowsIanaMapping");
+		private static void LoadData()
+		{
+			var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+			var resDir = Path.Combine(dir, "ServiceClients", "WindowsIanaMapping");
 
             using (var mappingFile = new FileStream(resDir, FileMode.Open))
             using (var sr = new StreamReader(mappingFile))

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/Resources/ConfirmRecipientResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/Resources/ConfirmRecipientResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.ConfirmRecipient.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ConfirmRecipientResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ConfirmRecipientResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\ConfirmRecipient\Resources");
-            _responseManager = new ResponseManager(resDir, "ConfirmRecipientResponses");
-        }
+		static ConfirmRecipientResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ConfirmRecipientResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "ConfirmRecipient", "Resources");
+			_responseManager = new ResponseManager(resDir, "ConfirmRecipientResponses");
+		}
 
         // Generated accessors
         public static BotResponse PromptTooManyPeople => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.DeleteEmail.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static DeleteEmailResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(DeleteEmailResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\DeleteEmail\Resources");
-            _responseManager = new ResponseManager(resDir, "DeleteEmailResponses");
-        }
+		static DeleteEmailResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(DeleteEmailResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "DeleteEmail", "Resources");
+			_responseManager = new ResponseManager(resDir, "DeleteEmailResponses");
+		}
 
         // Generated accessors
         public static BotResponse DeletePrompt => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/Resources/ForwardEmailResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/Resources/ForwardEmailResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.ForwardEmail.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ForwardEmailResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ForwardEmailResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\ForwardEmail\Resources");
-            _responseManager = new ResponseManager(resDir, "ForwardEmailResponses");
-        }
+		static ForwardEmailResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ForwardEmailResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "ForwardEmail", "Resources");
+			_responseManager = new ResponseManager(resDir, "ForwardEmailResponses");
+		}
 
         // Generated accessors
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/Resources/EmailMainResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/Resources/EmailMainResponses.cs
@@ -15,12 +15,12 @@ namespace EmailSkill.Dialogs.Main.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static EmailMainResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(EmailMainResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Main\Resources");
-            _responseManager = new ResponseManager(resDir, "EmailMainResponses");
-        }
+		static EmailMainResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(EmailMainResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Main", "Resources");
+			_responseManager = new ResponseManager(resDir, "EmailMainResponses");
+		}
 
         // Generated accessors
         public static BotResponse EmailWelcomeMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/Resources/ReplyEmailResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/Resources/ReplyEmailResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.ReplyEmail.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ReplyEmailResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ReplyEmailResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\ReplyEmail\Resources");
-            _responseManager = new ResponseManager(resDir, "ReplyEmailResponses");
-        }
+		static ReplyEmailResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ReplyEmailResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "ReplyEmail", "Resources");
+			_responseManager = new ResponseManager(resDir, "ReplyEmailResponses");
+		}
 
         // Generated accessors
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/Resources/SendEmailResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/Resources/SendEmailResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.SendEmail.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static SendEmailResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(SendEmailResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\SendEmail\Resources");
-            _responseManager = new ResponseManager(resDir, "SendEmailResponses");
-        }
+		static SendEmailResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(SendEmailResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "SendEmail", "Resources");
+			_responseManager = new ResponseManager(resDir, "SendEmailResponses");
+		}
 
         // Generated accessors
         public static BotResponse RecipientConfirmed => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.Shared.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static EmailSharedResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(EmailSharedResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Shared\Resources");
-            _responseManager = new ResponseManager(resDir, "EmailSharedResponses");
-        }
+		static EmailSharedResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(EmailSharedResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Shared", "Resources");
+			_responseManager = new ResponseManager(resDir, "EmailSharedResponses");
+		}
 
         // Generated accessors
         public static BotResponse DidntUnderstandMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/Resources/ShowEmailResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/Resources/ShowEmailResponses.cs
@@ -14,12 +14,12 @@ namespace EmailSkill.Dialogs.ShowEmail.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ShowEmailResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ShowEmailResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\ShowEmail\Resources");
-            _responseManager = new ResponseManager(resDir, "ShowEmailResponses");
-        }
+		static ShowEmailResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ShowEmailResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "ShowEmail", "Resources");
+			_responseManager = new ResponseManager(resDir, "ShowEmailResponses");
+		}
 
         // Generated accessors
         public static BotResponse EmailNotFound => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/Resources/CancelRouteResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/Resources/CancelRouteResponses.cs
@@ -15,12 +15,12 @@ namespace PointOfInterestSkill.Dialogs.CancelRoute.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static CancelRouteResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(CancelRouteResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\CancelRoute\Resources");
-            _responseManager = new ResponseManager(resDir, "CancelRouteResponses");
-        }
+		static CancelRouteResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(CancelRouteResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "CancelRoute", "Resources");
+			_responseManager = new ResponseManager(resDir, "CancelRouteResponses");
+		}
 
         // Generated accessors
         public static BotResponse CancelActiveRoute => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/FindPointOfInterest/Resources/FindPointOfInterestResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/FindPointOfInterest/Resources/FindPointOfInterestResponses.cs
@@ -15,12 +15,12 @@ namespace PointOfInterestSkill.Dialogs.FindPointOfInterest.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static FindPointOfInterestResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(FindPointOfInterestResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\FindPointOfInterest\Resources");
-            _responseManager = new ResponseManager(resDir, "FindPointOfInterestResponses");
-        }
+		static FindPointOfInterestResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(FindPointOfInterestResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "FindPointOfInterest", "Resources");
+			_responseManager = new ResponseManager(resDir, "FindPointOfInterestResponses");
+		}
 
         // Generated accessors
         private static BotResponse GetBotResponse([CallerMemberName] string propertyName = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/Resources/POIMainResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/Resources/POIMainResponses.cs
@@ -15,12 +15,12 @@ namespace PointOfInterestSkill.Dialogs.Main.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static POIMainResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(POIMainResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Main\Resources");
-            _responseManager = new ResponseManager(resDir, "POIMainResponses");
-        }
+		static POIMainResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(POIMainResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Main", "Resources");
+			_responseManager = new ResponseManager(resDir, "POIMainResponses");
+		}
 
         // Generated accessors
         public static BotResponse PointOfInterestWelcomeMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/Resources/RouteResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/Resources/RouteResponses.cs
@@ -15,12 +15,12 @@ namespace PointOfInterestSkill.Dialogs.Route.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static RouteResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(RouteResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Route\Resources");
-            _responseManager = new ResponseManager(resDir, "RouteResponses");
-        }
+		static RouteResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(RouteResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Route", "Resources");
+			_responseManager = new ResponseManager(resDir, "RouteResponses");
+		}
 
         // Generated accessors
         public static BotResponse MissingActiveLocationErrorMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/Resources/POISharedResponses.cs
@@ -15,12 +15,12 @@ namespace PointOfInterestSkill.Dialogs.Shared.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static POISharedResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(POISharedResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Shared\Resources");
-            _responseManager = new ResponseManager(resDir, "POISharedResponses");
-        }
+		static POISharedResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(POISharedResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Shared", "Resources");
+			_responseManager = new ResponseManager(resDir, "POISharedResponses");
+		}
 
         // Generated accessors
         public static BotResponse DidntUnderstandMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/DeleteToDo/Resources/DeleteToDoResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/DeleteToDo/Resources/DeleteToDoResponses.cs
@@ -15,12 +15,12 @@ namespace ToDoSkill.Dialogs.DeleteToDo.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static DeleteToDoResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(DeleteToDoResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\DeleteToDo\Resources");
-            _responseManager = new ResponseManager(resDir, "DeleteToDoResponses");
-        }
+		static DeleteToDoResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(DeleteToDoResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "DeleteToDo", "Resources");
+			_responseManager = new ResponseManager(resDir, "DeleteToDoResponses");
+		}
 
         // Generated accessors
         public static BotResponse AfterTaskDeleted => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/Resources/TODoMainResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/Resources/TODoMainResponses.cs
@@ -15,12 +15,12 @@ namespace ToDoSkill.Dialogs.Main.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ToDoMainResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ToDoMainResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Main\Resources");
-            _responseManager = new ResponseManager(resDir, "ToDoMainResponses");
-        }
+		static ToDoMainResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ToDoMainResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Main", "Resources");
+			_responseManager = new ResponseManager(resDir, "ToDoMainResponses");
+		}
 
         // Generated accessors
         public static BotResponse ToDoWelcomeMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/MarkToDo/Resources/MarkToDoResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/MarkToDo/Resources/MarkToDoResponses.cs
@@ -15,12 +15,12 @@ namespace ToDoSkill.Dialogs.MarkToDo.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static MarkToDoResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(MarkToDoResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\MarkToDo\Resources");
-            _responseManager = new ResponseManager(resDir, "MarkToDoResponses");
-        }
+		static MarkToDoResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(MarkToDoResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "MarkToDo", "Resources");
+			_responseManager = new ResponseManager(resDir, "MarkToDoResponses");
+		}
 
         // Generated accessors
         public static BotResponse AfterToDoTaskCompleted => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/Resources/ToDoSharedResponses.cs
@@ -15,12 +15,12 @@ namespace ToDoSkill.Dialogs.Shared.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ToDoSharedResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ToDoSharedResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\Shared\Resources");
-            _responseManager = new ResponseManager(resDir, "ToDoSharedResponses");
-        }
+		static ToDoSharedResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ToDoSharedResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "Shared", "Resources");
+			_responseManager = new ResponseManager(resDir, "ToDoSharedResponses");
+		}
 
         // Generated accessors
         public static BotResponse DidntUnderstandMessage => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/ShowToDo/Resources/ShowToDoResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/ShowToDo/Resources/ShowToDoResponses.cs
@@ -15,12 +15,12 @@ namespace ToDoSkill.Dialogs.ShowToDo.Resources
     {
         private static readonly ResponseManager _responseManager;
 
-        static ShowToDoResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(ShowToDoResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Dialogs\ShowToDo\Resources");
-            _responseManager = new ResponseManager(resDir, "ShowToDoResponses");
-        }
+		static ShowToDoResponses()
+		{
+			var dir = Path.GetDirectoryName(typeof(ShowToDoResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Dialogs", "ShowToDo", "Resources");
+			_responseManager = new ResponseManager(resDir, "ShowToDoResponses");
+		}
 
         // Generated accessors
         public static BotResponse FirstToDoTasks => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Resources/TestResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Resources/TestResponses.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Bot.Solutions.Tests.Resources
         private static readonly ResponseManager _responseManager;
 
 		static TestResponses()
-        {
-            var dir = Path.GetDirectoryName(typeof(TestResponses).Assembly.Location);
-            var resDir = Path.Combine(dir, @"Resources");
-            _responseManager = new ResponseManager(resDir, "TestResponses");
-        }
+		{
+			var dir = Path.GetDirectoryName(typeof(TestResponses).Assembly.Location);
+			var resDir = Path.Combine(dir, "Resources");
+			_responseManager = new ResponseManager(resDir, "TestResponses");
+		}
 
         // Generated accessors  
         public static BotResponse GetResponseText => GetBotResponse();


### PR DESCRIPTION
## Description
Fixed literal usage on Path.Combine to allow for paths on OSX. 
Replaced xpath usage on prebuild commands to use MSBuild copy commands.

## Related Issue
[https://github.com/Microsoft/AI/issues/376](https://github.com/Microsoft/AI/issues/376)

## Testing Steps
Compile using Visual Stuio on both OSX and Windows. Check the skills can be accessed correctly at run time. i.e asking "add milk to my shopping list" will work on both platforms (currently OSX will fail).

## Checklist
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have added or updated the appropriate unit tests
- [X ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.