### PR TITLE
[Enterprise Bot Generator][Typescript] Implement mocha

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
@@ -855,6 +855,11 @@
                 }
             }
         },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+        },
         "browserify-mime": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
@@ -1292,8 +1297,7 @@
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "documentdb": {
             "version": "1.14.5",
@@ -2413,6 +2417,11 @@
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
         },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+        },
         "handle-thing": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
@@ -2452,8 +2461,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-value": {
             "version": "1.0.0",
@@ -2495,6 +2503,11 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -3287,6 +3300,52 @@
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "requires": {
                 "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "moment": {

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
@@ -31,7 +31,8 @@
         "dotenv": "^6.0.0",
         "i18n": "^0.8.3",
         "ms-rest-azure": "^2.5.0",
-        "restify": "^7.2.1"
+        "restify": "^7.2.1",
+        "mocha": "^5.2.0"
     },
     "devDependencies": {
         "@types/dotenv": "^4.0.3",
@@ -45,5 +46,9 @@
         "typescript": "^3.2.2",
         "tslint": "^5.12.1",
         "tslint-microsoft-contrib": "6.0.0"
+    },
+    "env": {
+        "mocha": true,
+        "node": true
     }
 }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
@@ -29,7 +29,8 @@
         "dotenv": "^6.0.0",
         "i18n": "^0.8.3",
         "ms-rest-azure": "^2.5.0",
-        "restify": "^7.2.1"
+        "restify": "^7.2.1",
+        "mocha": "^5.2.0"
     },
     "devDependencies": {
         "@types/dotenv": "^4.0.3",
@@ -41,5 +42,9 @@
         "replace": "^1.0.1",
         "rimraf": "^2.6.2",
         "typescript": "^3.2.2"
+    },
+    "env": {
+        "mocha": true,
+        "node": true
     }
 }


### PR DESCRIPTION
## Description

- Implement Mocha on Enterprise Bot.

## Related Issue
Fix #639

## Testing Steps

1. Open `AI\templates\Enterprise-Template\src\typescript\enterprise-bot`.
2. Run `npm i` and check that Mocha dependency was installed.

## Checklist 

~- [] I have commented my code, particularly in hard-to-understand areas~ 
~- [] I have added or updated the appropriate unit tests~ 
~- [] I have updated related documentation~ 

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant 

~- [ ] A duplicate issue is filed to track future  work.~ 

If you have updated responses or `.lu` files: 

~- [] All languages have been updated~ 
~- [X] You have tested deployment with your new models~