### PR TITLE
remove EndComponentAsync implementation from inherited classes

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/ConfirmRecipientDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/ConfirmRecipientDialog.cs
@@ -345,17 +345,5 @@ namespace EmailSkill
                 return new DialogTurnResult(DialogTurnStatus.Cancelled, CommonUtil.DialogTurnResultCancelAllDialogs);
             }
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            if (result.ToString().Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
@@ -120,18 +120,5 @@ namespace EmailSkill
                 return new DialogTurnResult(DialogTurnStatus.Cancelled, CommonUtil.DialogTurnResultCancelAllDialogs);
             }
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            var resultString = result?.ToString();
-            if (!string.IsNullOrWhiteSpace(resultString) && resultString.Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/ForwardEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/ForwardEmailDialog.cs
@@ -106,18 +106,5 @@ namespace EmailSkill
             await ClearConversationState(sc);
             return await sc.EndDialogAsync(true);
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            var resultString = result?.ToString();
-            if (!string.IsNullOrWhiteSpace(resultString) && resultString.Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/ReplyEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/ReplyEmailDialog.cs
@@ -101,18 +101,5 @@ namespace EmailSkill
             await ClearConversationState(sc);
             return await sc.EndDialogAsync(true);
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            var resultString = result?.ToString();
-            if (!string.IsNullOrWhiteSpace(resultString) && resultString.Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/SendEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/SendEmailDialog.cs
@@ -147,18 +147,5 @@ namespace EmailSkill
             await ClearConversationState(sc);
             return await sc.EndDialogAsync(true);
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            var resultString = result?.ToString();
-            if (!string.IsNullOrWhiteSpace(resultString) && resultString.Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/ShowEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/ShowEmailDialog.cs
@@ -389,18 +389,5 @@ namespace EmailSkill
                 return new DialogTurnResult(DialogTurnStatus.Cancelled, CommonUtil.DialogTurnResultCancelAllDialogs);
             }
         }
-
-        protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
-        {
-            var resultString = result?.ToString();
-            if (!string.IsNullOrWhiteSpace(resultString) && resultString.Equals(CommonUtil.DialogTurnResultCancelAllDialogs, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return outerDc.CancelAllDialogsAsync();
-            }
-            else
-            {
-                return base.EndComponentAsync(outerDc, result, cancellationToken);
-            }
-        }
     }
 }


### PR DESCRIPTION
## Description
Don't need to implement EndComponentAsync in all dialogs. Only needed in the lowest level dialog

