### PR TITLE
[Enterprise Bot Generator][TypeScript] Improve params and validations for Generator

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -1,12 +1,13 @@
 "use strict";
 const Generator = require("yeoman-generator");
 const chalk = require("chalk");
-const pkg = require("../../package.json");
 const path = require("path");
+const pkg = require("../../package.json");
 const _pick = require("lodash/pick");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
 const _kebabCase = require("lodash/kebabCase");
+const fs = require("fs");
 
 const languages = [
   {
@@ -62,21 +63,22 @@ const bigBot =
 const tinyBot =
   " " + chalk.blue.bold("<") + " ** " + chalk.blue.bold(">") + " ";
 
-var botGenerationPath;
+var botGenerationPath = process.cwd();
+var isAlreadyCreated = false;
 
 module.exports = class extends Generator {
   constructor(args, opts) {
     super(args, opts);
 
     this.option("botName", {
-      description: "The name you want to give to your bot",
+      description: "The name you want to give to your bot.",
       type: String,
       default: "enterprise-bot",
       alias: "n"
     });
 
     this.option("botDesc", {
-      description: "A brief bit of text used to describe what your bot does",
+      description: "A brief bit of text used to describe what your bot does.",
       type: String,
       alias: "d"
     });
@@ -88,8 +90,15 @@ module.exports = class extends Generator {
       alias: "l"
     });
 
+    this.option("botGenerationPath", {
+      description: "The path where the bot will be generated.",
+      type: String,
+      default: process.cwd(),
+      alias: "p"
+    });
+
     this.option("noPrompt", {
-      description: "Do not prompt for any information or confirmation",
+      description: "Do not prompt for any information or confirmation.",
       type: Boolean,
       default: false
     });
@@ -97,7 +106,11 @@ module.exports = class extends Generator {
 
   prompting() {
     this.log(bigBot);
-
+    this.log(
+      chalk.magenta(
+        "\nREMINDER: For deployment's steps, the bot's name needs to be unique."
+      )
+    );
     // Validate language option
     if (
       this.options.botLang &&
@@ -120,7 +133,18 @@ module.exports = class extends Generator {
         type: "input",
         name: "botName",
         message: `What's the name of your bot?`,
-        default: this.options.botName ? this.options.botName : "enterprise-bot"
+        default: this.options.botName ? this.options.botName : "enterprise-bot",
+        validate: input => {
+          if (input.length > 12) {
+            this.log(
+              chalk.yellow(
+                "\nWARNING: If the name of the bot has more than 12 characters, it could have some problems deploying some services."
+              )
+            );
+          }
+
+          return true;
+        }
       },
       {
         type: "input",
@@ -128,7 +152,7 @@ module.exports = class extends Generator {
         message: "What will your bot do?",
         default: this.options.botDesc
           ? this.options.botDesc
-          : "Demonstrate advanced capabilities of a Conversational AI bot"
+          : "Demonstrate advanced capabilities of a Conversational AI bot."
       },
       {
         type: "list",
@@ -138,15 +162,49 @@ module.exports = class extends Generator {
         default: selectedLang
       },
       {
-        name: "finalConfirmation",
         type: "confirm",
+        name: "pathConfirmation",
+        message: "Do you want to change the location of the generation?",
+        default: false
+      },
+      {
+        when: function(response) {
+          return response.pathConfirmation === true;
+        },
+        type: "input",
+        name: "botGenerationPath",
+        message: "Where do you want to generate the bot?",
+        default: this.options.botGenerationPath
+          ? this.options.botGenerationPath
+          : process.cwd(),
+        validate: path => {
+          if (fs.existsSync(path)) {
+            return true;
+          }
+
+          this.log(
+            chalk.red(
+              "\n",
+              "ERROR: This is not a valid path. Please try again."
+            )
+          );
+        }
+      },
+      {
+        type: "confirm",
+        name: "finalConfirmation",
         message: "Looking good. Shall I go ahead and create your new bot?",
         default: true
       }
     ];
 
     if (this.options.noPrompt) {
-      this.props = _pick(this.options, ["botName", "botDesc", "botLang"]);
+      this.props = _pick(this.options, [
+        "botName",
+        "botDesc",
+        "botLang",
+        "botGenerationPath"
+      ]);
 
       // Validate we have what we need, or we'll need to throw
       if (!this.props.botName) {
@@ -173,34 +231,50 @@ module.exports = class extends Generator {
     const templateName = "enterprise-bot";
     const botLang = this.props.botLang;
     const botDesc = this.props.botDesc;
-    const botName = _kebabCase(this.props.botName);
+    if (!this.props.botName.replace(/\s/g, "").length) {
+      this.props.botName = templateName;
+    }
+
+    const botName = _kebabCase(this.props.botName).replace(
+      /([^a-z0-9-]+)/gi,
+      ""
+    );
     const botNamePascalCase = _upperFirst(_camelCase(this.props.botName));
     const botNameCamelCase = _camelCase(this.props.botName);
+    botGenerationPath = path.join(botGenerationPath, botName);
+    if (this.props.botGenerationPath !== undefined) {
+      botGenerationPath = path.join(this.props.botGenerationPath, botName);
+    }
 
-    this.log("Current values:");
-    this.log(botName);
-    this.log(botNameCamelCase);
-    this.log(botDesc);
-    this.log(botLang);
+    if (fs.existsSync(botGenerationPath)) {
+      isAlreadyCreated = true;
+      return;
+    }
+
+    this.log(chalk.magenta("\nCurrent values for the new bot:"));
+    this.log(chalk.magenta("Name: " + botName));
+    this.log(chalk.magenta("Description: " + botDesc));
+    this.log(chalk.magenta("Language: " + botLang));
+    this.log(chalk.magenta("Path: " + botGenerationPath + "\n"));
 
     this.fs.copy(
       this.templatePath(templateName, "cognitiveModels", "LUIS", botLang, "*"),
-      this.destinationPath(botNameCamelCase, "cognitiveModels", "LUIS")
+      this.destinationPath(botGenerationPath, "cognitiveModels", "LUIS")
     );
 
     this.fs.copy(
       this.templatePath(templateName, "cognitiveModels", "QnA", botLang, "*"),
-      this.destinationPath(botNameCamelCase, "cognitiveModels", "QnA")
+      this.destinationPath(botGenerationPath, "cognitiveModels", "QnA")
     );
 
     this.fs.copy(
       this.templatePath(templateName, "deploymentScripts", botLang, "*"),
-      this.destinationPath(botNameCamelCase, "deploymentScripts")
+      this.destinationPath(botGenerationPath, "deploymentScripts")
     );
 
     this.fs.copyTpl(
       this.templatePath(templateName, "_package.json"),
-      this.destinationPath(botNameCamelCase, "package.json"),
+      this.destinationPath(botGenerationPath, "package.json"),
       {
         name: botName,
         description: botDesc
@@ -209,7 +283,7 @@ module.exports = class extends Generator {
 
     this.fs.copyTpl(
       this.templatePath(templateName, "src", "_index.ts"),
-      this.destinationPath(botNameCamelCase, "src", "index.ts"),
+      this.destinationPath(botGenerationPath, "src", "index.ts"),
       {
         name: botName,
         description: botDesc,
@@ -220,7 +294,7 @@ module.exports = class extends Generator {
 
     this.fs.copyTpl(
       this.templatePath(templateName, "src", "_enterpriseBot.ts"),
-      this.destinationPath(botNameCamelCase, "src", `${botNameCamelCase}.ts`),
+      this.destinationPath(botGenerationPath, "src", `${botNameCamelCase}.ts`),
       {
         name: botName,
         description: botDesc,
@@ -231,7 +305,7 @@ module.exports = class extends Generator {
 
     this.fs.copy(
       this.templatePath(templateName, "src", "botServices.ts"),
-      this.destinationPath(botNameCamelCase, "src", "botServices.ts")
+      this.destinationPath(botGenerationPath, "src", "botServices.ts")
     );
 
     const commonFiles = [
@@ -246,7 +320,7 @@ module.exports = class extends Generator {
     commonFiles.forEach(fileName =>
       this.fs.copy(
         this.templatePath(templateName, fileName),
-        this.destinationPath(botNameCamelCase + "/" + fileName)
+        this.destinationPath(botGenerationPath, fileName)
       )
     );
 
@@ -261,15 +335,13 @@ module.exports = class extends Generator {
     commonDirectories.forEach(directory =>
       this.fs.copy(
         this.templatePath(templateName, "src", directory, "**", "*"),
-        this.destinationPath(botNameCamelCase, "src", directory)
+        this.destinationPath(botGenerationPath, "src", directory)
       )
     );
-
-    botGenerationPath = path.join(process.cwd(), botNameCamelCase);
   }
 
   install() {
-    if (this.props.finalConfirmation !== true) {
+    if (this.props.finalConfirmation !== true || isAlreadyCreated) {
       return;
     }
 
@@ -279,14 +351,37 @@ module.exports = class extends Generator {
 
   end() {
     if (this.props.finalConfirmation === true) {
-      this.log(chalk.green("------------------------ "));
-      this.log(chalk.green(" Your new bot is ready!  "));
-      this.log(chalk.green("------------------------ "));
-      this.log(
-        "Open the " +
-          chalk.green.bold("README.md") +
-          " to learn how to run your bot. "
-      );
+      if (isAlreadyCreated) {
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " ERROR: It's seems like you already have a bot with the same name in the destination path. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " Try again changing the name or the destination path or deleting the previous bot. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+      } else {
+        this.log(chalk.green("------------------------ "));
+        this.log(chalk.green(" Your new bot is ready!  "));
+        this.log(chalk.green("------------------------ "));
+        this.log(
+          "Open the " +
+            chalk.green.bold("README.md") +
+            " to learn how to run your bot. "
+        );
+      }
     } else {
       this.log(chalk.red.bold("-------------------------------- "));
       this.log(chalk.red.bold(" New bot creation was canceled. "));

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
@@ -5,17 +5,17 @@
 // This script is run as part of the Post Deploy step when
 // deploying the bot to Azure.  It ensures the Azure Web App
 // is configured correctly to host a TypeScript authored bot.
-const fs = require('fs');
-const path = require('path');
-const replace = require('replace');
-const WEB_CONFIG_FILE = path.join(__dirname, '..', 'web.config');
+const fs = require("fs");
+const path = require("path");
+const replace = require("replace");
+const WEB_CONFIG_FILE = path.join(__dirname, "..", "web.config");
 
 if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
-    replace({
-        regex: "url=\"index.js\"",
-        replacement: "url=\"lib/index.js\"",
-        paths: [ WEB_CONFIG_FILE ],
-        recursive: false,
-        silent: true,
-    })
+  replace({
+    regex: 'url="index.js"',
+    replacement: 'url="lib/index.js"',
+    paths: [WEB_CONFIG_FILE],
+    recursive: false,
+    silent: true
+  });
 }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/app.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/app.js
@@ -11,9 +11,10 @@ describe("The generator-botbuilder-enterprise ", () => {
   var botName = "myBot";
   const botDesc = "A description for myBot";
   const botLang = "en";
+  botName = _kebabCase(botName).replace(/([^a-z0-9-]+)/gi, "");
   const botNamePascalCase = _upperFirst(_camelCase(botName));
   const botNameCamelCase = _camelCase(botName);
-  botName = _kebabCase(botName);
+  const botGenerationPath = path.join("tmp", botName);
 
   before(() => {
     return helpers
@@ -23,6 +24,8 @@ describe("The generator-botbuilder-enterprise ", () => {
         botName: botName,
         botDesc: botDesc,
         botLang: botLang,
+        confirmationPath: true,
+        botPath: process.cwd(),
         finalConfirmation: true
       });
   });
@@ -42,10 +45,7 @@ describe("The generator-botbuilder-enterprise ", () => {
     commonDirectories.forEach(directoryName =>
       it(directoryName + " folder", () => {
         assert.file(
-          path.join(
-            __dirname,
-            "tmp/" + botNameCamelCase + "/src/" + directoryName + "/"
-          )
+          path.join(__dirname, botGenerationPath, "src", directoryName)
         );
       })
     );
@@ -56,11 +56,9 @@ describe("The generator-botbuilder-enterprise ", () => {
         assert.file(
           path.join(
             __dirname,
-            "tmp/" +
-              botNameCamelCase +
-              "/cognitiveModels/" +
-              directoryName +
-              "/"
+            botGenerationPath,
+            "cognitiveModels",
+            directoryName
           )
         );
       })
@@ -79,9 +77,7 @@ describe("The generator-botbuilder-enterprise ", () => {
     ];
     rootFiles.forEach(fileName =>
       it(fileName + "file", () => {
-        assert.file(
-          path.join(__dirname, "tmp/" + botNameCamelCase + "/" + fileName)
-        );
+        assert.file(path.join(__dirname, botGenerationPath, fileName));
       })
     );
   });
@@ -90,9 +86,7 @@ describe("The generator-botbuilder-enterprise ", () => {
     const srcFiles = [botNameCamelCase + ".ts", "botServices.ts"];
     srcFiles.forEach(fileName =>
       it(fileName + " file", () => {
-        assert.file(
-          path.join(__dirname, "tmp/" + botNameCamelCase + "/src/" + fileName)
-        );
+        assert.file(path.join(__dirname, botGenerationPath, "src", fileName));
       })
     );
   });
@@ -100,14 +94,14 @@ describe("The generator-botbuilder-enterprise ", () => {
   describe("should have in the package.json", () => {
     it("a name property with the given name", () => {
       assert.fileContent(
-        path.join(__dirname, "tmp/" + botNameCamelCase + "/package.json"),
+        path.join(__dirname, botGenerationPath, "/package.json"),
         `"name": "${botName}"`
       );
     });
 
     it("a description property with given description", () => {
       assert.fileContent(
-        path.join(__dirname, "tmp/" + botNameCamelCase + "/package.json"),
+        path.join(__dirname, botGenerationPath, "/package.json"),
         `"description": "${botDesc}"`
       );
     });
@@ -116,21 +110,21 @@ describe("The generator-botbuilder-enterprise ", () => {
   describe("should have in the index file", () => {
     it("an import component containing the given name", () => {
       assert.fileContent(
-        path.join(__dirname, "tmp/" + botNameCamelCase + "/src/index.ts"),
-        `import { ${botNamePascalCase} } from "./${botNameCamelCase}"`
+        path.join(__dirname, botGenerationPath, "/src/index.ts"),
+        `import { ${botNamePascalCase} } from './${botNameCamelCase}'`
       );
     });
 
     it("a declaration component with the given name", () => {
       assert.fileContent(
-        path.join(__dirname, "tmp/" + botNameCamelCase + "/src/index.ts"),
+        path.join(__dirname, botGenerationPath, "/src/index.ts"),
         `let bot: ${botNamePascalCase}`
       );
     });
 
     it("an instantiation component with the given name", () => {
       assert.fileContent(
-        path.join(__dirname, "tmp/" + botNameCamelCase + "/src/index.ts"),
+        path.join(__dirname, botGenerationPath, "/src/index.ts"),
         `bot = new ${botNamePascalCase}`
       );
     });
@@ -141,7 +135,9 @@ describe("The generator-botbuilder-enterprise ", () => {
       assert.fileContent(
         path.join(
           __dirname,
-          "tmp/" + botNameCamelCase + "/src/" + botNameCamelCase + ".ts"
+          botGenerationPath,
+          "src",
+          botNameCamelCase + ".ts"
         ),
         `export class ${botNamePascalCase}`
       );
@@ -151,9 +147,11 @@ describe("The generator-botbuilder-enterprise ", () => {
       assert.fileContent(
         path.join(
           __dirname,
-          "tmp/" + botNameCamelCase + "/src/" + botNameCamelCase + ".ts"
+          botGenerationPath,
+          "src",
+          botNameCamelCase + ".ts"
         ),
-        `("${botNamePascalCase}")`
+        `('${botNamePascalCase}')`
       );
     });
   });

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/update-template.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/update-template.js
@@ -1,58 +1,87 @@
-const fs = require('fs');
+const fs = require("fs");
 const path = require("path");
-const testFolder = path.join(__dirname, 'generators/app/templates/enterprise-bot');
-const srcFolder = path.join(__dirname, '../enterprise-bot');
+const testFolder = path.join(
+  __dirname,
+  "generators/app/templates/enterprise-bot"
+);
+const srcFolder = path.join(__dirname, "../enterprise-bot");
 
-console.log('Starting to delete files without placeholders...');
+console.log("Starting to delete files without placeholders...");
 readPath(testFolder);
-console.log('Finished deleting files...');
+console.log("Finished deleting files...");
 
-console.log('Starting to copy files without placeholders...');
+console.log("Starting to copy files without placeholders...");
 readPath2(srcFolder);
-console.log('Finished copying files...');
+console.log("Finished copying files...");
 
 function readPath(pathToRead) {
-    fs.readdirSync(pathToRead).forEach(file => {
-        const filePath = path.join(pathToRead, file);
-        const stat = fs.statSync(filePath);
-        // If directory, execute a recursive call
-        if (stat && stat.isDirectory()) {
-            readPath(filePath);
-            try {
-                fs.rmdirSync(filePath);
-            }
-            catch(error) {
-                console.log('The folder "' + filePath + '" couldn\'t be deleted, as it may have files left inside. If the files\' name starts with a `_`, ignore this error.')
-            }
-        } else {
-            if (file.startsWith('_')) {
-                console.log('The file "' + file + '" located in "' +  filePath + '" won\'t be updated automatically as it has placeholders.');
-            } else {
-                try {
-                    fs.unlinkSync(filePath);
-                } catch (error) {
-                    console.log('The file "' + filePath + '" couldn\'t be deleted. More info: ' + error);
-                }
-            }
-        }
-    });
+  fs.readdirSync(pathToRead).forEach(file => {
+    const filePath = path.join(pathToRead, file);
+    const stat = fs.statSync(filePath);
+    // If directory, execute a recursive call
+    if (stat && stat.isDirectory()) {
+      readPath(filePath);
+      try {
+        fs.rmdirSync(filePath);
+      } catch (error) {
+        console.log(
+          'The folder "' +
+            filePath +
+            "\" couldn't be deleted, as it may have files left inside. If the files' name starts with a `_`, ignore this error."
+        );
+      }
+    } else if (file.startsWith("_")) {
+      console.log(
+        'The file "' +
+          file +
+          '" located in "' +
+          filePath +
+          "\" won't be updated automatically as it has placeholders."
+      );
+    } else {
+      try {
+        fs.unlinkSync(filePath);
+      } catch (error) {
+        console.log(
+          'The file "' +
+            filePath +
+            "\" couldn't be deleted. More info: " +
+            error
+        );
+      }
+    }
+  });
 }
 
 function readPath2(pathToRead) {
-    fs.readdirSync(pathToRead).forEach(file => {
-        const filePath = path.join(pathToRead, file);
-        const stat = fs.statSync(filePath);
-        if (stat && stat.isDirectory()) {
-            if (!fs.existsSync(path.join(testFolder, path.relative(srcFolder, filePath)))) {
-                fs.mkdirSync(path.join(testFolder, path.relative(srcFolder, filePath)));
-            }
-            readPath2(filePath);
-        } else {
-            if (fs.existsSync(path.join(testFolder, path.relative(srcFolder, pathToRead), '_' + file))) {
-                console.log('File "' + file + '" was not copied because it\'s already present in destination folder with placeholders. Please review it yourself.');
-            } else {
-                fs.copyFileSync(filePath, path.join(testFolder, path.relative(srcFolder, pathToRead), file));
-            }
-        }
-    });
+  fs.readdirSync(pathToRead).forEach(file => {
+    const filePath = path.join(pathToRead, file);
+    const stat = fs.statSync(filePath);
+    if (stat && stat.isDirectory()) {
+      if (
+        !fs.existsSync(
+          path.join(testFolder, path.relative(srcFolder, filePath))
+        )
+      ) {
+        fs.mkdirSync(path.join(testFolder, path.relative(srcFolder, filePath)));
+      }
+
+      readPath2(filePath);
+    } else if (
+      fs.existsSync(
+        path.join(testFolder, path.relative(srcFolder, pathToRead), "_" + file)
+      )
+    ) {
+      console.log(
+        'File "' +
+          file +
+          "\" was not copied because it's already present in destination folder with placeholders. Please review it yourself."
+      );
+    } else {
+      fs.copyFileSync(
+        filePath,
+        path.join(testFolder, path.relative(srcFolder, pathToRead), file)
+      );
+    }
+  });
 }


### PR DESCRIPTION
## Description

- Add destination path's param
- Add validations for bot's name, bot's destination path
- Fix ESLint errors

## Related Issue
Fix #641 

## Testing Steps

1. Go to `AI\templates\Enterprise-Template\src\typescript\generator-botbuilder-enterprise` and run `npm link` to symlink the package folder
2. Open a terminal wherever you want to create a bot
3. Run `yo botbuilder-enterprise`
4. Follow the generator's prompts
5. Check that the bot was created successfully
Check the warning output if the bot's name has more than 12 characters
Check that you can pass the destination path for the bot
Check the error output if you pass a non-existent path
Check the error output if the bot already exists in the destination path
Check how the bot's name is modified if you pass a name with specials characters


## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
