### PR TITLE
Removed NoAttendees strings for Google and fix a Chinese string

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -379,16 +379,6 @@ namespace CalendarSkill
                     return await sc.NextAsync(cancellationToken: cancellationToken);
                 }
 
-                if (state.EventSource == EventSource.Microsoft)
-                {
-                    return await sc.PromptAsync(Actions.Prompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoAttendeesMS) }, cancellationToken);
-                }
-
-                if (sc.Result != null)
-                {
-                    return await sc.PromptAsync(Actions.Prompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(CreateEventResponses.WrongAddress) }, cancellationToken);
-                }
-
                 return await sc.PromptAsync(Actions.Prompt, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoAttendees) }, cancellationToken);
             }
             catch

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.cs
@@ -36,10 +36,6 @@ namespace CalendarSkill.Dialogs.CreateEvent.Resources
 
         public static BotResponse EventCreationFailed => GetBotResponse();
 
-        public static BotResponse NoAttendeesMS => GetBotResponse();
-
-        public static BotResponse WrongAddress => GetBotResponse();
-
         public static BotResponse NoAttendees => GetBotResponse();
 
         public static BotResponse PromptTooManyPeople => GetBotResponse();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.json
@@ -82,32 +82,12 @@
         ],
         "inputHint": "acceptingInput"
     },
-  "NoAttendeesMS": {
+  "NoAttendees": {
     "replies": [
 
       {
         "text": "Who will join?",
         "speak": "Who will join?"
-      }
-    ],
-    "inputHint": "expectingInput"
-  },
-  "WrongAddress": {
-    "replies": [
-
-      {
-        "text": "That doesn't look like an email address, please try again. (Please enter Email address like: Alice@example.com)",
-        "speak": "That doesn't look like an email address, please try again. (Please enter Email address like: Alice@example.com)"
-      }
-    ],
-    "inputHint": "expectingInput"
-  },
-  "NoAttendees": {
-    "replies": [
-
-      {
-        "text": "Who are the participants? (Please enter Email address like: Alice@example.com)",
-        "speak": "Who are the participants? (Please enter Email address like: Alice@example.com)"
       }
     ],
     "inputHint": "expectingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventResponses.zh.json
@@ -2,8 +2,8 @@
   "NoTitle": {
     "replies": [
       {
-        "text": "好的，我将发送会议给{UserName}, 会议主题是什么？",
-        "speak": "好的，我将发送会议给{UserName}, 会议主题是什么？"
+        "text": "好的，我将发送会议给{UserName}，会议主题是什么？",
+        "speak": "好的，我将发送会议给{UserName}，会议主题是什么？"
       }
     ],
     "inputHint": "expectingInput"
@@ -78,29 +78,11 @@
         ],
         "inputHint": "acceptingInput"
     },
-  "NoAttendeesMS": {
+  "NoAttendees": {
     "replies": [
       {
         "text": "谁将参加会议？",
         "speak": "谁将参加会议？"
-      }
-    ],
-    "inputHint": "expectingInput"
-  },
-  "WrongAddress": {
-    "replies": [
-      {
-        "text": "这不是一个正确的邮件地址，请重试。 (请输入电子邮件地址，例如: Alice@example.com)",
-        "speak": "这不是一个正确的邮件地址，请重试。 (请输入电子邮件地址，例如: Alice@example.com)"
-      }
-    ],
-    "inputHint": "expectingInput"
-  },
-  "NoAttendees": {
-    "replies": [
-      {
-        "text": "谁将参加会议？ (请输入电子邮件地址，例如: Alice@example.com)",
-        "speak": "谁将参加会议？ (请输入电子邮件地址，例如: Alice@example.com)"
       }
     ],
     "inputHint": "expectingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CreateCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CreateCalendarFlowTests.cs
@@ -47,7 +47,7 @@ namespace CalendarSkillTest.Flow
 
         private string[] AskForParticpantsPrompt()
         {
-            return this.ParseReplies(CreateEventResponses.NoAttendeesMS.Replies, new StringDictionary());
+            return this.ParseReplies(CreateEventResponses.NoAttendees.Replies, new StringDictionary());
         }
 
         private string[] AskForSubjectPrompt()


### PR DESCRIPTION
## Description
1. Before we add the google contact API, we ask user to input full email address when use the Google account. Now remove the related strings.
2. Fixed a punctuation in a Chinese string.

## Testing Steps
1. Go into the create meeting flow with Google account. Check the string of asking attendee.
2. Change the language to zh-cn then go into the creating meeting flow, check the asking title string.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
