### PR TITLE
Properly end single turn dialogs

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/RouterDialog.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/RouterDialog.cs
@@ -48,13 +48,9 @@ namespace $safeprojectname$.Dialogs.Shared
                                 case DialogTurnStatus.Empty:
                                     {
                                         await RouteAsync(innerDc);
-                                        // Waterfalls with no turns should fire EndDialog code.
+                                        // Waterfalls with no turns should Complete.
                                         if (innerDc.Stack.Count == 0)
-                                        {
                                             await CompleteAsync(innerDc);
-                                            // End active dialog
-                                            await innerDc.EndDialogAsync();
-                                        }
                                         break;
                                     }
 

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/RouterDialog.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/RouterDialog.cs
@@ -48,6 +48,13 @@ namespace $safeprojectname$.Dialogs.Shared
                                 case DialogTurnStatus.Empty:
                                     {
                                         await RouteAsync(innerDc);
+                                        // Waterfalls with no turns should fire EndDialog code.
+                                        if (innerDc.Stack.Count == 0)
+                                        {
+                                            await CompleteAsync(innerDc);
+                                            // End active dialog
+                                            await innerDc.EndDialogAsync();
+                                        }
                                         break;
                                     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Single turn dialogs currently don't properly end the active dialog.  For these dialog no DialogTurnStatus complete is ever sent.  Only a single Empty is sent.  So check if that is the case and then end the dialog.

<!--- Describe your changes in detail -->
Check for empty dialog stack in the dialog turn status empty case.  Perform proper end dialog processing in this case.

## Related Issue
https://github.com/Microsoft/AI/issues/643

## Testing Steps
Create a simple single turn dialog (code in issue).
