### PR TITLE
make sure sending intro card when getting the first call with locale string

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/SetLocaleMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/SetLocaleMiddleware.cs
@@ -26,9 +26,6 @@ namespace Microsoft.Bot.Solutions.Middleware
 
             CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture = cultureInfo;
 
-            // If the current activity locale is empty or not supported (i.e. "iv"), set its culture to the default.
-            context.Activity.Locale = cultureInfo.Name;
-
             await next(cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
## Description
In webchat, the Intro card is sent back to the user in English, even if the client is calling startConversation with a different locale. It's because the StartConversation call doesn't have locale string in it and we just take that and send back the intro card with the default locale.

## Related Issue
#501 

## Testing Steps
Setup webchat and make sure you pass the language option through when calling directline API. When passing the language options as something other than en-us, you can see the intro card is always in English regardless.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation
