### PR TITLE
[Calendar] localize the contact name separator

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -450,7 +450,7 @@ namespace CalendarSkill
                         {
                             if (userInput != null)
                             {
-                                var nameList = userInput.Split(new string[] { ",", "and", ";" }, StringSplitOptions.None)
+                                var nameList = userInput.Split(CreateEventWhiteList.GetContactNameSeparator(), StringSplitOptions.None)
                                     .Select(x => x.Trim())
                                     .Where(x => !string.IsNullOrWhiteSpace(x))
                                     .ToList();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.cs
@@ -20,6 +20,9 @@ namespace CalendarSkill.Dialogs.CreateEvent.Resources
 
             [JsonProperty("DefaultTitle")]
             public List<string> DefaultTitle;
+
+            [JsonProperty("ContactSeparator")]
+            public string[] ContactSeparator;
         }
 
         private static Dictionary<string, WhiteList> WhiteLists;
@@ -63,6 +66,18 @@ namespace CalendarSkill.Dialogs.CreateEvent.Resources
 
             int rand = Random.Next(0, WhiteLists[locale].DefaultTitle.Count);
             return WhiteLists[locale].DefaultTitle[rand];
+        }
+
+        public static string[] GetContactNameSeparator()
+        {
+            var locale = CultureInfo.CurrentUICulture.Name.Split("-")[0].ToLower();
+
+            if (!WhiteLists.ContainsKey(locale))
+            {
+                locale = DefaultCulture;
+            }
+
+            return WhiteLists[locale].ContactSeparator;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.json
@@ -5,7 +5,12 @@
     "no",
     "No"
   ],
-  "DefaultTitle": [
-    "Meeting"
-  ]
+    "DefaultTitle": [
+        "Meeting"
+    ],
+    "ContactSeparator": [
+        ",",
+        "and",
+        ";"
+    ]
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/Resources/CreateEventWhiteList.zh.json
@@ -1,9 +1,16 @@
 {
-  "SkipPhrases": [
-    "跳过",
-    "空着"
-  ],
-  "DefaultTitle": [
-    "会议"
-  ]
+    "SkipPhrases": [
+        "跳过",
+        "空着"
+    ],
+    "DefaultTitle": [
+        "会议"
+    ],
+    "ContactSeparator": [
+        ",",
+        "和",
+        ";",
+        "，",
+        "；"
+    ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When user input multiple contact name will separate by a string list. This change will localize the list.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
Input "Lu和Qiong" when bot asked for participants.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
