### PR TITLE
Telemetry: QnA does not need to add activityID

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/Middleware/Telemetry/QnATelemetryConstants.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/Middleware/Telemetry/QnATelemetryConstants.cs
@@ -9,7 +9,6 @@ namespace EnterpriseBotSample.Middleware.Telemetry
     public static class QnATelemetryConstants
     {
         public const string KnowledgeBaseIdProperty = "knowledgeBaseId";
-        public const string ActivityIdProperty = "activityId";
         public const string AnswerProperty = "answer";
         public const string ArticleFoundProperty = "articleFound";
         public const string ChannelIdProperty = "channelId";

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/Middleware/Telemetry/TelemetryQnAMaker.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/Middleware/Telemetry/TelemetryQnAMaker.cs
@@ -57,8 +57,6 @@ namespace EnterpriseBotSample.Middleware.Telemetry
                 var telemetryMetrics = new Dictionary<string, double>();
 
                 telemetryProperties.Add(QnATelemetryConstants.KnowledgeBaseIdProperty, _endpoint.KnowledgeBaseId);
-                // Make it so we can correlate our reports with Activity or Conversation
-                telemetryProperties.Add(QnATelemetryConstants.ActivityIdProperty, context.Activity.Id);
                 var conversationId = context.Activity.Conversation.Id;
                 if (!string.IsNullOrEmpty(conversationId))
                 {

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
@@ -6,7 +6,6 @@
  */
 export class QnATelemetryConstants {
     public readonly KNOWLEDGE_BASE_ID_PROPERTY: string = 'knowledgeBaseId';
-    public readonly ACTIVITY_ID_PROPERTY: string = 'activityId';
     public readonly ANSWER_PROPERTY: string = 'answer';
     public readonly ARTICLE_FOUND_PROPERTY: string = 'articleFound';
     public readonly CHANNEL_ID_PROPERTY: string = 'channelId';

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryQnAMaker.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryQnAMaker.ts
@@ -69,8 +69,6 @@ export class TelemetryQnAMaker extends QnAMaker {
             const metrics: { [key: string]: number } = {};
 
             properties[this.QNA_TELEMETRY_CONSTANTS.KNOWLEDGE_BASE_ID_PROPERTY] = this.ENDPOINT.knowledgeBaseId;
-            // Make it so we can correlate our reports with Activity or Conversation
-            properties[this.QNA_TELEMETRY_CONSTANTS.ACTIVITY_ID_PROPERTY] = context.activity.id || '';
             const conversationId: string = context.activity.conversation.id;
             if (conversationId && conversationId.trim()) {
                 properties[this.QNA_TELEMETRY_CONSTANTS.CONVERSATION_ID_PROPERTY] = conversationId;


### PR DESCRIPTION

## Description
Fixes collision in Application Insights where QnA recognizer adding property that the initializer automatically puts in..

This needs to be replicated to VA (and other locations in Enterprise (?)).