### PR TITLE
[Enterprise Bot Template][TS] Move misplaced file and add method summary

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
@@ -10,6 +10,16 @@ import { duration } from "moment";
     {
         public static DependencyType: string = "Bot";
      
+        /**
+         * Send information about a dependency in the Bot Application.
+         * TypeParam <TResult> The type of the return value of the method that this delegate encapsulates.
+         * The action delegate will be timed and an Application Insights dependency record will be created.
+         * @param {TelemetryClient} telemetryClient - The TelemetryClient.
+         * @param {TResult} action - Encapsulates a method that has no parameters and returns a value of the type specified by the TResult parameter.
+         * @param {string} dependencyName - Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.
+         * @param {string} dependencyData - Command initiated by this dependency call. For example, Middleware.
+         * @returns The return value of the method that this delegate encapsulates.
+         */
           public static trackBotDependency<TResult>(telemetryClient: TelemetryClient, action: () => TResult, dependencyName: string, dependencyData: string): TResult {
           // return action();
 


### PR DESCRIPTION
## Description
- Move misplaced file `telemetryBotDependencyExtension.ts` after PR #581 (modification to folders structure introduced in #583 was not contemplated).
- Add missing summary for `telemetryBotDependencyExtension.ts` methods for parity with C# version.

## Related Issue
\-

## Testing Steps
\-

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
- [x] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
