### PR TITLE
[Email] Add delete email info confirm

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/DeleteEmailDialog.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EmailSkill.Dialogs.DeleteEmail.Resources;
 using EmailSkill.Dialogs.Shared.Resources;
+using EmailSkill.Dialogs.Shared.Resources.Strings;
+using EmailSkill.Util;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Solutions.Extensions;
@@ -64,10 +67,26 @@ namespace EmailSkill
                 var focusedMessage = state.Message?.FirstOrDefault();
                 if (focusedMessage != null)
                 {
-                    return await sc.PromptAsync(Actions.TakeFurtherAction, new PromptOptions { Prompt = sc.Context.Activity.CreateReply(DeleteEmailResponses.DeleteConfirm) });
+                    var nameListString = DisplayHelper.ToDisplayRecipientsString_Summay(focusedMessage.ToRecipients);
+                    var emailCard = new EmailCardData
+                    {
+                        Subject = string.Format(EmailCommonStrings.SubjectFormat, focusedMessage.Subject),
+                        NameList = string.Format(EmailCommonStrings.ToFormat, nameListString),
+                        EmailContent = string.Format(EmailCommonStrings.ContentFormat, focusedMessage.BodyPreview),
+                    };
+
+                    var speech = SpeakHelper.ToSpeechEmailSendDetailString(focusedMessage.Subject, nameListString, focusedMessage.BodyPreview);
+                    var stringToken = new StringDictionary
+                    {
+                        { "EmailDetails", speech },
+                    };
+                    var replyMessage = sc.Context.Activity.CreateAdaptiveCardReply(DeleteEmailResponses.DeleteConfirm, "Dialogs/Shared/Resources/Cards/EmailWithOutButtonCard.json", emailCard, ResponseBuilder, stringToken);
+
+                    return await sc.PromptAsync(Actions.TakeFurtherAction, new PromptOptions { Prompt = replyMessage, RetryPrompt = sc.Context.Activity.CreateReply(EmailSharedResponses.ConfirmSendFailed, ResponseBuilder), });
                 }
 
-                return await sc.BeginDialogAsync(Actions.Show, skillOptions);
+                skillOptions.SubFlowMode = true;
+                return await sc.BeginDialogAsync(Actions.UpdateSelectMessage, skillOptions);
             }
             catch (Exception ex)
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.json
@@ -24,7 +24,7 @@
     "replies": [
       {
         "text": "Are you sure you want to delete?",
-        "speak": "Are you sure you want to delete?"
+        "speak": "Are you sure you want to delete? Details of email: {EmailDetails}"
       }
     ],
     "inputHint": "expectingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/DeleteEmail/Resources/DeleteEmailResponses.zh.json
@@ -11,8 +11,8 @@
   "DeleteConfirm": {
     "replies": [
       {
-        "text": "Ok, I'll delete this.",
-        "speak": "Ok, I'll delete this."
+        "text": "您确定要删除这封邮件么?",
+        "speak": "您确定要删除这封邮件么? 邮件内容: {EmailDetails}"
       }
     ],
     "inputHint": "expectingInput"
@@ -20,8 +20,8 @@
   "DeleteSuccessfully": {
     "replies": [
       {
-        "text": "我已经删除了这个邮件。",
-        "speak": "我已经删除了这个邮件。"
+        "text": "我已经删除了这封邮件。",
+        "speak": "我已经删除了这封邮件。"
       }
     ],
     "inputHint": "acceptingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Main/MainDialog.cs
@@ -109,6 +109,7 @@ namespace EmailSkill
                     case Email.Intent.SearchMessages:
                     case Email.Intent.CheckMessages:
                     case Email.Intent.ReadAloud:
+                    case Email.Intent.QueryLastText:
                         {
                             await dc.BeginDialogAsync(nameof(ShowEmailDialog), skillOptions);
                             break;

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/Dialogs/Shared/EmailSkillDialog.cs
@@ -826,6 +826,7 @@ namespace EmailSkill
                     break;
                 case Actions.Reply:
                 case Actions.Forward:
+                case Actions.Delete:
                 default:
                     nameListString = DisplayHelper.ToDisplayRecipientsString_Summay(state.Recipients);
                     break;

--- a/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/DeleteEmailFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/tests/emailskilltest/Flow/DeleteEmailFlowTests.cs
@@ -32,7 +32,7 @@ namespace EmailSkillTest.Flow
                 .AssertReply(this.ShowEmailList())
                 .AssertReplyOneOf(this.NoFocusMessage())
                 .Send(BaseTestUtterances.FirstOne)
-                .AssertReplyOneOf(this.DeleteConfirm())
+                .AssertReply(this.DeleteConfirm())
                 .Send(GeneralTestUtterances.No)
                 .AssertReplyOneOf(this.NotSendingMessage())
                 .AssertReply(this.ActionEndMessage())
@@ -49,7 +49,7 @@ namespace EmailSkillTest.Flow
                 .AssertReply(this.ShowEmailList())
                 .AssertReplyOneOf(this.NoFocusMessage())
                 .Send(BaseTestUtterances.FirstOne)
-                .AssertReplyOneOf(this.DeleteConfirm())
+                .AssertReply(this.DeleteConfirm())
                 .Send(GeneralTestUtterances.Yes)
                 .AssertReplyOneOf(this.DeleteSuccess())
                 .AssertReply(this.ActionEndMessage())
@@ -71,9 +71,14 @@ namespace EmailSkillTest.Flow
             return this.ParseReplies(DeleteEmailResponses.DeleteSuccessfully.Replies, new StringDictionary());
         }
 
-        private string[] DeleteConfirm()
+        private Action<IActivity> DeleteConfirm()
         {
-            return this.ParseReplies(DeleteEmailResponses.DeleteConfirm.Replies, new StringDictionary());
+            return activity =>
+            {
+                var messageActivity = activity.AsMessageActivity();
+                CollectionAssert.Contains(this.ParseReplies(DeleteEmailResponses.DeleteConfirm.Replies, new StringDictionary()), messageActivity.Text);
+                Assert.AreEqual(messageActivity.Attachments.Count, 1);
+            };
         }
 
         private Action<IActivity> ActionEndMessage()


### PR DESCRIPTION
## Description
[Email] Add delete email info confirm
[Email] Enable "show email"

## Related Issue
#496 #495 

## Testing Steps
1. User: Delete email
2. Bot: Which one would you like to delete?
3, User: The first one
4. Bot: Are you sure to delete? A card of detailed email showed.
5. User: Yes

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
