### PR TITLE
add all language models by default

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-createvirtualassistant.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-createvirtualassistant.md
@@ -124,7 +124,7 @@ msbot list --bot YOURBOTFILE.bot --secret YOUR_BOT_SECRET
   }
 ```
 
-- Finally, add the .bot file paths for each of your language configurations:
+- Finally, edit the .bot file paths for each of your language configurations:
 
 ```
 "defaultLocale": "en-us",
@@ -154,6 +154,8 @@ msbot list --bot YOURBOTFILE.bot --secret YOUR_BOT_SECRET
       "botFileSecret": ""
     }
 ```
+
+Note: update the language models for the languages that you support and feel free to remove the ones you don't support.
 
 ## Skill Configuration
 

--- a/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
@@ -7,7 +7,27 @@
   "defaultLocale": "en-us",
   "languageModels": {
     "en": {
-      "botFilePath": ".\\LocaleConfigurations\\YOUR_LOCALE_PATH.bot",
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_EN_BOT_PATH.bot",
+      "botFileSecret": ""
+    },
+    "de": {
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_DE_BOT_PATH.bot",
+      "botFileSecret": ""
+    },
+    "es": {
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_ES_BOT_PATH.bot",
+      "botFileSecret": ""
+    },
+    "fr": {
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_FR_BOT_PATH.bot",
+      "botFileSecret": ""
+    },
+    "it": {
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_IT_BOT_PATH.bot",
+      "botFileSecret": ""
+    },
+    "zh": {
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_ZH_BOT_PATH.bot",
       "botFileSecret": ""
     }
   },

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryExtensions.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 


### PR DESCRIPTION
## Description
Need to add all language models by default to enable better continuous integration, mainly the release time replacement of bot file path

## Related Issue
#558 

## Testing Steps
Run the bot in different languages and see if emulator configured with different languages work with the bot correctly with different languages.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation
