### PR TITLE
Added Speak variants for speech scenarios in news experimental skill

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/Dialogs/FindArticles/FindArticlesResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/Dialogs/FindArticles/FindArticlesResponses.cs
@@ -38,6 +38,16 @@ namespace NewsSkill
             if (articles.Any())
             {
                 response.Text = "Here's what I found:";
+
+                if (articles.Count > 1)
+                {
+                    response.Speak = $"I found a few news stories, here's a summary of the first: {articles[0].Description}";
+                }
+                else
+                {
+                    response.Speak = $"{articles[0].Description}";
+                }
+
                 response.Attachments = new List<Attachment>();
                 response.AttachmentLayout = AttachmentLayoutTypes.Carousel;
 
@@ -65,6 +75,7 @@ namespace NewsSkill
             else
             {
                 response.Text = "Sorry, I couldn't find any articles on that topic.";
+                response.Speak = "Sorry, I couldn't find any articles on that topic.";
             }
 
             return response;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Populating the Speak property on the news article response so it behaves well in speech scenarios. Use the description field (albeit truncated) to provide some summary.