### PR TITLE
[DO NOT MERGE] Virtual Assistant: update Bot.Builder 4.2 & telemetry

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-detailedoverview.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-detailedoverview.md
@@ -26,7 +26,10 @@ The host app is responsible for the following capabilities. These can of course 
 The Assistant makes use of a number of Middleware Components to process incoming messages:
     - Telemetry Middleware leverages Application Insights to store telemetry for incoming messages, LUIS evaluation and QNA activities. PowerBI can then use this data to surface conversational insights.
     - Event Processing Middleware processes events sent by the device
-    - Content Moderator Middleware uses the Content Moderator Cognitive Service to detect inappropriate / PII content
+    - Content Moderator Middleware uses the Content Moderator Cognitive Service to detect inappropriate / PII content]]
+
+## Advanced Conversational Analytics
+The Assistant is configured to collect telemetry into Application Insights. This can be imported into a PowerBI dashboard to view [advanced conversational analytics](https://aka.ms/botPowerBiTemplate).
 
 ## Dispatcher
 

--- a/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
@@ -40,9 +40,23 @@ namespace VirtualAssistant
                 {
                     case ServiceTypes.AppInsights:
                         {
-                            var appInsights = service as AppInsightsService;
+                            var appInsights = (AppInsightsService)service;
+                            if (appInsights == null)
+                            {
+                                throw new InvalidOperationException("The Application Insights is not configured correctly in your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(appInsights.InstrumentationKey))
+                            {
+                                throw new InvalidOperationException("The Application Insights Instrumentation Key ('instrumentationKey') is required to run this sample.  Please update your '.bot' file.");
+                            }
+
                             var telemetryConfig = new TelemetryConfiguration(appInsights.InstrumentationKey);
-                            TelemetryClient = new TelemetryClient(telemetryConfig);
+                            TelemetryClient = new TelemetryClient(telemetryConfig)
+                            {
+                                InstrumentationKey = appInsights.InstrumentationKey,
+                            };
+
                             break;
                         }
 
@@ -93,6 +107,21 @@ namespace VirtualAssistant
                         case ServiceTypes.Dispatch:
                             {
                                 var dispatch = service as DispatchService;
+                                if (dispatch == null)
+                                {
+                                    throw new InvalidOperationException("The Dispatch service is not configured correctly in your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(dispatch.AppId))
+                                {
+                                    throw new InvalidOperationException("The Dispatch Luis Model Application Id ('appId') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(dispatch.SubscriptionKey))
+                                {
+                                    throw new InvalidOperationException("The Subscription Key ('subscriptionKey') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
                                 var dispatchApp = new LuisApplication(dispatch.AppId, dispatch.SubscriptionKey, dispatch.GetEndpoint());
                                 localeConfig.DispatchRecognizer = new TelemetryLuisRecognizer(dispatchApp);
                                 break;
@@ -101,8 +130,34 @@ namespace VirtualAssistant
                         case ServiceTypes.Luis:
                             {
                                 var luis = service as LuisService;
+                                if (luis == null)
+                                {
+                                    throw new InvalidOperationException("The Luis service is not configured correctly in your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(luis.AppId))
+                                {
+                                    throw new InvalidOperationException("The Luis Model Application Id ('appId') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(luis.AuthoringKey))
+                                {
+                                    throw new InvalidOperationException("The Luis Authoring Key ('authoringKey') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(luis.SubscriptionKey))
+                                {
+                                    throw new InvalidOperationException("The Subscription Key ('subscriptionKey') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(luis.Region))
+                                {
+                                    throw new InvalidOperationException("The Region ('region') is required to run this sample.  Please update your '.bot' file.");
+                                }
+
                                 var luisApp = new LuisApplication(luis.AppId, luis.SubscriptionKey, luis.GetEndpoint());
-                                localeConfig.LuisServices.Add(service.Id, new TelemetryLuisRecognizer(luisApp));
+                                var recognizer = new TelemetryLuisRecognizer(luisApp);
+                                localeConfig.LuisServices.Add(service.Id, recognizer);
                                 break;
                             }
 

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Escalate/EscalateDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Escalate/EscalateDialog.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 
 namespace VirtualAssistant
@@ -11,17 +12,18 @@ namespace VirtualAssistant
     {
         private EscalateResponses _responder = new EscalateResponses();
 
-        public EscalateDialog(BotServices botServices)
-            : base(botServices, nameof(EscalateDialog))
+        public EscalateDialog(BotServices botServices, IBotTelemetryClient telemetryClient)
+            : base(botServices, nameof(EscalateDialog), telemetryClient)
         {
             InitialDialogId = nameof(EscalateDialog);
+            TelemetryClient = telemetryClient;
 
             var escalate = new WaterfallStep[]
             {
                 SendEscalationMessage,
             };
 
-            AddDialog(new WaterfallDialog(InitialDialogId, escalate));
+            AddDialog(new WaterfallDialog(InitialDialogId, escalate) { TelemetryClient = telemetryClient });
         }
 
         private async Task<DialogTurnResult> SendEscalationMessage(WaterfallStepContext sc, CancellationToken cancellationToken)

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -34,7 +34,7 @@ namespace VirtualAssistant
         private SkillRouter _skillRouter;
 
         public MainDialog(BotServices services, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
-            : base(nameof(MainDialog))
+            : base(nameof(MainDialog), telemetryClient)
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _botConfig = botConfig;
@@ -48,8 +48,8 @@ namespace VirtualAssistant
             var dialogState = _conversationState.CreateProperty<DialogState>(nameof(DialogState));
 
             AddDialog(new OnboardingDialog(_services, _onboardingState, telemetryClient));
-            AddDialog(new EscalateDialog(_services));
-            AddDialog(new CustomSkillDialog(_services.SkillConfigurations, dialogState, endpointService));
+            AddDialog(new EscalateDialog(_services, telemetryClient));
+            AddDialog(new CustomSkillDialog(_services.SkillConfigurations, dialogState, endpointService, telemetryClient));
 
             // Initialize skill dispatcher
             _skillRouter = new SkillRouter(_services.SkillDefinitions);

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Onboarding/OnboardingDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Onboarding/OnboardingDialog.cs
@@ -21,7 +21,7 @@ namespace VirtualAssistant
         private OnboardingState _state;
 
         public OnboardingDialog(BotServices botServices, IStatePropertyAccessor<OnboardingState> accessor, IBotTelemetryClient telemetryClient)
-            : base(botServices, nameof(OnboardingDialog))
+            : base(botServices, nameof(OnboardingDialog), telemetryClient)
         {
             _accessor = accessor;
             InitialDialogId = nameof(OnboardingDialog);

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Onboarding/OnboardingDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Onboarding/OnboardingDialog.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 
@@ -19,7 +20,7 @@ namespace VirtualAssistant
         private IStatePropertyAccessor<OnboardingState> _accessor;
         private OnboardingState _state;
 
-        public OnboardingDialog(BotServices botServices, IStatePropertyAccessor<OnboardingState> accessor)
+        public OnboardingDialog(BotServices botServices, IStatePropertyAccessor<OnboardingState> accessor, IBotTelemetryClient telemetryClient)
             : base(botServices, nameof(OnboardingDialog))
         {
             _accessor = accessor;
@@ -32,7 +33,10 @@ namespace VirtualAssistant
                 FinishOnboardingDialog,
             };
 
-            AddDialog(new WaterfallDialog(InitialDialogId, onboarding));
+            // To capture built-in waterfall dialog telemetry, set the telemetry client 
+            // to the new waterfall dialog and add it to the component dialog
+            TelemetryClient = telemetryClient;
+            AddDialog(new WaterfallDialog(InitialDialogId, onboarding) { TelemetryClient = telemetryClient });
             AddDialog(new TextPrompt(NamePrompt));
             AddDialog(new TextPrompt(LocationPrompt));
         }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/CustomSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/CustomSkillDialog.cs
@@ -10,10 +10,10 @@ namespace VirtualAssistant
 {
     public class CustomSkillDialog : ComponentDialog
     {
-        public CustomSkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService)
+        public CustomSkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService, IBotTelemetryClient telemetryClient)
             : base(nameof(CustomSkillDialog))
         {
-            AddDialog(new SkillDialog(skills, accessor, endpointService));
+            AddDialog(new SkillDialog(skills, accessor, endpointService, telemetryClient));
         }
 
         protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/EnterpriseDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Shared/EnterpriseDialog.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Luis;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Solutions.Dialogs;
 
@@ -18,10 +19,11 @@ namespace VirtualAssistant
         private readonly BotServices _services;
         private readonly MainResponses _responder = new MainResponses();
 
-        public EnterpriseDialog(BotServices botServices, string dialogId)
-            : base(dialogId)
+        public EnterpriseDialog(BotServices botServices, string dialogId, IBotTelemetryClient telemetryClient)
+            : base(dialogId, telemetryClient)
         {
             _services = botServices;
+            TelemetryClient = telemetryClient;
         }
 
         protected override async Task<InterruptionAction> OnInterruptDialogAsync(DialogContext dc, CancellationToken cancellationToken)

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Program.cs
@@ -16,8 +16,7 @@ namespace VirtualAssistant
         public static IWebHost BuildWebHost(string[] args)
         {
             return WebHost.CreateDefaultBuilder(args)
-                            .UseApplicationInsights()
-                            .UseStartup<Startup>()
+                            .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
                             .Build();
         }
     }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -35,11 +35,6 @@ namespace VirtualAssistant
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
-            if (env.IsDevelopment())
-            {
-                builder.AddUserSecrets<Startup>();
-            }
-
             Configuration = builder.Build();
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
@@ -34,6 +35,11 @@ namespace VirtualAssistant
                 .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
+            if (env.IsDevelopment())
+            {
+                builder.AddUserSecrets<Startup>();
+            }
+
             Configuration = builder.Build();
         }
 
@@ -46,6 +52,9 @@ namespace VirtualAssistant
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
             var botConfig = BotConfiguration.Load(botFilePath ?? @".\CustomAssistant.bot", botFileSecret);
             services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded."));
+
+            // Use Application Insights
+            services.AddBotApplicationInsights(botConfig);
 
             // Initializes your bot service clients and adds a singleton that your Bot can access through dependency injection.
             var languageModels = Configuration.GetSection("languageModels").Get<Dictionary<string, Dictionary<string, string>>>();
@@ -94,7 +103,9 @@ namespace VirtualAssistant
                 // Telemetry Middleware (logs activity messages in Application Insights)
                 var appInsightsService = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.AppInsights) ?? throw new Exception("Please configure your AppInsights connection in your .bot file.");
                 var instrumentationKey = (appInsightsService as AppInsightsService).InstrumentationKey;
-                var appInsightsLogger = new TelemetryLoggerMiddleware(instrumentationKey, logUserName: true, logOriginalMessage: true);
+                var sp = services.BuildServiceProvider();
+                var telemetryClient = sp.GetService<IBotTelemetryClient>();
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logUserName: true, logOriginalMessage: true);
                 options.Middleware.Add(appInsightsLogger);
 
                 // Catches any errors that occur during a conversation turn and logs them to AppInsights.
@@ -104,7 +115,7 @@ namespace VirtualAssistant
                     var responseBuilder = new MainResponses();
                     await responseBuilder.ReplyWith(context, MainResponses.ResponseIds.Error);
                     await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Virtual Assistant Error: {exception.Message} | {exception.StackTrace}"));
-                    connectedServices.TelemetryClient.TrackException(exception);
+                    telemetryClient.TrackException(exception);
                 };
 
                 // Transcript Middleware (saves conversation history in a standard format)
@@ -145,7 +156,8 @@ namespace VirtualAssistant
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             _isProduction = env.IsProduction();
-            app.UseDefaultFiles()
+            app.UseBotApplicationInsights()
+                .UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
         }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -21,6 +21,7 @@ namespace VirtualAssistant
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
         private readonly EndpointService _endpointService;
+        private readonly IBotTelemetryClient _telemetryClient;
         private DialogSet _dialogs;
 
         /// <summary>
@@ -31,16 +32,17 @@ namespace VirtualAssistant
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
         /// <param name="endpointService">Bot endpoint service.</param>
-        public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService)
+        public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
             _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _botConfig = botConfig;
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(VirtualAssistant)));
-            _dialogs.Add(new MainDialog(_services, _botConfig, _conversationState, _userState, _endpointService));
+            _dialogs.Add(new MainDialog(_services, _botConfig, _conversationState, _userState, _endpointService, _telemetryClient));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -32,6 +32,7 @@ namespace VirtualAssistant
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
         /// <param name="endpointService">Bot endpoint service.</param>
+        /// <param name="telemetryClient">Bot telemetry client.</param>
         public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
@@ -23,19 +23,30 @@
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.36.1.1342" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
     <PackageReference Include="Google.Apis.Calendar.v3" Version="1.35.2.1363" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.1" />    
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Graph" Version="1.11.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Graph" Version="1.12.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     <PackageReference Include="MimeKit" Version="2.0.7" />

--- a/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
@@ -9,10 +9,6 @@
     "en": {
       "botFilePath": ".\\LocaleConfigurations\\YOUR_LOCALE_PATH.bot",
       "botFileSecret": ""
-    },
-    "zh": {
-      "botFilePath": ".\\LocaleConfigurations\\YOUR_LOCALE_PATH.bot",
-      "botFileSecret": ""
     }
   },
   "skills": [

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Dialogs/InterruptableDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Dialogs/InterruptableDialog.cs
@@ -3,16 +3,18 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Bot.Solutions.Dialogs
 {
     public abstract class InterruptableDialog : ComponentDialog
     {
-        public InterruptableDialog(string dialogId)
+        public InterruptableDialog(string dialogId, IBotTelemetryClient telemetryClient)
             : base(dialogId)
         {
             PrimaryDialogName = dialogId;
+            TelemetryClient = telemetryClient;
         }
 
         public string PrimaryDialogName { get; set; }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Dialogs/RouterDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Dialogs/RouterDialog.cs
@@ -10,9 +10,10 @@ namespace Microsoft.Bot.Solutions
 {
     public abstract class RouterDialog : InterruptableDialog
     {
-        public RouterDialog(string dialogId)
-            : base(dialogId)
+        public RouterDialog(string dialogId, IBotTelemetryClient telemetryClient)
+            : base(dialogId, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
         }
 
         protected override Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken)) => OnContinueDialogAsync(innerDc, cancellationToken);

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Microsoft.Bot.Solutions.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Microsoft.Bot.Solutions.csproj
@@ -15,15 +15,15 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryLuisRecognizer.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Bot.Solutions
 {
@@ -11,9 +12,10 @@ namespace Microsoft.Bot.Solutions
 
         bool LogUsername { get; }
 
-        Task<RecognizerResult> RecognizeAsync(ITurnContext context, CancellationToken cancellationToken, bool logOriginalMessage);
+        Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new();
 
-        Task<T> RecognizeAsync<T>(ITurnContext context, CancellationToken cancellationToken, bool logOriginalMessage)
+        Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/LuisTelemetryConstants.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/LuisTelemetryConstants.cs
@@ -8,13 +8,14 @@ namespace Microsoft.Bot.Solutions
     /// </summary>
     public static class LuisTelemetryConstants
     {
-        public const string IntentPrefix = "LuisIntent";  // Application Insights Custom Event name (with Intent)
-        public const string IntentProperty = "Intent";
-        public const string IntentScoreProperty = "IntentScore";
-        public const string ConversationIdProperty = "ConversationId";
-        public const string QuestionProperty = "Question";
-        public const string ActivityIdProperty = "ActivityId";
-        public const string SentimentLabelProperty = "SentimentLabel";
-        public const string SentimentScoreProperty = "SentimentScore";
+        public const string IntentPrefix = "luisIntent";  // Application Insights Custom Event name (with Intent)
+        public const string IntentProperty = "intent";
+        public const string IntentScoreProperty = "intentScore";
+        public const string ConversationIdProperty = "conversationId";
+        public const string QuestionProperty = "question";
+        public const string ActivityIdProperty = "activityId";
+        public const string SentimentLabelProperty = "sentimentLabel";
+        public const string SentimentScoreProperty = "sentimentScore";
+        public const string DialogId = "dialogId";
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/QnATelemetryConstants.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/QnATelemetryConstants.cs
@@ -8,12 +8,14 @@ namespace Microsoft.Bot.Solutions
     /// </summary>
     public static class QnATelemetryConstants
     {
-        public const string ActivityIdProperty = "ActivityId";
-        public const string UsernameProperty = "Username";
-        public const string ConversationIdProperty = "ConversationId";
-        public const string OriginalQuestionProperty = "OriginalQuestion";
-        public const string QuestionProperty = "Question";
-        public const string AnswerProperty = "Answer";
-        public const string ScoreProperty = "Score";
+        public const string ActivityIdProperty = "activityId";
+        public const string AnswerProperty = "answer";
+        public const string ArticleFoundProperty = "articleFound";
+        public const string ChannelIdProperty = "channelId";
+        public const string ConversationIdProperty = "conversationId";
+        public const string OriginalQuestionProperty = "originalQuestion";
+        public const string QuestionProperty = "question";
+        public const string ScoreProperty = "score";
+        public const string UsernameProperty = "username";
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryConstants.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryConstants.cs
@@ -5,15 +5,17 @@ namespace Microsoft.Bot.Solutions
 {
     public static class TelemetryConstants
     {
-        public const string ActivityIDProperty = "ActivityId";
-        public const string ChannelProperty = "Channel";
-        public const string FromIdProperty = "FromId";
-        public const string FromNameProperty = "FromName";
-        public const string RecipientIdProperty = "RecipientId";
-        public const string RecipientNameProperty = "RecipientName";
-        public const string ConversationIdProperty = "ConversationId";
-        public const string ConversationNameProperty = "ConversationName";
-        public const string TextProperty = "Text";
-        public const string LocaleProperty = "Locale";
+        public const string ActivityIDProperty = "activityId";
+        public const string ReplyActivityIDProperty = "replyActivityId";
+        public const string ChannelIdProperty = "channelId";
+        public const string FromIdProperty = "fromId";
+        public const string FromNameProperty = "fromName";
+        public const string RecipientIdProperty = "recipientId";
+        public const string RecipientNameProperty = "recipientName";
+        public const string ConversationIdProperty = "conversationId";
+        public const string ConversationNameProperty = "conversationName";
+        public const string TextProperty = "text";
+        public const string LocaleProperty = "locale";
+        public const string SpeakProperty = "speak";
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Bot.Solutions
             {
                 throw new ArgumentNullException(nameof(dialogContext));
             }
+
             return await RecognizeInternalAsync(dialogContext.Context, logOriginalMessage, dialogContext.ActiveDialog?.Id, cancellationToken);
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.Dialogs;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Solutions
@@ -26,7 +27,7 @@ namespace Microsoft.Bot.Solutions
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryLuisRecognizer"/> class.
         /// </summary>
-        /// <param name="application">The LUIS _application to use to recognize text.</param>
+        /// <param name="application">The LUIS application to use to recognize text.</param>
         /// <param name="predictionOptions">The LUIS prediction options to use.</param>
         /// <param name="includeApiResults">TRUE to include raw LUIS API response.</param>
         /// <param name="logOriginalMessage">TRUE to include original user message.</param>
@@ -50,14 +51,59 @@ namespace Microsoft.Bot.Solutions
         /// <value>If true, will log the user name into the AppInsight Custom Event for Luis intents.</value>
         public bool LogUsername { get; }
 
+        public async Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new()
+        {
+            var result = new T();
+            result.Convert(await RecognizeAsync(dialogContext, logOriginalMessage, cancellationToken).ConfigureAwait(false));
+            return result;
+        }
+
+        public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new()
+        {
+            var result = new T();
+            result.Convert(await RecognizeAsync(turnContext, logOriginalMessage, cancellationToken).ConfigureAwait(false));
+            return result;
+        }
+
+
+        /// <summary>
+        /// Return results of the analysis (Suggested actions and intents), passing the dialog id from dialog context to the TelemetryClient.
+        /// </summary>
+        /// <param name="dialogContext">Dialog context object containing information for the dialog being executed.</param>
+        /// <param name="logOriginalMessage">Determines if the original message is logged into Application Insights.  This is a privacy consideration.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        public async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (dialogContext == null)
+            {
+                throw new ArgumentNullException(nameof(dialogContext));
+            }
+            return await RecognizeInternalAsync(dialogContext.Context, logOriginalMessage, dialogContext.ActiveDialog?.Id, cancellationToken);
+        }
+
+        /// <summary>
+        /// Return results of the analysis (Suggested actions and intents), using the turn context. This is missing a dialog id used for telemetry..
+        /// </summary>
+        /// <param name="context">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="logOriginalMessage">Determines if the original message is logged into Application Insights.  This is a privacy consideration.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        public async Task<RecognizerResult> RecognizeAsync(ITurnContext context, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await RecognizeInternalAsync(context, logOriginalMessage, null, cancellationToken);
+        }
+
         /// <summary>
         /// Analyze the current message text and return results of the analysis (Suggested actions and intents).
         /// </summary>
         /// <param name="context">Context object containing information for a single turn of conversation with a user.</param>
-        /// <param name="ct">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <param name="logOriginalMessage">Determines if the original message is logged into Application Insights.  This is a privacy consideration.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
-        public async Task<RecognizerResult> RecognizeAsync(ITurnContext context, CancellationToken ct, bool logOriginalMessage = false)
+        private async Task<RecognizerResult> RecognizeInternalAsync(ITurnContext context, bool logOriginalMessage, string dialogId = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (context == null)
             {
@@ -65,9 +111,7 @@ namespace Microsoft.Bot.Solutions
             }
 
             // Call Luis Recognizer
-            var recognizerResult = await base.RecognizeAsync(context, ct);
-
-            var conversationId = context.Activity.Conversation.Id;
+            var recognizerResult = await RecognizeAsync(context, cancellationToken);
 
             // Find the Telemetry Client
             if (context.TurnState.TryGetValue(TelemetryLoggerMiddleware.AppInsightsServiceKey, out var telemetryClient) && recognizerResult != null)
@@ -78,10 +122,15 @@ namespace Microsoft.Bot.Solutions
                 // Add the intent score and conversation id properties
                 var telemetryProperties = new Dictionary<string, string>()
                 {
-                    { LuisTelemetryConstants.ActivityIdProperty, context.Activity.Id },
                     { LuisTelemetryConstants.IntentProperty, topLuisIntent.intent },
                     { LuisTelemetryConstants.IntentScoreProperty, intentScore },
                 };
+
+
+                if (dialogId != null)
+                {
+                    telemetryProperties.Add(LuisTelemetryConstants.DialogId, dialogId);
+                }
 
                 if (recognizerResult.Properties.TryGetValue("sentiment", out var sentiment) && sentiment is JObject)
                 {
@@ -94,11 +143,6 @@ namespace Microsoft.Bot.Solutions
                     {
                         telemetryProperties.Add(LuisTelemetryConstants.SentimentScoreProperty, score.Value<string>());
                     }
-                }
-
-                if (!string.IsNullOrEmpty(conversationId))
-                {
-                    telemetryProperties.Add(LuisTelemetryConstants.ConversationIdProperty, conversationId);
                 }
 
                 // Add Luis Entitites
@@ -118,75 +162,11 @@ namespace Microsoft.Bot.Solutions
                 }
 
                 // Track the event
-                ((TelemetryClient)telemetryClient).TrackEvent($"{LuisTelemetryConstants.IntentPrefix}.{topLuisIntent.intent}", telemetryProperties);
+                ((IBotTelemetryClient)telemetryClient).TrackEvent($"{LuisTelemetryConstants.IntentPrefix}.{topLuisIntent.intent}", telemetryProperties);
             }
 
             return recognizerResult;
         }
 
-        public async Task<T> RecognizeAsync<T>(ITurnContext context, CancellationToken ct, bool logOriginalMessage = false)
-            where T : IRecognizerConvert, new()
-        {
-            var result = new T();
-            var recognizerResult = await base.RecognizeAsync(context, ct);
-
-            var conversationId = context.Activity.Conversation.Id;
-
-            // Find the Telemetry Client
-            if (context.TurnState.TryGetValue(TelemetryLoggerMiddleware.AppInsightsServiceKey, out var telemetryClient) && recognizerResult != null)
-            {
-                var topLuisIntent = recognizerResult.GetTopScoringIntent();
-                var intentScore = topLuisIntent.score.ToString("N2");
-
-                // Add the intent score and conversation id properties
-                var telemetryProperties = new Dictionary<string, string>()
-                {
-                    { LuisTelemetryConstants.ActivityIdProperty, context.Activity.Id },
-                    { LuisTelemetryConstants.IntentProperty, topLuisIntent.intent },
-                    { LuisTelemetryConstants.IntentScoreProperty, intentScore },
-                };
-
-                if (recognizerResult.Properties.TryGetValue("sentiment", out var sentiment) && sentiment is JObject)
-                {
-                    if (((JObject)sentiment).TryGetValue("label", out var label))
-                    {
-                        telemetryProperties.Add(LuisTelemetryConstants.SentimentLabelProperty, label.Value<string>());
-                    }
-
-                    if (((JObject)sentiment).TryGetValue("score", out var score))
-                    {
-                        telemetryProperties.Add(LuisTelemetryConstants.SentimentScoreProperty, score.Value<string>());
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(conversationId))
-                {
-                    telemetryProperties.Add(LuisTelemetryConstants.ConversationIdProperty, conversationId);
-                }
-
-                // Add Luis Entitites
-                var entities = new List<string>();
-                foreach (var entity in recognizerResult.Entities)
-                {
-                    if (!entity.Key.ToString().Equals("$instance"))
-                    {
-                        entities.Add($"{entity.Key}: {entity.Value.First}");
-                    }
-                }
-
-                // For some customers, logging user name within Application Insights might be an issue so have provided a config setting to disable this feature
-                if (logOriginalMessage && !string.IsNullOrEmpty(context.Activity.Text))
-                {
-                    telemetryProperties.Add(LuisTelemetryConstants.QuestionProperty, context.Activity.Text);
-                }
-
-                // Track the event
-                ((TelemetryClient)telemetryClient).TrackEvent($"{LuisTelemetryConstants.IntentPrefix}.{topLuisIntent.intent}", telemetryProperties);
-            }
-
-            // Convert LUIS result to LG class
-            result.Convert(recognizerResult);
-            return result;
-        }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
@@ -81,18 +81,21 @@ namespace Microsoft.Bot.Solutions
                     telemetryProperties.Add(QnATelemetryConstants.QuestionProperty, string.Join(",", queryResult.Questions));
                     telemetryProperties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
                     telemetryMetrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);
+                    telemetryProperties.Add(QnATelemetryConstants.ArticleFoundProperty, "true");
                 }
                 else
                 {
                     telemetryProperties.Add(QnATelemetryConstants.QuestionProperty, "No Qna Question matched");
                     telemetryProperties.Add(QnATelemetryConstants.AnswerProperty, "No Qna Question matched");
+                    telemetryProperties.Add(QnATelemetryConstants.ArticleFoundProperty, "true");
                 }
 
                 // Track the event
-                ((TelemetryClient)telemetryClient).TrackEvent(QnaMsgEvent, telemetryProperties, telemetryMetrics);
+                ((IBotTelemetryClient)telemetryClient).TrackEvent(QnaMsgEvent, telemetryProperties, telemetryMetrics);
             }
 
             return queryResults;
         }
+
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/LocaleConfiguration.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/LocaleConfiguration.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Bot.Solutions.Skills
         /// </summary>
         /// <remarks>The LUIS services collection should not be modified while the bot is running.</remarks>
         /// <value>
-        /// A <see cref="LuisRecognizer"/> client instance created based on configuration in the .bot file.
+        /// A <see cref="ITelemetryLuisRecognizer"/> client instance created based on configuration in the .bot file.
         /// </value>
-        public Dictionary<string, IRecognizer> LuisServices { get; set; } = new Dictionary<string, IRecognizer>();
+        public Dictionary<string, ITelemetryLuisRecognizer> LuisServices { get; set; } = new Dictionary<string, ITelemetryLuisRecognizer>();
 
         /// <summary>
         /// Gets or sets the QnAMaker Services used.
@@ -40,8 +40,8 @@ namespace Microsoft.Bot.Solutions.Skills
         /// </summary>
         /// <remarks>The QnAMaker services collection should not be modified while the bot is running.</remarks>
         /// <value>
-        /// A <see cref="TelemetryQnAMaker"/> client instance created based on configuration in the .bot file.
+        /// A <see cref="ITelemetryQnAMaker"/> client instance created based on configuration in the .bot file.
         /// </value>
-        public Dictionary<string, QnAMaker> QnAServices { get; set; } = new Dictionary<string, QnAMaker>();
+        public Dictionary<string, ITelemetryQnAMaker> QnAServices { get; set; } = new Dictionary<string, ITelemetryQnAMaker>();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Bot.Solutions.Skills
                 try
                 {
                     var skillType = Type.GetType(skillDefinition.Assembly);
-                    _activatedSkill = (IBot)Activator.CreateInstance(skillType, skillConfiguration, conversationState, userState, null, true);
+                    _activatedSkill = (IBot)Activator.CreateInstance(skillType, skillConfiguration, conversationState, userState, TelemetryClient, null, true);
                 }
                 catch (Exception e)
                 {

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -29,12 +29,13 @@ namespace Microsoft.Bot.Solutions.Skills
         private bool _skillInitialized;
         private bool _useCachedTokens;
 
-        public SkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService, bool useCachedTokens = true)
+        public SkillDialog(Dictionary<string, ISkillConfiguration> skills, IStatePropertyAccessor<DialogState> accessor, EndpointService endpointService, IBotTelemetryClient telemetryClient, bool useCachedTokens = true)
             : base(nameof(SkillDialog))
         {
             _skills = skills;
             _accessor = accessor;
             _endpointService = endpointService;
+            TelemetryClient = telemetryClient;
             _useCachedTokens = useCachedTokens;
             _dialogs = new DialogSet(_accessor);
         }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Bot.Solutions.Skills
         private Dictionary<string, ISkillConfiguration> _skills;
         private IStatePropertyAccessor<DialogState> _accessor;
         private EndpointService _endpointService;
+        private IBotTelemetryClient _telemetryClient;
         private DialogSet _dialogs;
         private InProcAdapter _inProcAdapter;
         private IBot _activatedSkill;
@@ -35,7 +36,7 @@ namespace Microsoft.Bot.Solutions.Skills
             _skills = skills;
             _accessor = accessor;
             _endpointService = endpointService;
-            TelemetryClient = telemetryClient;
+            _telemetryClient = telemetryClient;
             _useCachedTokens = useCachedTokens;
             _dialogs = new DialogSet(_accessor);
         }
@@ -148,7 +149,7 @@ namespace Microsoft.Bot.Solutions.Skills
                 try
                 {
                     var skillType = Type.GetType(skillDefinition.Assembly);
-                    _activatedSkill = (IBot)Activator.CreateInstance(skillType, skillConfiguration, conversationState, userState, TelemetryClient, null, true);
+                    _activatedSkill = (IBot)Activator.CreateInstance(skillType, skillConfiguration, conversationState, userState, _telemetryClient, null, true);
                 }
                 catch (Exception e)
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.cs
@@ -20,20 +20,22 @@ namespace CalendarSkill
         private readonly ISkillConfiguration _services;
         private readonly UserState _userState;
         private readonly ConversationState _conversationState;
+        private readonly IBotTelemetryClient _telemetryClient;
         private readonly IServiceManager _serviceManager;
         private bool _skillMode;
         private DialogSet _dialogs;
 
-        public CalendarSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, IServiceManager serviceManager = null, bool skillMode = false)
+        public CalendarSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, IServiceManager serviceManager = null, bool skillMode = false)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _serviceManager = serviceManager ?? new ServiceManager(_services);
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(DialogState)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _serviceManager, _skillMode));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _serviceManager, _skillMode));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/CalendarSkill.csproj
@@ -22,24 +22,26 @@
     <PackageReference Include="Google.Apis.Calendar.v3" Version="1.35.2.1354" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
     <PackageReference Include="HtmlAgilityPack" Version="1.8.10" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -27,9 +27,12 @@ namespace CalendarSkill
         public CreateEventDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(CreateEventDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(CreateEventDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var createEvent = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -82,13 +85,13 @@ namespace CalendarSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.CreateEvent, createEvent));
-            AddDialog(new WaterfallDialog(Actions.UpdateAddress, updateAddress));
-            AddDialog(new WaterfallDialog(Actions.ConfirmAttendee, confirmAttendee));
-            AddDialog(new WaterfallDialog(Actions.UpdateName, updateName));
-            AddDialog(new WaterfallDialog(Actions.UpdateStartDateForCreate, updateStartDate));
-            AddDialog(new WaterfallDialog(Actions.UpdateStartTimeForCreate, updateStartTime));
-            AddDialog(new WaterfallDialog(Actions.UpdateDurationForCreate, updateDuration));
+            AddDialog(new WaterfallDialog(Actions.CreateEvent, createEvent) { TelemetryClient = telemetryClient});
+            AddDialog(new WaterfallDialog(Actions.UpdateAddress, updateAddress) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.ConfirmAttendee, confirmAttendee) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateName, updateName) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateStartDateForCreate, updateStartDate) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateStartTimeForCreate, updateStartTime) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateDurationForCreate, updateDuration) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.CreateEvent;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -21,9 +21,12 @@ namespace CalendarSkill
         public DeleteEventDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(DeleteEventDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(DeleteEventDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var deleteEvent = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -39,8 +42,8 @@ namespace CalendarSkill
                 AfterUpdateStartTime,
             };
 
-            AddDialog(new WaterfallDialog(Actions.DeleteEvent, deleteEvent));
-            AddDialog(new WaterfallDialog(Actions.UpdateStartTime, updateStartTime));
+            AddDialog(new WaterfallDialog(Actions.DeleteEvent, deleteEvent) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateStartTime, updateStartTime) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.DeleteEvent;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/JoinEvent/ConnectToMeetingDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/JoinEvent/ConnectToMeetingDialog.cs
@@ -20,9 +20,12 @@ namespace CalendarSkill
         public ConnectToMeetingDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(ConnectToMeetingDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ConnectToMeetingDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var joinMeeting = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -30,7 +33,7 @@ namespace CalendarSkill
                 JoinMeeting
             };
 
-            AddDialog(new WaterfallDialog(Actions.ConnectToMeeting, joinMeeting));
+            AddDialog(new WaterfallDialog(Actions.ConnectToMeeting, joinMeeting) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.ConnectToMeeting;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -33,14 +33,16 @@ namespace CalendarSkill
             ISkillConfiguration services,
             ConversationState conversationState,
             UserState userState,
+            IBotTelemetryClient telemetryClient,
             IServiceManager serviceManager,
             bool skillMode)
-            : base(nameof(MainDialog))
+            : base(nameof(MainDialog), telemetryClient)
         {
             _skillMode = skillMode;
             _services = services;
             _userState = userState;
             _conversationState = conversationState;
+            TelemetryClient = telemetryClient;
             _serviceManager = serviceManager;
 
             // Initialize state accessor

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Main/MainDialog.cs
@@ -322,13 +322,13 @@ namespace CalendarSkill
 
         private void RegisterDialogs()
         {
-            AddDialog(new CreateEventDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new DeleteEventDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new NextMeetingDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new TimeRemainingDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new SummaryDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new UpdateEventDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new ConnectToMeetingDialog(_services, _stateAccessor, _serviceManager));
+            AddDialog(new CreateEventDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new DeleteEventDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new NextMeetingDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new TimeRemainingDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new SummaryDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new UpdateEventDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new ConnectToMeetingDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
         }
 
         private class Events

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/NextMeeting/NextMeetingDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/NextMeeting/NextMeetingDialog.cs
@@ -19,9 +19,12 @@ namespace CalendarSkill
         public NextMeetingDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(NextMeetingDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(NextMeetingDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var nextMeeting = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -30,7 +33,7 @@ namespace CalendarSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.ShowEventsSummary, nextMeeting));
+            AddDialog(new WaterfallDialog(Actions.ShowEventsSummary, nextMeeting) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.ShowEventsSummary;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -8,6 +8,7 @@ using CalendarSkill.Dialogs.Main.Resources;
 using CalendarSkill.Dialogs.Shared.Resources;
 using Luis;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
@@ -19,7 +20,6 @@ using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.DateTime;
 using Newtonsoft.Json.Linq;
 using static Microsoft.Recognizers.Text.Culture;
-using Microsoft.Bot.Builder.AI.Luis;
 
 namespace CalendarSkill
 {
@@ -32,12 +32,14 @@ namespace CalendarSkill
             string dialogId,
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
             : base(dialogId)
         {
             Services = services;
             Accessor = accessor;
             ServiceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             if (!Services.AuthenticationConnections.Any())
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -24,9 +24,12 @@ namespace CalendarSkill
         public SummaryDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(SummaryDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(SummaryDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var showSummary = new WaterfallStep[]
             {
                 IfClearContextStep,
@@ -44,8 +47,8 @@ namespace CalendarSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.ShowEventsSummary, showSummary));
-            AddDialog(new WaterfallDialog(Actions.Read, readEvent));
+            AddDialog(new WaterfallDialog(Actions.ShowEventsSummary, showSummary) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Read, readEvent) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.ShowEventsSummary;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/TimeRemain/TimeRemainingDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/TimeRemain/TimeRemainingDialog.cs
@@ -19,9 +19,12 @@ namespace CalendarSkill
         public TimeRemainingDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(TimeRemainingDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(TimeRemainingDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var timeRemain = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -30,7 +33,7 @@ namespace CalendarSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.ShowTimeRemaining, timeRemain));
+            AddDialog(new WaterfallDialog(Actions.ShowTimeRemaining, timeRemain) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.ShowTimeRemaining;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
@@ -22,18 +22,20 @@ namespace CalendarSkill
         public UpdateEventDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<CalendarSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(UpdateEventDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(UpdateEventDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
             var updateEvent = new WaterfallStep[]
-           {
+            {
                 GetAuthToken,
                 AfterGetAuthToken,
                 FromTokenToStartTime,
                 FromEventsToNewDate,
                 ConfirmBeforeUpdate,
                 UpdateEventTime,
-           };
+            };
 
             var updateStartTime = new WaterfallStep[]
             {
@@ -48,9 +50,9 @@ namespace CalendarSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.UpdateEventTime, updateEvent));
-            AddDialog(new WaterfallDialog(Actions.UpdateStartTime, updateStartTime));
-            AddDialog(new WaterfallDialog(Actions.UpdateNewStartTime, updateNewStartTime));
+            AddDialog(new WaterfallDialog(Actions.UpdateEventTime, updateEvent) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateStartTime, updateStartTime) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateNewStartTime, updateNewStartTime) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Actions.UpdateEventTime;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Program.cs
@@ -15,8 +15,7 @@ namespace CalendarSkill
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
-                .UseStartup<Startup>()
+                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
                 .Build();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Startup.cs
@@ -100,7 +100,9 @@ namespace CalendarSkill
                 // Telemetry Middleware (logs activity messages in Application Insights)
                 var appInsightsService = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.AppInsights) ?? throw new Exception("Please configure your AppInsights connection in your .bot file.");
                 var instrumentationKey = (appInsightsService as AppInsightsService).InstrumentationKey;
-                var appInsightsLogger = new TelemetryLoggerMiddleware(instrumentationKey, logUserName: true, logOriginalMessage: true);
+                var sp = services.BuildServiceProvider();
+                var telemetryClient = sp.GetService<IBotTelemetryClient>();
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logUserName: true, logOriginalMessage: true);
                 options.Middleware.Add(appInsightsLogger);
 
                 // Catches any errors that occur during a conversation turn and logs them to AppInsights.
@@ -109,7 +111,7 @@ namespace CalendarSkill
                     CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
                     await context.SendActivityAsync(context.Activity.CreateReply(CalendarSharedResponses.CalendarErrorMessage));
                     await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Calendar Skill Error: {exception.Message} | {exception.StackTrace}"));
-                    connectedServices.TelemetryClient.TrackException(exception);
+                    telemetryClient.TrackException(exception);
                 };
 
                 // Transcript Middleware (saves conversation history in a standard format)
@@ -135,7 +137,8 @@ namespace CalendarSkill
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             _isProduction = env.IsProduction();
-            app.UseDefaultFiles()
+            app.UseBotApplicationInsights()
+                .UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Startup.cs
@@ -6,10 +6,14 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using CalendarSkill.Dialogs.Shared.Resources;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
@@ -46,6 +50,9 @@ namespace CalendarSkill
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
             var botConfig = BotConfiguration.Load(botFilePath ?? @".\CalendarSkill.bot", botFileSecret);
             services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded."));
+
+            // Use Application Insights
+            services.AddBotApplicationInsights(botConfig);
 
             // Initializes your bot service clients and adds a singleton that your Bot can access through dependency injection.
             var parameters = Configuration.GetSection("parameters")?.Get<string[]>();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/ConfirmRecipientDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ConfirmRecipient/ConfirmRecipientDialog.cs
@@ -25,9 +25,12 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(ConfirmRecipientDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ConfirmRecipientDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var confirmRecipient = new WaterfallStep[]
             {
                 ConfirmRecipient,
@@ -41,8 +44,8 @@ namespace EmailSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.ConfirmRecipient, confirmRecipient));
-            AddDialog(new WaterfallDialog(Actions.UpdateRecipientName, updateRecipientName));
+            AddDialog(new WaterfallDialog(Actions.ConfirmRecipient, confirmRecipient) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateRecipientName, updateRecipientName) { TelemetryClient = telemetryClient });
             InitialDialogId = Actions.ConfirmRecipient;
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
@@ -18,9 +18,12 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(DeleteEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(DeleteEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var deleteEmail = new WaterfallStep[]
             {
                 IfClearContextStep,
@@ -44,9 +47,9 @@ namespace EmailSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.Delete, deleteEmail));
-            AddDialog(new WaterfallDialog(Actions.Show, showEmail));
-            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage));
+            AddDialog(new WaterfallDialog(Actions.Delete, deleteEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Show, showEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage) { TelemetryClient = telemetryClient });
             InitialDialogId = Actions.Delete;
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/ForwardEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ForwardEmail/ForwardEmailDialog.cs
@@ -21,9 +21,12 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(ForwardEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ForwardEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var forwardEmail = new WaterfallStep[]
             {
                 IfClearContextStep,
@@ -51,10 +54,10 @@ namespace EmailSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.Forward, forwardEmail));
-            AddDialog(new WaterfallDialog(Actions.Show, showEmail));
-            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage));
-            AddDialog(new ConfirmRecipientDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager));
+            AddDialog(new WaterfallDialog(Actions.Forward, forwardEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Show, showEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage) { TelemetryClient = telemetryClient });
+            AddDialog(new ConfirmRecipientDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient));
 
             InitialDialogId = Actions.Forward;
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -31,13 +31,14 @@ namespace EmailSkill
         private IStatePropertyAccessor<DialogState> _dialogStateAccessor;
         private EmailSkillResponseBuilder _responseBuilder = new EmailSkillResponseBuilder();
 
-        public MainDialog(ISkillConfiguration skillConfiguration, ConversationState conversationState, UserState userState, IServiceManager serviceManager, bool skillMode)
-            : base(nameof(MainDialog))
+        public MainDialog(ISkillConfiguration skillConfiguration, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, IServiceManager serviceManager, bool skillMode)
+            : base(nameof(MainDialog), telemetryClient)
         {
             _skillMode = skillMode;
             _skillConfig = skillConfiguration;
             _conversationState = conversationState;
             _userState = userState;
+            TelemetryClient = telemetryClient;
             _serviceManager = serviceManager;
 
             // Initialize state accessor

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -307,11 +307,11 @@ namespace EmailSkill
 
         private void RegisterDialogs()
         {
-            AddDialog(new ForwardEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager));
-            AddDialog(new SendEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager));
-            AddDialog(new ShowEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager));
-            AddDialog(new ReplyEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager));
-            AddDialog(new DeleteEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager));
+            AddDialog(new ForwardEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new SendEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new ShowEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new ReplyEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new DeleteEmailDialog(_skillConfig, _stateAccessor, _dialogStateAccessor, _serviceManager, TelemetryClient));
         }
 
         private void GetReadingDisplayConfig()

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/ReplyEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ReplyEmail/ReplyEmailDialog.cs
@@ -19,9 +19,12 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(ReplyEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ReplyEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var replyEmail = new WaterfallStep[]
             {
                 IfClearContextStep,
@@ -48,8 +51,8 @@ namespace EmailSkill
             AddDialog(new WaterfallDialog(Actions.Reply, replyEmail));
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.Show, showEmail));
-            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage));
+            AddDialog(new WaterfallDialog(Actions.Show, showEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.UpdateSelectMessage, updateSelectMessage) { TelemetryClient = telemetryClient });
 
             InitialDialogId = Actions.Reply;
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/SendEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/SendEmail/SendEmailDialog.cs
@@ -20,11 +20,14 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(SendEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(SendEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var sendEmail = new WaterfallStep[]
-           {
+            {
                 IfClearContextStep,
                 GetAuthToken,
                 AfterGetAuthToken,
@@ -34,11 +37,11 @@ namespace EmailSkill
                 CollectText,
                 ConfirmBeforeSending,
                 SendEmail,
-           };
+            };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.Send, sendEmail));
-            AddDialog(new ConfirmRecipientDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager));
+            AddDialog(new WaterfallDialog(Actions.Send, sendEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new ConfirmRecipientDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient));
             InitialDialogId = Actions.Send;
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
@@ -37,13 +37,15 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
             : base(dialogId)
         {
             Services = services;
             EmailStateAccessor = emailStateAccessor;
             DialogStateAccessor = dialogStateAccessor;
             ServiceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             if (!Services.AuthenticationConnections.Any())
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/ShowEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/ShowEmail/ShowEmailDialog.cs
@@ -24,9 +24,12 @@ namespace EmailSkill
             ISkillConfiguration services,
             IStatePropertyAccessor<EmailSkillState> emailStateAccessor,
             IStatePropertyAccessor<DialogState> dialogStateAccessor,
-            IServiceManager serviceManager)
-            : base(nameof(ShowEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ShowEmailDialog), services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var showEmail = new WaterfallStep[]
             {
                 IfClearContextStep,
@@ -69,15 +72,15 @@ namespace EmailSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Actions.Show, showEmail));
-            AddDialog(new WaterfallDialog(Actions.Read, readEmail));
-            AddDialog(new WaterfallDialog(Actions.Delete, deleteEmail));
-            AddDialog(new WaterfallDialog(Actions.Forward, forwardEmail));
-            AddDialog(new WaterfallDialog(Actions.Reply, replyEmail));
-            AddDialog(new WaterfallDialog(Actions.Reshow, reshowEmail));
-            AddDialog(new DeleteEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager));
-            AddDialog(new ReplyEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager));
-            AddDialog(new ForwardEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager));
+            AddDialog(new WaterfallDialog(Actions.Show, showEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Read, readEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Delete, deleteEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Forward, forwardEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Reply, replyEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Actions.Reshow, reshowEmail) { TelemetryClient = telemetryClient });
+            AddDialog(new DeleteEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient));
+            AddDialog(new ReplyEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient));
+            AddDialog(new ForwardEmailDialog(services, emailStateAccessor, dialogStateAccessor, serviceManager, telemetryClient));
             InitialDialogId = Actions.Show;
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.cs
@@ -20,20 +20,22 @@ namespace EmailSkill
         private readonly ISkillConfiguration _services;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
