### PR TITLE
[Proactive]Add proactive model middleware to auto save conversation for users into state

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -117,7 +117,9 @@ namespace VirtualAssistant
                 options.Middleware.Add(new SetLocaleMiddleware(defaultLocale ?? "en-us"));
                 options.Middleware.Add(new EventDebuggerMiddleware());
                 options.Middleware.Add(new AutoSaveStateMiddleware(userState, conversationState));
-                options.Middleware.Add(new ProactiveStateMiddleware(proactiveState));
+
+                // TODO: uncomment the following line to enable auto save of proactive state
+                // options.Middleware.Add(new ProactiveStateMiddleware(proactiveState));
 
                 //// Translator is an optional component for scenarios when an Assistant needs to work beyond native language support
                 // var translatorKey = Configuration.GetValue<string>("translatorKey");

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -14,6 +14,7 @@ using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Middleware;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,10 +66,12 @@ namespace VirtualAssistant
             var dataStore = new CosmosDbStorage(cosmosOptions);
             var userState = new UserState(dataStore);
             var conversationState = new ConversationState(dataStore);
+            var proactiveState = new ProactiveState(dataStore);
 
             services.AddSingleton(dataStore);
             services.AddSingleton(userState);
             services.AddSingleton(conversationState);
+            services.AddSingleton(proactiveState);
             services.AddSingleton(new BotStateSet(userState, conversationState));
 
             var environment = _isProduction ? "production" : "development";
@@ -114,6 +117,7 @@ namespace VirtualAssistant
                 options.Middleware.Add(new SetLocaleMiddleware(defaultLocale ?? "en-us"));
                 options.Middleware.Add(new EventDebuggerMiddleware());
                 options.Middleware.Add(new AutoSaveStateMiddleware(userState, conversationState));
+                options.Middleware.Add(new ProactiveStateMiddleware(proactiveState));
 
                 //// Translator is an optional component for scenarios when an Assistant needs to work beyond native language support
                 // var translatorKey = Configuration.GetValue<string>("translatorKey");

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/ProactiveStateMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/ProactiveStateMiddleware.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Solutions.Models.Proactive;
+using static Microsoft.Bot.Solutions.Models.Proactive.ProactiveModel;
+
+namespace Microsoft.Bot.Solutions.Middleware
+{
+    public class ProactiveStateMiddleware : IMiddleware
+    {
+        private ProactiveState _proactiveState;
+        private IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
+
+        public ProactiveStateMiddleware(ProactiveState proactiveState)
+        {
+            _proactiveState = proactiveState;
+            _proactiveStateAccessor = _proactiveState.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
+        }
+
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel());
+            ProactiveData data;
+            var userId = turnContext.Activity.From.Id;
+            var conversationReference = turnContext.Activity.GetConversationReference();
+            var proactiveData = new ProactiveData { Conversation = conversationReference };
+
+            if (proactiveState.TryGetValue(userId, out data))
+            {
+                data.Conversation = conversationReference;
+            }
+            else
+            {
+                data = new ProactiveData { Conversation = conversationReference };
+            }
+
+            proactiveState[userId] = data;
+            await _proactiveStateAccessor.SetAsync(turnContext, proactiveState);
+            await _proactiveState.SaveChangesAsync(turnContext);
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/ProactiveStateMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/ProactiveStateMiddleware.cs
@@ -9,6 +9,10 @@ using static Microsoft.Bot.Solutions.Models.Proactive.ProactiveModel;
 
 namespace Microsoft.Bot.Solutions.Middleware
 {
+    /// <summary>
+    /// A Middleware for saving the proactive model data
+    /// This middleware will refresh user's latest conversation reference and save it to state.
+    /// </summary>
     public class ProactiveStateMiddleware : IMiddleware
     {
         private ProactiveState _proactiveState;

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveModel.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Solutions.Models.Proactive

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveModel.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Solutions.Models.Proactive
+{
+    public class ProactiveModel : Dictionary<string, ProactiveModel.ProactiveData>
+    {
+        public class ProactiveData
+        {
+            public ConversationReference Conversation { get; set; }
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveState.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Bot.Builder;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
 
 namespace Microsoft.Bot.Solutions.Models.Proactive
 {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Models/Proactive/ProactiveState.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Bot.Builder;
+
+namespace Microsoft.Bot.Solutions.Models.Proactive
+{
+    public class ProactiveState : BotState
+    {
+        /// <summary>The key used to cache the state information in the turn context.</summary>
+        private const string StorageKey = "ProactiveState";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProactiveState"/> class.</summary>
+        /// <param name="storage">The storage provider to use.</param>
+        public ProactiveState(IStorage storage)
+            : base(storage, StorageKey)
+        {
+        }
+
+        /// <summary>Gets the storage key for caching state information.</summary>
+        /// <param name="turnContext">A <see cref="ITurnContext"/> containing all the data needed
+        /// for processing this conversation turn.</param>
+        /// <returns>The storage key.</returns>
+        protected override string GetStorageKey(ITurnContext turnContext) => StorageKey;
+    }
+}


### PR DESCRIPTION
## Description
The Middleware that enables proactive scenarios. It saves user's conversation reference for users automatically

## Related Issue
#103 

## Testing Steps
1. Open the bot in emulator. 
2. Wait until the intro card shows up.
3. Go to the azure portal and look at the cosmos db service
4. Find the collection called: botstate-collection
5. Find the document called ProactiveState
6. You will find the saved state in there 

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

