### PR TITLE
[Calendar] handle format exception when parse date time

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -20,7 +20,8 @@ using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Resources;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Util;
-using Calendar = Luis.Calendar;
+using Microsoft.Bot.Schema;
+using Microsoft.Recognizers.Text.DateTime;
 
 namespace CalendarSkill
 {
@@ -740,8 +741,9 @@ namespace CalendarSkill
                                     state.StartDate.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
                                 }
                             }
-                            catch (FormatException)
+                            catch (FormatException ex)
                             {
+                                await HandleExpectedDialogExceptions(sc, ex);
                             }
                         }
                     }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -816,8 +816,9 @@ namespace CalendarSkill
                                     state.StartTime.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
                                 }
                             }
-                            catch (FormatException)
+                            catch (FormatException ex)
                             {
+                                await HandleExpectedDialogExceptions(sc, ex);
                             }
                         }
                     }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -713,29 +713,35 @@ namespace CalendarSkill
                         var dateTimeValue = resolution?.Value;
                         if (dateTimeValue != null)
                         {
-                            var dateTime = DateTime.Parse(dateTimeValue);
-
-                            if (dateTime != null)
+                            try
                             {
-                                var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
-                                if (ContainsTime(dateTimeConvertType))
-                                {
-                                    state.StartTime.Add(TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()));
-                                }
+                                var dateTime = DateTime.Parse(dateTimeValue);
 
-                                // Workaround as DateTimePrompt only return as local time
-                                if (isRelativeTime)
+                                if (dateTime != null)
                                 {
-                                    dateTime = new DateTime(
-                                        dateTime.Year,
-                                        dateTime.Month,
-                                        dateTime.Day,
-                                        DateTime.Now.Hour,
-                                        DateTime.Now.Minute,
-                                        DateTime.Now.Second);
-                                }
+                                    var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
+                                    if (ContainsTime(dateTimeConvertType))
+                                    {
+                                        state.StartTime.Add(TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()));
+                                    }
 
-                                state.StartDate.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                                    // Workaround as DateTimePrompt only return as local time
+                                    if (isRelativeTime)
+                                    {
+                                        dateTime = new DateTime(
+                                            dateTime.Year,
+                                            dateTime.Month,
+                                            dateTime.Day,
+                                            DateTime.Now.Hour,
+                                            DateTime.Now.Minute,
+                                            DateTime.Now.Second);
+                                    }
+
+                                    state.StartDate.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                                }
+                            }
+                            catch (FormatException)
+                            {
                             }
                         }
                     }
@@ -798,12 +804,18 @@ namespace CalendarSkill
                         var dateTimeValue = resolution?.Value;
                         if (dateTimeValue != null)
                         {
-                            var dateTime = DateTime.Parse(dateTimeValue);
-
-                            if (dateTime != null)
+                            try
                             {
-                                var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
-                                state.StartTime.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                                var dateTime = DateTime.Parse(dateTimeValue);
+
+                                if (dateTime != null)
+                                {
+                                    var isRelativeTime = IsRelativeTime(sc.Context.Activity.Text, dateTimeValue, dateTimeConvertType);
+                                    state.StartTime.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, state.GetUserTimeZone()) : dateTime);
+                                }
+                            }
+                            catch (FormatException)
+                            {
                             }
                         }
                     }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -929,6 +929,20 @@ namespace CalendarSkill
             state.Clear();
         }
 
+        // This method is called by any waterfall step that throws a SkillException to ensure consistency
+        protected async Task HandleExpectedDialogExceptions(WaterfallStepContext sc, Exception ex)
+        {
+            // send trace back to emulator
+            var trace = new Activity(type: ActivityTypes.Trace, text: $"DialogException: {ex.Message}, StackTrace: {ex.StackTrace}");
+            await sc.Context.SendActivityAsync(trace);
+
+            // log exception
+            if (Services.TelemetryClient != null)
+            {
+                Services.TelemetryClient.TrackException(ex, AssembleTelemetryData(sc));
+            }
+        }
+
         protected override Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
         {
             var resultString = result?.ToString();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Handle format exception when parse date time

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
In create meeting flow, when bot asked for date or time, say "an hour".

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