+        private readonly IBotTelemetryClient _telemetryClient;
         private IServiceManager _serviceManager;
         private DialogSet _dialogs;
         private bool _skillMode;
 
-        public EmailSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, IServiceManager serviceManager = null, bool skillMode = false)
+        public EmailSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, IServiceManager serviceManager = null, bool skillMode = false)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _serviceManager = serviceManager ?? new ServiceManager(services);
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(DialogState)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _serviceManager, _skillMode));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _serviceManager, _skillMode));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Google.Apis" Version="1.36.1" />
     <PackageReference Include="Google.Apis.Gmail.v1" Version="1.36.1.1342" />
     <PackageReference Include="Google.Apis.People.v1" Version="1.25.0.830" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/EmailSkill.csproj
@@ -26,16 +26,16 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="MimeKit" Version="2.0.7" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Program.cs
@@ -15,8 +15,7 @@ namespace EmailSkill
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
-                .UseStartup<Startup>()
+                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
                 .Build();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Cancel/CancelDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Cancel/CancelDialog.cs
@@ -17,12 +17,13 @@ namespace PointOfInterestSkill
         private IStatePropertyAccessor<PointOfInterestSkillState> _accessor;
         private CancelResponses _responder = new CancelResponses();
 
-        public CancelDialog(IStatePropertyAccessor<PointOfInterestSkillState> accessor)
+        public CancelDialog(IStatePropertyAccessor<PointOfInterestSkillState> accessor, IBotTelemetryClient telemetryClient)
             : base(nameof(CancelDialog))
         {
             _accessor = accessor;
 
             InitialDialogId = nameof(CancelDialog);
+            TelemetryClient = telemetryClient;
 
             var cancel = new WaterfallStep[]
             {
@@ -30,7 +31,7 @@ namespace PointOfInterestSkill
                 FinishCancelDialog,
             };
 
-            AddDialog(new WaterfallDialog(InitialDialogId, cancel));
+            AddDialog(new WaterfallDialog(InitialDialogId, cancel) { TelemetryClient = telemetryClient });
             AddDialog(new ConfirmPrompt(CancelPrompt));
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/CancelRouteDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/CancelRoute/CancelRouteDialog.cs
@@ -13,16 +13,19 @@ namespace PointOfInterestSkill
         public CancelRouteDialog(
             SkillConfiguration services,
             IStatePropertyAccessor<PointOfInterestSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(CancelRouteDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(CancelRouteDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var cancelRoute = new WaterfallStep[]
             {
                 CancelActiveRoute,
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.CancelActiveRoute, cancelRoute));
+            AddDialog(new WaterfallDialog(Action.CancelActiveRoute, cancelRoute) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Action.CancelActiveRoute;

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/FindPointOfInterest/FindPointOfInterestDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/FindPointOfInterest/FindPointOfInterestDialog.cs
@@ -13,18 +13,21 @@ namespace PointOfInterestSkill
         public FindPointOfInterestDialog(
             SkillConfiguration services,
             IStatePropertyAccessor<PointOfInterestSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(FindPointOfInterestDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(FindPointOfInterestDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var findPointOfInterest = new WaterfallStep[]
-          {
+            {
                 GetPointOfInterestLocations,
                 ResponseToGetRoutePrompt,
-          };
+            };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.FindPointOfInterest, findPointOfInterest));
-            AddDialog(new RouteDialog(services, Accessor, ServiceManager));
+            AddDialog(new WaterfallDialog(Action.FindPointOfInterest, findPointOfInterest) { TelemetryClient = telemetryClient });
+            AddDialog(new RouteDialog(services, Accessor, ServiceManager, TelemetryClient));
 
             // Set starting dialog for component
             InitialDialogId = Action.FindPointOfInterest;

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -35,15 +35,17 @@ namespace PointOfInterestSkill
             SkillConfiguration services,
             ConversationState conversationState,
             UserState userState,
+            IBotTelemetryClient telemetryClient,
             IServiceManager serviceManager,
             bool skillMode)
-            : base(nameof(MainDialog))
+            : base(nameof(MainDialog), telemetryClient)
         {
             _skillMode = skillMode;
             _services = services;
             _userState = userState;
             _conversationState = conversationState;
             _serviceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             // Initialize state accessor
             _stateAccessor = _conversationState.CreateProperty<PointOfInterestSkillState>(nameof(PointOfInterestSkillState));
@@ -78,7 +80,7 @@ namespace PointOfInterestSkill
             }
             else
             {
-                var result = await luisService.RecognizeAsync<PointOfInterest>(dc.Context, CancellationToken.None);
+                var result = await luisService.RecognizeAsync<PointOfInterest>(dc, true, CancellationToken.None);
 
                 var intent = result?.TopIntent().intent;
 
@@ -355,10 +357,10 @@ namespace PointOfInterestSkill
 
         private void RegisterDialogs()
         {
-            AddDialog(new RouteDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new CancelRouteDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new FindPointOfInterestDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new CancelDialog(_stateAccessor));
+            AddDialog(new RouteDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new CancelRouteDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new FindPointOfInterestDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new CancelDialog(_stateAccessor, TelemetryClient));
         }
 
         public class Events

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Route/RouteDialog.cs
@@ -18,15 +18,19 @@ namespace PointOfInterestSkill
         public RouteDialog(
             SkillConfiguration services,
             IStatePropertyAccessor<PointOfInterestSkillState> accessor,
-            IServiceManager serviceManager)
-            : base(nameof(RouteDialog), services, accessor, serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(RouteDialog), services, accessor, serviceManager, telemetryClient)
         {
+
+            TelemetryClient = telemetryClient;
+
             var checkForActiveRouteAndLocation = new WaterfallStep[]
-          {
+            {
                 CheckIfActiveRouteExists,
                 CheckIfFoundLocationExists,
                 CheckIfActiveLocationExists,
-          };
+            };
 
             var findRouteToActiveLocation = new WaterfallStep[]
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Dialogs/Shared/PointOfInterestSkillDialog.cs
@@ -26,12 +26,14 @@ namespace PointOfInterestSkill
             string dialogId,
             SkillConfiguration services,
             IStatePropertyAccessor<PointOfInterestSkillState> accessor,
-            IServiceManager serviceManager)
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient)
             : base(dialogId)
         {
             Services = services;
             Accessor = accessor;
             ServiceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             AddDialog(new TextPrompt(Action.Prompt, CustomPromptValidatorAsync));
             AddDialog(new ConfirmPrompt(Action.ConfirmPrompt) { Style = ListStyle.Auto, });

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.cs
@@ -21,19 +21,21 @@ namespace PointOfInterestSkill
         private readonly UserState _userState;
         private readonly ConversationState _conversationState;
         private readonly IServiceManager _serviceManager;
+        private readonly IBotTelemetryClient _telemetryClient;
         private DialogSet _dialogs;
         private bool _skillMode;
 
-        public PointOfInterestSkill(SkillConfiguration services, ConversationState conversationState, UserState userState, IServiceManager serviceManager = null, bool skillMode = false)
+        public PointOfInterestSkill(SkillConfiguration services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, IServiceManager serviceManager = null, bool skillMode = false)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _serviceManager = serviceManager ?? new ServiceManager();
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(DialogState)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _serviceManager, _skillMode));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _serviceManager, _skillMode));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
 
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/PointOfInterestSkill.csproj
@@ -24,16 +24,16 @@
 
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Program.cs
@@ -15,8 +15,7 @@ namespace PointOfInterestSkill
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
-                .UseStartup<Startup>()
+                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
                 .Build();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
@@ -47,6 +48,9 @@ namespace PointOfInterestSkill
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
             var botConfig = BotConfiguration.Load(botFilePath ?? @".\PointOfInterestSkill.bot", botFileSecret);
             services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded."));
+
+            // Use Application Insights
+            services.AddBotApplicationInsights(botConfig);
 
             // Initializes your bot service clients and adds a singleton that your Bot can access through dependency injection.
             var parameters = Configuration.GetSection("parameters")?.Get<string[]>();
@@ -92,7 +96,9 @@ namespace PointOfInterestSkill
                 // Telemetry Middleware (logs activity messages in Application Insights)
                 var appInsightsService = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.AppInsights) ?? throw new Exception("Please configure your AppInsights connection in your .bot file.");
                 var instrumentationKey = (appInsightsService as AppInsightsService).InstrumentationKey;
-                var appInsightsLogger = new TelemetryLoggerMiddleware(instrumentationKey, logUserName: true, logOriginalMessage: true);
+                var sp = services.BuildServiceProvider();
+                var telemetryClient = sp.GetService<IBotTelemetryClient>();
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logUserName: true, logOriginalMessage: true);
                 options.Middleware.Add(appInsightsLogger);
 
                 // Catches any errors that occur during a conversation turn and logs them to AppInsights.
@@ -101,7 +107,7 @@ namespace PointOfInterestSkill
                     CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
                     await context.SendActivityAsync(context.Activity.CreateReply(POISharedResponses.PointOfInterestErrorMessage));
                     await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"PointOfInterestSkill Error: {exception.Message} | {exception.StackTrace}"));
-                    connectedServices.TelemetryClient.TrackException(exception);
+                    telemetryClient.TrackException(exception);
                 };
 
                 // Transcript Middleware (saves conversation history in a standard format)
@@ -128,7 +134,8 @@ namespace PointOfInterestSkill
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             _isProduction = env.IsProduction();
-            app.UseDefaultFiles()
+            app.UseBotApplicationInsights()
+                .UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/CalendarSkillTest.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/CalendarSkillTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CalendarBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CalendarBotTestBase.cs
@@ -24,6 +24,8 @@ namespace CalendarSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public IBotTelemetryClient TelemetryClient { get; set; }
+
         public IServiceManager ServiceManager { get; set; }
 
         public SkillConfiguration Services { get; set; }
