### PR TITLE
Direct Line Example/Speech DDK web socket bug fix

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-ConsoleDirectLineSample/DirectLineExample/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-ConsoleDirectLineSample/DirectLineExample/Program.cs
@@ -25,7 +25,7 @@ namespace DirectLineExample
         // Set this to the Secret for the Bot you wish to communicate with
         private static string botDirectLineSecret = "";
         private static string botId = "";
-        private static string fromUser = "default-ryan";
+        private static string fromUser = "";
 
         static async Task Main(string[] args)
         {

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-ConsoleDirectLineSample/DirectLineExample/Program.cs
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-ConsoleDirectLineSample/DirectLineExample/Program.cs
@@ -15,7 +15,7 @@ using WebSocketSharp;
 namespace DirectLineExample
 {
     /// <summary>
-    /// A sample Application to demonstrate the use of DirectLine (WebSockets) to communicate with a Custom Assistant
+    /// A sample Application to demonstrate the use of DirectLine (WebSockets) to communicate with a Virtual Assistant
     /// It demonstrates the ability to send and receive Events as well as process responses including Adaptive Cards
     /// This simple example provides a clear demonstration of the basic communciation required to embed a Custom Assistant
     /// within a device.
@@ -25,7 +25,7 @@ namespace DirectLineExample
         // Set this to the Secret for the Bot you wish to communicate with
         private static string botDirectLineSecret = "";
         private static string botId = "";
-        private static string fromUser = "";
+        private static string fromUser = "default-ryan";
 
         static async Task Main(string[] args)
         {
@@ -37,6 +37,7 @@ namespace DirectLineExample
             using (var webSocketClient = new WebSocket(conversation.StreamUrl))
             {
                 webSocketClient.OnMessage += WebSocketClient_OnMessage;
+                webSocketClient.SslConfiguration.EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12;
                 webSocketClient.Connect();
 
                 // The Contoso Assistant Bot requires a "startup" event to get going, this is NOT needed for other bots
@@ -68,17 +69,19 @@ namespace DirectLineExample
             }
         }
 
+
+        /// <summary>
+        /// These are sample startup events used in the Virtual Assistant for setting 
+        /// locale and providing a user's current coordinates.
+        /// </summary>
         private async static Task SendStartupEvent(DirectLineClient client, Conversation conversation)
         {
-            DeviceInformation deviceInformation = new DeviceInformation();
-            deviceInformation.DeviceId = System.Guid.NewGuid().ToString();
-
             Activity startupEvent = new Activity
             {
-                Name = "IPA.DeviceTurnedOn",
+                Name = "startConversation",
                 From = new ChannelAccount(fromUser),
                 Type = ActivityTypes.Event,
-                Value = deviceInformation
+                Locale = "en-us"
             };
 
             await client.Conversations.PostActivityAsync(conversation.ConversationId, startupEvent);
@@ -145,7 +148,7 @@ namespace DirectLineExample
 
                         Console.WriteLine($"* Received a {activity.Name} event from the Custom Assistant.");
                         break;
-            }
+                }
 
                 Console.Write("Message> ");
             }

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/AppCompatPreferenceActivity.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/AppCompatPreferenceActivity.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import android.content.res.Configuration;

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/BotApplication.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/BotApplication.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -88,7 +111,15 @@ public class BotApplication{
         }
 
         /*
-         * Send the VA.Location event to the bot
+        Send startConversation event, with locale, to the bot
+         */
+        public void SendStartConversationEvent() throws ApiException {
+            Activity eventActivity = CreateEventActivity(Configuration.StartConversationEvent, null, null);
+            SendActivity(eventActivity);
+        }
+
+        /*
+         * Send the IPA.Location event to the bot
          */
         public void SendVirtualAssistantLocationEvent(String latitude, String longitude) throws ApiException {
             String coordinates = latitude + "," + longitude;
@@ -97,7 +128,7 @@ public class BotApplication{
         }
 
         /*
-         * Send the VA.TimeZone event to the bot
+         * Send the IPA.TimeZone event to the bot
          */
         public void SendVirtualAssistantTimeZoneEvent() throws ApiException {
             TimeZone tz = TimeZone.getDefault();

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/Configuration.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/Configuration.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import android.content.Context;
@@ -62,6 +85,8 @@ public final  class Configuration {
     public static String IPATimezoneEvent = "IPA.Timezone";
     // IPA.Location event name for Virtual Assistant
     public static String IPALocationEvent = "IPA.Location";
+    // startConversation event
+    public static String StartConversationEvent = "startConversation";
     public static String Latitude = "";
     public static String Longitude = "";
 

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/MessageAdapter.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/MessageAdapter.java
@@ -1,3 +1,27 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import android.content.Context;

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SettingsActivity.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SettingsActivity.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import android.os.Bundle;

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SpeechHandler.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SpeechHandler.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import android.os.AsyncTask;

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SpeechSynthesizer.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/com/microsoft/bot/solutions/speechdevices/samples/botapp/SpeechSynthesizer.java
@@ -1,3 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package com.microsoft.bot.solutions.speechdevices.samples.botapp;
 
 import com.microsoft.cognitiveservices.speech.texttospeech.Synthesizer;

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/io/swagger/client/WebSocketServerConnection.java
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-SpeechDevicesSDK/virtualassistant/app/src/main/java/io/swagger/client/WebSocketServerConnection.java
@@ -1,19 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package io.swagger.client;
-
 
 import android.os.Handler;
 import android.os.Message;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-
+import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
-
-public class ServerConnection {
+public class WebSocketServerConnection {
     public enum ConnectionStatus {
         DISCONNECTED,
         CONNECTED
@@ -53,20 +75,20 @@ public class ServerConnection {
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-            disconnect();
+            Disconnect();
         }
     }
 
-    public ServerConnection(String url) {
+    public WebSocketServerConnection(String url) {
         mClient = new OkHttpClient.Builder()
+                .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
                 .readTimeout(3,  TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .build();
-
         mServerUrl = url;
     }
 
-    public void connect(ServerListener listener) {
+    public void Connect(ServerListener listener) {
         Request request = new Request.Builder()
                 .url(mServerUrl)
                 .build();
@@ -78,14 +100,10 @@ public class ServerConnection {
             return true;});
     }
 
-    public void disconnect() {
+    public void Disconnect() {
         mWebSocket.cancel();
         mListener = null;
         mMessageHandler.removeCallbacksAndMessages(null);
         mStatusHandler.removeCallbacksAndMessages(null);
-    }
-
-    public void sendMessage(String message) {
-        mWebSocket.send(message);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Updated web socket connections in Speech DDK and Direct Line sample applications to use TLS 1.2.
Performed some maintenance tasks on DDK code to be up to date with Virtual Assistant and clarify web socket server class.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#557 

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
Provide settings for a Direct Line bot in either application and validate that the web socket is opened and messages are received.