### PR TITLE
add luis app id into TelemetryLuisRecognizer

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/LuisTelemetryConstants.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/LuisTelemetryConstants.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Bot.Solutions
     /// </summary>
     public static class LuisTelemetryConstants
     {
+        public const string ApplicationId = "applicationId";
         public const string IntentPrefix = "luisIntent";  // Application Insights Custom Event name (with Intent)
         public const string IntentProperty = "intent";
         public const string IntentScoreProperty = "intentScore";

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ApplicationInsights;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.Dialogs;
@@ -24,6 +23,8 @@ namespace Microsoft.Bot.Solutions
     /// </summary>
     public class TelemetryLuisRecognizer : LuisRecognizer, ITelemetryLuisRecognizer
     {
+        private LuisApplication _luisApplication;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryLuisRecognizer"/> class.
         /// </summary>
@@ -35,6 +36,8 @@ namespace Microsoft.Bot.Solutions
         public TelemetryLuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logOriginalMessage = false, bool logUserName = false)
             : base(application, predictionOptions, includeApiResults)
         {
+            _luisApplication = application;
+
             LogOriginalMessage = logOriginalMessage;
             LogUsername = logUserName;
         }
@@ -122,6 +125,7 @@ namespace Microsoft.Bot.Solutions
                 // Add the intent score and conversation id properties
                 var telemetryProperties = new Dictionary<string, string>()
                 {
+                    { LuisTelemetryConstants.ApplicationId, _luisApplication.ApplicationId },
                     { LuisTelemetryConstants.IntentProperty, topLuisIntent.intent },
                     { LuisTelemetryConstants.IntentScoreProperty, intentScore },
                 };


### PR DESCRIPTION
## Description
Add LuisAppId into telemetryLuisRecognizer

## Related Issue
closes #452 

## Testing Steps
Open VA, send some message to the bot, check the AppInsights to see if the field applicationId is included in the AppInsights log

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation
