### PR TITLE
Remove botservice from deployment instructions

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-createvirtualassistant.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-createvirtualassistant.md
@@ -11,17 +11,12 @@ Follow the instructions below to build, deploy and configure your Assistant.
 ### Prerequisites
 - Ensure you have updated [.NET Core](https://www.microsoft.com/net/download) to the latest version.
 - [Node.js](https://nodejs.org/) version 8.5 or higher.
-- Install the Azure Bot Service command line (CLI) tools. It's important to do this even if you have earlier versions as the Virtual Assistant makes use of new deployment capabilities. **Minimum version 4.0.7 required for msbot, and minimum version 1.1.0 required for ludown.**
+- Install the Azure Bot Service command line (CLI) tools. It's important to do this even if you have earlier versions as the Virtual Assistant makes use of new deployment capabilities. **Minimum version 4.3.2 required for msbot, and minimum version 1.1.0 required for ludown.**
 
 ```shell
 npm install -g botdispatch chatdown ludown luis-apis luisgen msbot qnamaker  
 ```
 - Install the [Azure Command Line Tools (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows?view=azure-cli-latest)
-
-- Install the Az Extension for Bot Service
-```shell
-az extension add -n botservice
-```
 
 - Retrieve your LUIS Authoring Key
    - Review the [LUIS regions](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-reference-regions) documentation page for the correct LUIS portal for the region you plan to deploy to. Note that www.luis.ai refers to the US region and an authoring key retrieved from this portal will not work with a europe deployment. 

--- a/solutions/Virtual-Assistant/docs/virtualassistant-skills.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-skills.md
@@ -29,7 +29,7 @@ The custom SkillDialog bootstraps the Adapter and processes appropriate middlewa
 
  ## Skill Registration
 
- Each Skill is registred with a Virtual Assistant through the configuration entry shown below
+ Each Skill is registered with a Virtual Assistant through the configuration entry shown below
 
  - Name: The name of your Skill
   - Assembly: Skills are invoked "in process" and are dynamically loaded using Reflection thus enabling a configuration only approach

--- a/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/Dialogs/FindArticles/FindArticlesResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/Dialogs/FindArticles/FindArticlesResponses.cs
@@ -38,6 +38,16 @@ namespace NewsSkill
             if (articles.Any())
             {
                 response.Text = "Here's what I found:";
+
+                if (articles.Count > 1)
+                {
+                    response.Speak = $"I found a few news stories, here's a summary of the first: {articles[0].Description}";
+                }
+                else
+                {
+                    response.Speak = $"{articles[0].Description}";
+                }
+
                 response.Attachments = new List<Attachment>();
                 response.AttachmentLayout = AttachmentLayoutTypes.Carousel;
 
@@ -65,6 +75,7 @@ namespace NewsSkill
             else
             {
                 response.Text = "Sorry, I couldn't find any articles on that topic.";
+                response.Speak = "Sorry, I couldn't find any articles on that topic.";
             }
 
             return response;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
botservice extension no longer needed for deployment, removed from instructions.