### PR TITLE
add date prompt to create

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -94,6 +94,7 @@ namespace CalendarSkill.Dialogs.CreateEvent
             AddDialog(new WaterfallDialog(Actions.UpdateStartDateForCreate, updateStartDate) { TelemetryClient = telemetryClient });
             AddDialog(new WaterfallDialog(Actions.UpdateStartTimeForCreate, updateStartTime) { TelemetryClient = telemetryClient });
             AddDialog(new WaterfallDialog(Actions.UpdateDurationForCreate, updateDuration) { TelemetryClient = telemetryClient });
+            AddDialog(new DatePrompt(Actions.DatePromptForCreate));
 
             // Set starting dialog for component
             InitialDialogId = Actions.CreateEvent;
@@ -679,18 +680,9 @@ namespace CalendarSkill.Dialogs.CreateEvent
                     return await sc.NextAsync(cancellationToken: cancellationToken);
                 }
 
-                if (((UpdateDateTimeDialogOptions)sc.Options).Reason == UpdateDateTimeDialogOptions.UpdateReason.NotFound)
+                return await sc.PromptAsync(Actions.DatePromptForCreate, new PromptOptions
                 {
-                    return await sc.PromptAsync(Actions.DateTimePrompt, new PromptOptions
-                    {
-                        Prompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoStartDate),
-                        RetryPrompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoStartDate_Retry)
-                    }, cancellationToken);
-                }
-
-                return await sc.PromptAsync(Actions.DateTimePrompt, new PromptOptions
-                {
-                    Prompt = sc.Context.Activity.CreateReply(CalendarSharedResponses.DidntUnderstandMessage),
+                    Prompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoStartDate),
                     RetryPrompt = sc.Context.Activity.CreateReply(CreateEventResponses.NoStartDate_Retry)
                 }, cancellationToken);
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/DatePrompt.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/CreateEvent/DatePrompt.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CalendarSkill.Dialogs.CreateEvent.Resources;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Recognizers.Text.DateTime;
+using static Microsoft.Recognizers.Text.Culture;
+
+namespace CalendarSkill.Dialogs.CreateEvent
+{
+    public class DatePrompt : Prompt<IList<DateTimeResolution>>
+    {
+        public DatePrompt(string dialogId, PromptValidator<IList<DateTimeResolution>> validator = null, string defaultLocale = null)
+               : base(dialogId, validator)
+        {
+            DefaultLocale = defaultLocale;
+        }
+
+        public string DefaultLocale { get; set; }
+
+        private bool IsSkip { get; set; } = false;
+
+        protected override async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (turnContext == null)
+            {
+                throw new ArgumentNullException(nameof(turnContext));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (isRetry && options.RetryPrompt != null)
+            {
+                await turnContext.SendActivityAsync(options.RetryPrompt, cancellationToken).ConfigureAwait(false);
+            }
+            else if (options.Prompt != null)
+            {
+                await turnContext.SendActivityAsync(options.Prompt, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        protected override async Task<PromptRecognizerResult<IList<DateTimeResolution>>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (turnContext == null)
+            {
+                throw new ArgumentNullException(nameof(turnContext));
+            }
+
+            var result = new PromptRecognizerResult<IList<DateTimeResolution>>();
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                var message = turnContext.Activity.AsMessageActivity();
+                var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
+                IList<DateTimeResolution> date = GetDateFromMessage(message.Text, culture);
+                if (date.Count > 0)
+                {
+                    result.Succeeded = true;
+                    result.Value = date;
+                }
+            }
+
+            return await Task.FromResult(result);
+        }
+
+        private IList<DateTimeResolution> GetDateFromMessage(string message, string culture)
+        {
+            if (CreateEventWhiteList.IsSkip(message))
+            {
+                message = "today";
+
+                // log is this one skip. may change logic in future.
+                // no use for now
+                IsSkip = true;
+            }
+
+            IList<DateTimeResolution> results = RecognizeDateTime(message, culture);
+
+            return results;
+        }
+
+        private List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture)
+        {
+            var results = DateTimeRecognizer.RecognizeDateTime(dateTimeString, culture);
+            if (results.Count > 0)
+            {
+                // Return list of resolutions from first match
+                var result = new List<DateTimeResolution>();
+                var values = (List<Dictionary<string, string>>)results[0].Resolution["values"];
+                foreach (var value in values)
+                {
+                    if (ContainsDate(value))
+                    {
+                        result.Add(ReadResolution(value));
+                    }
+                }
+
+                return result;
+            }
+
+            return new List<DateTimeResolution>();
+        }
+
+        private bool ContainsDate(IDictionary<string, string> resolution)
+        {
+            if (resolution.TryGetValue("value", out var value))
+            {
+                try
+                {
+                    var dateTime = DateTime.Parse(value);
+                    if (dateTime != null)
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            return false;
+        }
+
+        private DateTimeResolution ReadResolution(IDictionary<string, string> resolution)
+        {
+            var result = new DateTimeResolution();
+
+            if (resolution.TryGetValue("timex", out var timex))
+            {
+                result.Timex = timex;
+            }
+
+            if (resolution.TryGetValue("value", out var value))
+            {
+                result.Value = value;
+            }
+
+            if (resolution.TryGetValue("start", out var start))
+            {
+                result.Start = start;
+            }
+
+            if (resolution.TryGetValue("end", out var end))
+            {
+                result.End = end;
+            }
+
+            return result;
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Actions.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/Dialogs/Shared/Actions.cs
@@ -24,6 +24,7 @@
         public const string UpdateDurationForCreate = "UpdateDurationForCreate";
         public const string DateTimePrompt = "DateTimePrompt";
         public const string DateTimePromptForUpdateDelete = "DateTimePromptForUpdateDelete";
+        public const string DatePromptForCreate = "DatePromptForCreate";
         public const string Read = "read";
         public const string Greeting = "greeting";
         public const string GetEventsInit = "getEventsInit";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Change the Create Get Date to Date Prompt


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
test in the date part with 
  alalalal (not datetime)
  afternoon (not date)
  skip (set default as today)

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
