### PR TITLE
change self begin call to replace

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -461,7 +461,7 @@ namespace CalendarSkill
                         }
                         else
                         {
-                            return await sc.BeginDialogAsync(Actions.UpdateAddress, new UpdateAddressDialogOptions(UpdateAddressDialogOptions.UpdateReason.NotAnAddress), cancellationToken);
+                            return await sc.ReplaceDialogAsync(Actions.UpdateAddress, new UpdateAddressDialogOptions(UpdateAddressDialogOptions.UpdateReason.NotAnAddress), cancellationToken);
                         }
                     }
                 }
@@ -575,12 +575,12 @@ namespace CalendarSkill
                 if (sc.Result == null)
                 {
                     state.ShowAttendeesIndex = 0;
-                    return await sc.BeginDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
+                    return await sc.ReplaceDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
                 }
                 else if (sc.Result.ToString() == General.Intent.Next.ToString())
                 {
                     state.ShowAttendeesIndex++;
-                    return await sc.BeginDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
+                    return await sc.ReplaceDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
                 }
                 else if (sc.Result.ToString() == General.Intent.Previous.ToString())
                 {
@@ -589,7 +589,7 @@ namespace CalendarSkill
                         state.ShowAttendeesIndex--;
                     }
 
-                    return await sc.BeginDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
+                    return await sc.ReplaceDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
                 }
                 else
                 {
@@ -610,7 +610,7 @@ namespace CalendarSkill
                     state.ConfirmAttendeesNameIndex++;
                     if (state.ConfirmAttendeesNameIndex < state.AttendeesNameList.Count)
                     {
-                        return await sc.BeginDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
+                        return await sc.ReplaceDialogAsync(Actions.ConfirmAttendee, cancellationToken: cancellationToken);
                     }
 
                     return await sc.EndDialogAsync(true, cancellationToken);
@@ -746,7 +746,7 @@ namespace CalendarSkill
                     return await sc.EndDialogAsync(cancellationToken: cancellationToken);
                 }
 
-                return await sc.BeginDialogAsync(Actions.UpdateStartDateForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
+                return await sc.ReplaceDialogAsync(Actions.UpdateStartDateForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
             }
             catch (Exception ex)
             {
@@ -838,7 +838,7 @@ namespace CalendarSkill
                     return await sc.EndDialogAsync(cancellationToken: cancellationToken);
                 }
 
-                return await sc.BeginDialogAsync(Actions.UpdateStartTimeForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
+                return await sc.ReplaceDialogAsync(Actions.UpdateStartTimeForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
             }
             catch (Exception ex)
             {
@@ -947,11 +947,11 @@ namespace CalendarSkill
                 if (state.Duration <= 0)
                 {
                     await sc.Context.SendActivityAsync(sc.Context.Activity.CreateReply(CreateEventResponses.InvaildDuration));
-                    return await sc.BeginDialogAsync(Actions.UpdateDurationForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotFound), cancellationToken);
+                    return await sc.ReplaceDialogAsync(Actions.UpdateDurationForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotFound), cancellationToken);
                 }
                 else
                 {
-                    return await sc.BeginDialogAsync(Actions.UpdateDurationForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
+                    return await sc.ReplaceDialogAsync(Actions.UpdateDurationForCreate, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime), cancellationToken);
                 }
             }
             catch (Exception ex)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/DeleteEvent/DeleteEventDialog.cs
@@ -263,7 +263,7 @@ namespace CalendarSkill
                     }
                     else
                     {
-                        return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                        return await sc.ReplaceDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
                     }
                 }
                 else if (state.Events.Count > 1)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -356,7 +356,7 @@ namespace CalendarSkill
                 }
                 else if (topIntent == Luis.Calendar.Intent.ReadAloud)
                 {
-                    return await sc.BeginDialogAsync(Actions.Read);
+                    return await sc.ReplaceDialogAsync(Actions.Read);
                 }
                 else
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/UpdateEvent/UpdateEventDialog.cs
@@ -323,12 +323,12 @@ namespace CalendarSkill
                     }
                     else
                     {
-                        return await sc.BeginDialogAsync(Actions.UpdateNewStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime));
+                        return await sc.ReplaceDialogAsync(Actions.UpdateNewStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime));
                     }
                 }
                 else
                 {
-                    return await sc.BeginDialogAsync(Actions.UpdateNewStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime));
+                    return await sc.ReplaceDialogAsync(Actions.UpdateNewStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NotADateTime));
                 }
             }
             catch (Exception ex)
@@ -480,7 +480,7 @@ namespace CalendarSkill
                     }
                     else
                     {
-                        return await sc.BeginDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
+                        return await sc.ReplaceDialogAsync(Actions.UpdateStartTime, new UpdateDateTimeDialogOptions(UpdateDateTimeDialogOptions.UpdateReason.NoEvent));
                     }
                 }
                 else if (state.Events.Count > 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix potential stack overflow bug when begin dialog same as the caller as we do not need the caller any more.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
Create meeting
....
What time
[give a wrong time]

Check the stack.

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