@@ -37,6 +39,7 @@ namespace CalendarSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.TelemetryClient = new NullBotTelemetryClient();
             this.CalendarStateAccessor = this.ConversationState.CreateProperty<CalendarSkillState>(nameof(CalendarSkillState));
             this.Services = new MockSkillConfiguration();
 
@@ -77,7 +80,7 @@ namespace CalendarSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new CalendarSkill.CalendarSkill(this.Services, this.ConversationState, this.UserState,  this.ServiceManager, true);
+            return new CalendarSkill.CalendarSkill(this.Services, this.ConversationState, this.UserState, this.TelemetryClient, this.ServiceManager, true);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CreateCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/CreateCalendarFlowTests.cs
@@ -5,15 +5,16 @@ using System.Threading.Tasks;
 using CalendarSkill.Dialogs.CreateEvent.Resources;
 using CalendarSkill.Dialogs.Main.Resources;
 using CalendarSkill.Dialogs.Shared.Resources;
-using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using CalendarSkillTest.Flow.Utterances;
 using CalendarSkillTest.Flow.Fakes;
-using Newtonsoft.Json;
-using Microsoft.Bot.Solutions.Resources;
 using CalendarSkillTest.Flow.Models;
-using Microsoft.Bot.Solutions.Skills;
+using CalendarSkillTest.Flow.Utterances;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
+using Microsoft.Bot.Solutions.Resources;
+using Microsoft.Bot.Solutions.Skills;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace CalendarSkillTest.Flow
 {
@@ -26,7 +27,7 @@ namespace CalendarSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "calendar", new MockLuisRecognizer(new CreateMeetingTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CalendarSkillTest.Flow.Utterances;
 using CalendarSkillTest.Flow.Fakes;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Builder;
 
@@ -22,7 +23,7 @@ namespace CalendarSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "calendar", new MockLuisRecognizer(new DeleteMeetingTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/Fakes/MockLuisRecognizer.cs
@@ -1,17 +1,23 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using CalendarSkillTest.Flow.Utterances;
 using Luis;
 using Microsoft.Bot.Builder;
-using CalendarSkillTest.Flow.Utterances;
-using System.Collections.Generic;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Solutions;
 
 namespace CalendarSkillTest.Flow.Fakes
 {
-    public class MockLuisRecognizer : IRecognizer
+    public class MockLuisRecognizer : ITelemetryLuisRecognizer
     {
         private BaseTestUtterances utterancesManager;
         private GeneralTestUtterances generalUtterancesManager;
+
+        public bool LogOriginalMessage => throw new NotImplementedException();
+
+        public bool LogUsername => throw new NotImplementedException();
 
         public MockLuisRecognizer(BaseTestUtterances utterancesManager)
         {
@@ -51,6 +57,18 @@ namespace CalendarSkillTest.Flow.Fakes
             }
 
             return await Task.FromResult(mockResult);
+        }
+
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/NextCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/NextCalendarFlowTests.cs
@@ -5,12 +5,13 @@ using System.Threading.Tasks;
 using CalendarSkill.Dialogs.Main.Resources;
 using CalendarSkill.Dialogs.NextMeeting.Resources;
 using CalendarSkill.Dialogs.Shared.Resources;
-using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using CalendarSkillTest.Flow.Utterances;
 using CalendarSkillTest.Flow.Fakes;
-using Microsoft.Bot.Solutions.Skills;
+using CalendarSkillTest.Flow.Utterances;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
+using Microsoft.Bot.Solutions.Skills;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CalendarSkillTest.Flow
 {
@@ -23,7 +24,7 @@ namespace CalendarSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using CalendarSkill;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Solutions;
 
 namespace CalendarSkillTest.Flow
 {
@@ -28,7 +29,7 @@ namespace CalendarSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CalendarSkillTest.Flow.Utterances;
 using CalendarSkillTest.Flow.Fakes;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder;
@@ -23,7 +24,7 @@ namespace CalendarSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "calendar", new MockLuisRecognizer(new UpdateMeetingTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/EmailBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/EmailBotTestBase.cs
@@ -22,6 +22,8 @@ namespace EmailSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public IBotTelemetryClient TelemetryClient { get; set; }
+
         public IServiceManager ServiceManager { get; set; }
 
         public ISkillConfiguration Services { get; set; }
@@ -33,6 +35,7 @@ namespace EmailSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.TelemetryClient = new NullBotTelemetryClient();
             this.EmailStateAccessor = this.ConversationState.CreateProperty<EmailSkillState>(nameof(EmailSkillState));
             this.Services = new MockSkillConfiguration();
 
@@ -75,7 +78,7 @@ namespace EmailSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new EmailSkill.EmailSkill(this.Services, this.ConversationState, this.UserState,  this.ServiceManager, true);
+            return new EmailSkill.EmailSkill(this.Services, this.ConversationState, this.UserState,  this.TelemetryClient, this.ServiceManager, true);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockEmailLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockEmailLuisRecognizer.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 using EmailSkillTest.Flow.Utterances;
 using Luis;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Solutions;
 
 namespace EmailSkillTest.Flow.Fakes
 {
-    public class MockEmailLuisRecognizer : IRecognizer
+    public class MockEmailLuisRecognizer : ITelemetryLuisRecognizer
     {
         private BaseTestUtterances emailUtterancesManager;
 
@@ -21,6 +23,10 @@ namespace EmailSkillTest.Flow.Fakes
         {
             this.emailUtterancesManager = utterancesManager;
         }
+
+        public bool LogOriginalMessage => throw new NotImplementedException();
+
+        public bool LogUsername => throw new NotImplementedException();
 
         public Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
@@ -37,6 +43,18 @@ namespace EmailSkillTest.Flow.Fakes
             var mockResult = (T)test;
 
             return Task.FromResult(mockResult);
+        }
+
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockGeneralLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockGeneralLuisRecognizer.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 using EmailSkillTest.Flow.Utterances;
 using Luis;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Solutions;
 
 namespace EmailSkillTest.Flow.Fakes
 {
-    public class MockGeneralLuisRecognizer : IRecognizer
+    public class MockGeneralLuisRecognizer : ITelemetryLuisRecognizer
     {
         private GeneralTestUtterances generalUtterancesManager;
 
@@ -16,6 +18,10 @@ namespace EmailSkillTest.Flow.Fakes
         {
             this.generalUtterancesManager = new GeneralTestUtterances();
         }
+
+        public bool LogOriginalMessage => throw new NotImplementedException();
+
+        public bool LogUsername => throw new NotImplementedException();
 
         public Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
@@ -33,6 +39,18 @@ namespace EmailSkillTest.Flow.Fakes
             var mockResult = (T)test;
 
             return Task.FromResult(mockResult);
+        }
+
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockSkillConfiguration.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/Fakes/MockSkillConfiguration.cs
@@ -2,6 +2,7 @@
 using Microsoft.ApplicationInsights;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 
 namespace EmailSkillTest.Flow.Fakes
@@ -13,7 +14,7 @@ namespace EmailSkillTest.Flow.Fakes
             this.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>
                 {
                     { "general", new MockGeneralLuisRecognizer() },
                     { "email", new MockEmailLuisRecognizer() }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/testframework/TestFramework.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/testframework/TestFramework.csproj
@@ -21,10 +21,10 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/AddToDoFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/AddToDoFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.Shared.Resources;
@@ -26,7 +27,7 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new AddToDoFlowTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/DeleteAllToDosFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/DeleteAllToDosFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.DeleteToDo.Resources;
@@ -28,7 +29,7 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new DeleteToDoFlowTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/DeleteToDoFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/DeleteToDoFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.DeleteToDo.Resources;
@@ -28,12 +29,17 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = NewMethod()
+            });
+        }
+
+        private static Dictionary<string, ITelemetryLuisRecognizer> NewMethod()
+        {
+            return new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new DeleteToDoFlowTestUtterances()) }
-                }
-            });
+                };
         }
 
         [TestMethod]

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/Fakes/MockLuisRecognizer.cs
@@ -4,14 +4,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using Luis;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Solutions;
 using ToDoSkillTest.Flow.Utterances;
 
 namespace ToDoSkillTest.Flow.Fakes
 {
-    public class MockLuisRecognizer : IRecognizer
+    public class MockLuisRecognizer : ITelemetryLuisRecognizer
     {
         private BaseTestUtterances utterancesManager;
         private GeneralTestUtterances generalUtterancesManager;
+
+        public bool LogOriginalMessage => throw new NotImplementedException();
+
+        public bool LogUsername => throw new NotImplementedException();
 
         public MockLuisRecognizer(BaseTestUtterances utterancesManager)
         {
@@ -51,6 +57,18 @@ namespace ToDoSkillTest.Flow.Fakes
             }
 
             return Task.FromResult(mockResult);
+        }
+
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken)) 
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/MarkAllToDosFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/MarkAllToDosFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.Shared.Resources;
@@ -27,7 +28,7 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new MarkToDoFlowTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/MarkToDoFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/MarkToDoFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.Shared.Resources;
@@ -27,7 +28,7 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new MarkToDoFlowTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/ShowToDoFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/ShowToDoFlowTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Dialogs.Shared.Resources;
@@ -27,7 +28,7 @@ namespace ToDoSkillTest.Flow
             this.Services.LocaleConfigurations.Add("en", new LocaleConfiguration()
             {
                 Locale = "en-us",
-                LuisServices = new Dictionary<string, IRecognizer>()
+                LuisServices = new Dictionary<string, ITelemetryLuisRecognizer>()
                 {
                     { "general", new MockLuisRecognizer() },
                     { "todo", new MockLuisRecognizer(new ShowToDoFlowTestUtterances()) }

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/ToDoBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/todoskilltest/Flow/ToDoBotTestBase.cs
@@ -23,6 +23,8 @@ namespace ToDoSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public IBotTelemetryClient TelemetryClient { get; set; }
+
         public IStatePropertyAccessor<ToDoSkillState> ToDoStateAccessor { get; set; }
 
         public ITaskService ToDoService { get; set; }
@@ -38,6 +40,7 @@ namespace ToDoSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.TelemetryClient = new NullBotTelemetryClient();
             this.ToDoStateAccessor = this.ConversationState.CreateProperty<ToDoSkillState>(nameof(ToDoSkillState));
             this.Services = new MockSkillConfiguration();
 
@@ -76,7 +79,7 @@ namespace ToDoSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new ToDoSkill.ToDoSkill(this.Services, this.ConversationState, this.UserState, this.ToDoService, true);
+            return new ToDoSkill.ToDoSkill(this.Services, this.ConversationState, this.UserState, this.TelemetryClient, this.ToDoService, true);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/AddToDo/AddToDoItemDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/AddToDo/AddToDoItemDialog.cs
@@ -9,17 +9,20 @@ namespace ToDoSkill
         public AddToDoItemDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<ToDoSkillState> accessor,
-            ITaskService serviceManager)
-            : base(nameof(AddToDoItemDialog), services, accessor, serviceManager)
+            ITaskService serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(AddToDoItemDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var addToDoTask = new WaterfallStep[]
-           {
+            {
                 GetAuthToken,
                 AfterGetAuthToken,
                 ClearContext,
                 CollectToDoTaskContent,
                 AddToDoTask,
-           };
+            };
 
             var collectToDoTaskContent = new WaterfallStep[]
             {
@@ -28,8 +31,8 @@ namespace ToDoSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.AddToDoTask, addToDoTask));
-            AddDialog(new WaterfallDialog(Action.CollectToDoTaskContent, collectToDoTaskContent));
+            AddDialog(new WaterfallDialog(Action.AddToDoTask, addToDoTask) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.CollectToDoTaskContent, collectToDoTaskContent) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Action.AddToDoTask;

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/DeleteToDo/DeleteToDoItemDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/DeleteToDo/DeleteToDoItemDialog.cs
@@ -18,11 +18,14 @@ namespace ToDoSkill
         public DeleteToDoItemDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<ToDoSkillState> accessor,
-            ITaskService serviceManager)
-            : base(nameof(DeleteToDoItemDialog), services, accessor, serviceManager)
+            ITaskService serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(DeleteToDoItemDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var deleteToDoTask = new WaterfallStep[]
-           {
+            {
                 GetAuthToken,
                 AfterGetAuthToken,
                 ClearContext,
@@ -30,7 +33,7 @@ namespace ToDoSkill
                 CollectToDoTaskIndex,
                 CollectAskDeletionConfirmation,
                 DeleteToDoTask,
-           };
+            };
 
             var collectToDoTaskIndex = new WaterfallStep[]
             {
@@ -45,9 +48,9 @@ namespace ToDoSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.DeleteToDoTask, deleteToDoTask));
-            AddDialog(new WaterfallDialog(Action.CollectToDoTaskIndex, collectToDoTaskIndex));
-            AddDialog(new WaterfallDialog(Action.CollectDeleteTaskConfirmation, collectDeleteTaskConfirmation));
+            AddDialog(new WaterfallDialog(Action.DeleteToDoTask, deleteToDoTask) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.CollectToDoTaskIndex, collectToDoTaskIndex) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.CollectDeleteTaskConfirmation, collectDeleteTaskConfirmation) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Action.DeleteToDoTask;

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -34,15 +34,17 @@ namespace ToDoSkill
             ISkillConfiguration services,
             ConversationState conversationState,
             UserState userState,
