### PR TITLE
[Enterprise Bot Template][Typescript] Fix auto-install sample dependencies

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -2,7 +2,7 @@
 const Generator = require("yeoman-generator");
 const chalk = require("chalk");
 const pkg = require("../../package.json");
-
+const path = require("path");
 const _pick = require("lodash/pick");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
@@ -61,6 +61,8 @@ const bigBot =
 
 const tinyBot =
   " " + chalk.blue.bold("<") + " ** " + chalk.blue.bold(">") + " ";
+
+var botGenerationPath;
 
 module.exports = class extends Generator {
   constructor(args, opts) {
@@ -262,6 +264,8 @@ module.exports = class extends Generator {
         this.destinationPath(botNameCamelCase, "src", directory)
       )
     );
+
+    botGenerationPath = path.join(process.cwd(), botNameCamelCase);
   }
 
   install() {
@@ -269,6 +273,7 @@ module.exports = class extends Generator {
       return;
     }
 
+    process.chdir(botGenerationPath);
     this.installDependencies({ npm: true, bower: false });
   }
 


### PR DESCRIPTION
## Description 

Add instruction to change the process path directory for successfully installing the dependencies.

## Testing Steps 

1. Open a terminal in the Enterprise Bot Generator path. 
2. Install the Generator locally with `npm link.` 
3. Generate the Enterprise Bot Sample with `yo botbuilder-enterprise`. 
4. The installation was sucessfully and dependencies are installed. 

![image](https://user-images.githubusercontent.com/42946572/51844089-2e423900-22f3-11e9-9f9c-4ca8cdf06878.png)
![image](https://user-images.githubusercontent.com/42946572/51844109-3ac69180-22f3-11e9-9c7a-8bf7a297311d.png)

## Related Issue 

Fixes #634 

## Checklist 

~- [] I have commented my code, particularly in hard-to-understand areas~ 

~- [] I have added or updated the appropriate unit tests~ 

~- [] I have updated related documentation~ 

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant 

~- [ ] A duplicate issue is filed to track future  work.~ 

If you have updated responses or `.lu` files: 

~- [] All languages have been updated~ 

~- [X] You have tested deployment with your new models~ 