+            IBotTelemetryClient telemetryClient,
             ITaskService serviceManager,
             bool skillMode)
-            : base(nameof(MainDialog))
+            : base(nameof(MainDialog), telemetryClient)
         {
             _skillMode = skillMode;
             _services = services;
             _conversationState = conversationState;
             _userState = userState;
             _serviceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             // Initialize state accessor
             _stateAccessor = _conversationState.CreateProperty<ToDoSkillState>(nameof(ToDoSkillState));

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Main/MainDialog.cs
@@ -301,13 +301,13 @@ namespace ToDoSkill
 
             return InterruptionAction.StartedDialog;
         }
-
+        
         private void RegisterDialogs()
         {
-            AddDialog(new AddToDoItemDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new MarkToDoItemDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new DeleteToDoItemDialog(_services, _stateAccessor, _serviceManager));
-            AddDialog(new ShowToDoItemDialog(_services, _stateAccessor, _serviceManager));
+            AddDialog(new AddToDoItemDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new MarkToDoItemDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new DeleteToDoItemDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
+            AddDialog(new ShowToDoItemDialog(_services, _stateAccessor, _serviceManager, TelemetryClient));
         }
 
         private void InitializeConfig(ToDoSkillState state)

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/MarkToDo/MarkToDoItemDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/MarkToDo/MarkToDoItemDialog.cs
@@ -17,9 +17,12 @@ namespace ToDoSkill
         public MarkToDoItemDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<ToDoSkillState> accessor,
-            ITaskService serviceManager)
-            : base(nameof(MarkToDoItemDialog), services, accessor, serviceManager)
+            ITaskService serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(MarkToDoItemDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var markToDoTask = new WaterfallStep[]
             {
                 GetAuthToken,
@@ -37,8 +40,8 @@ namespace ToDoSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.MarkToDoTaskCompleted, markToDoTask));
-            AddDialog(new WaterfallDialog(Action.CollectToDoTaskIndex, collectToDoTaskIndex));
+            AddDialog(new WaterfallDialog(Action.MarkToDoTaskCompleted, markToDoTask) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.CollectToDoTaskIndex, collectToDoTaskIndex) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Action.MarkToDoTaskCompleted;

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/ToDoSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/Shared/ToDoSkillDialog.cs
@@ -31,12 +31,14 @@ namespace ToDoSkill
             string dialogId,
             ISkillConfiguration services,
             IStatePropertyAccessor<ToDoSkillState> accessor,
-            ITaskService serviceManager)
+            ITaskService serviceManager,
+            IBotTelemetryClient telemetryClient)
             : base(dialogId)
         {
             Services = services;
             Accessor = accessor;
             ServiceManager = serviceManager;
+            TelemetryClient = telemetryClient;
 
             if (!Services.AuthenticationConnections.Any())
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/ShowToDo/ShowToDoItemDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Dialogs/ShowToDo/ShowToDoItemDialog.cs
@@ -18,17 +18,20 @@ namespace ToDoSkill
         public ShowToDoItemDialog(
             ISkillConfiguration services,
             IStatePropertyAccessor<ToDoSkillState> accessor,
-            ITaskService serviceManager)
-            : base(nameof(ShowToDoItemDialog), services, accessor, serviceManager)
+            ITaskService serviceManager,
+            IBotTelemetryClient telemetryClient)
+            : base(nameof(ShowToDoItemDialog), services, accessor, serviceManager, telemetryClient)
         {
+            TelemetryClient = telemetryClient;
+
             var showToDoTasks = new WaterfallStep[]
-           {
+            {
                 GetAuthToken,
                 AfterGetAuthToken,
                 ClearContext,
                 ShowToDoTasks,
                 AddFirstTask,
-           };
+            };
 
             var addFirstTask = new WaterfallStep[]
             {
@@ -45,9 +48,9 @@ namespace ToDoSkill
             };
 
             // Define the conversation flow using a waterfall model.
-            AddDialog(new WaterfallDialog(Action.ShowToDoTasks, showToDoTasks));
-            AddDialog(new WaterfallDialog(Action.AddFirstTask, addFirstTask));
-            AddDialog(new WaterfallDialog(Action.CollectToDoTaskContent, collectToDoTaskContent));
+            AddDialog(new WaterfallDialog(Action.ShowToDoTasks, showToDoTasks) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.AddFirstTask, addFirstTask) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(Action.CollectToDoTaskContent, collectToDoTaskContent) { TelemetryClient = telemetryClient });
 
             // Set starting dialog for component
             InitialDialogId = Action.ShowToDoTasks;

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Program.cs
@@ -15,8 +15,7 @@ namespace ToDoSkill
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
-                .UseStartup<Startup>()
+                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
                 .Build();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
@@ -48,6 +49,9 @@ namespace ToDoSkill
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
             var botConfig = BotConfiguration.Load(botFilePath ?? @".\ToDoSkill.bot", botFileSecret);
             services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded."));
+
+            // Use Application Insights
+            services.AddBotApplicationInsights(botConfig);
 
             // Initializes your bot service clients and adds a singleton that your Bot can access through dependency injection.
             var parameters = Configuration.GetSection("parameters")?.Get<string[]>();
@@ -104,7 +108,9 @@ namespace ToDoSkill
                 // Telemetry Middleware (logs activity messages in Application Insights)
                 var appInsightsService = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.AppInsights) ?? throw new Exception("Please configure your AppInsights connection in your .bot file.");
                 var instrumentationKey = (appInsightsService as AppInsightsService).InstrumentationKey;
-                var appInsightsLogger = new TelemetryLoggerMiddleware(instrumentationKey, logUserName: true, logOriginalMessage: true);
+                var sp = services.BuildServiceProvider();
+                var telemetryClient = sp.GetService<IBotTelemetryClient>();
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logUserName: true, logOriginalMessage: true);
                 options.Middleware.Add(appInsightsLogger);
 
                 // Catches any errors that occur during a conversation turn and logs them to AppInsights.
@@ -113,7 +119,7 @@ namespace ToDoSkill
                     CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
                     await context.SendActivityAsync(context.Activity.CreateReply(ToDoSharedResponses.ToDoErrorMessage));
                     await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"To Do Skill Error: {exception.Message} | {exception.StackTrace}"));
-                    connectedServices.TelemetryClient.TrackException(exception);
+                    telemetryClient.TrackException(exception);
                 };
 
                 // Transcript Middleware (saves conversation history in a standard format)
@@ -139,7 +145,8 @@ namespace ToDoSkill
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             _isProduction = env.IsProduction();
-            app.UseDefaultFiles()
+            app.UseBotApplicationInsights()
+                .UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.cs
@@ -22,16 +22,18 @@ namespace ToDoSkill
         private readonly ISkillConfiguration _services;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
+        private readonly IBotTelemetryClient _telemetryClient;
         private ITaskService _serviceManager;
         private DialogSet _dialogs;
         private bool _skillMode;
 
-        public ToDoSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, ITaskService serviceManager = null, bool skillMode = false)
+        public ToDoSkill(ISkillConfiguration services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, ITaskService serviceManager = null, bool skillMode = false)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
             var isOutlookProvider = _services.Properties.ContainsKey("TaskServiceProvider")
                 && _services.Properties["TaskServiceProvider"].ToString().Equals(ProviderTypes.Outlook.ToString(), StringComparison.InvariantCultureIgnoreCase);
@@ -44,7 +46,7 @@ namespace ToDoSkill
             _serviceManager = serviceManager ?? taskService;
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(DialogState)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _serviceManager, _skillMode));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _serviceManager, _skillMode));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/ToDoSkill.csproj
@@ -27,16 +27,16 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This updates all `Bot.Builder` references in the Virtual Assistant solution to 4.2, taking advanced of build-in telemetry collection to Application Insights. The IBotTelemetryClient needs to be passed into a `WaterfallDialog`, and set on each parent dialog inheriting `ComponentDialog`. This requires passing the telemetry client up to:
- InterruptableDialog (Microsoft.Bot.Solutions)
    - RouterDialog (Microsoft.Bot.Solution)
        - MainDialog 
             - SkillDialog         
                - WaterfallDialog

Latest telemetry middleware allows for passing an IBotTelemetryClient and uses camelCasing for all custom dimensions sent to said client.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#135 

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
Run the VA with some queries that would trigger waterfall dialogs, like "find a pharmacy" or "book a meeting." Afterwards, view the `customEvents` in your app insights and look for `WaterfallStart/WaterfallStep/WaterfallCancel/WaterfallDone` instances. This comes from the SDK.


## Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the appropriate unit tests - coming
- [X] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [X] A duplicate issue is filed to track future  work.
