### PR TITLE
Lamil/va constructor update

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -37,7 +37,7 @@ namespace VirtualAssistant.Dialogs.Main
 
         private bool _conversationStarted = false;
 
-        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, EndpointService endpointService)
+        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
             : base(nameof(MainDialog), telemetryClient)
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
@@ -388,7 +388,7 @@ namespace VirtualAssistant.Dialogs.Main
         {
             foreach (var definition in skillDefinitions)
             {
-                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], TelemetryClient, _endpointService));
+                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], _endpointService, TelemetryClient));
             }
 
             // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -26,7 +26,6 @@ namespace VirtualAssistant.Dialogs.Main
     {
         // Fields
         private BotServices _services;
-        private BotConfiguration _botConfig;
         private UserState _userState;
         private ConversationState _conversationState;
         private EndpointService _endpointService;
@@ -38,11 +37,10 @@ namespace VirtualAssistant.Dialogs.Main
 
         private bool _conversationStarted = false;
 
-        public MainDialog(BotServices services, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
+        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, EndpointService endpointService)
             : base(nameof(MainDialog), telemetryClient)
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
-            _botConfig = botConfig;
             _conversationState = conversationState;
             _userState = userState;
             _endpointService = endpointService;
@@ -390,7 +388,7 @@ namespace VirtualAssistant.Dialogs.Main
         {
             foreach (var definition in skillDefinitions)
             {
-                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], _endpointService, TelemetryClient));
+                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], TelemetryClient, _endpointService));
             }
 
             // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -46,8 +46,7 @@ namespace VirtualAssistant
             // Load the connected services from .bot file.
             var botFilePath = Configuration.GetSection("botFilePath")?.Value;
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
-            var botConfig = BotConfiguration.Load(botFilePath ?? @".\CustomAssistant.bot", botFileSecret);
-            services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot config file could not be loaded."));
+            var botConfig = BotConfiguration.Load(botFilePath ?? throw new Exception("Please configure your bot file path in appsettings.json."), botFileSecret);
 
             // Use Application Insights
             services.AddBotApplicationInsights(botConfig);

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -32,16 +32,16 @@ namespace VirtualAssistant
         /// <param name="userState">Bot user state.</param>
         /// <param name="endpointService">Bot endpoint service.</param>
         /// <param name="telemetryClient">Bot telemetry client.</param>
-        public VirtualAssistant(BotServices botServices, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, EndpointService endpointService)
+        public VirtualAssistant(BotServices botServices, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
+            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-            _endpointService = endpointService;
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(VirtualAssistant)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _endpointService));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _endpointService, _telemetryClient));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -18,7 +18,6 @@ namespace VirtualAssistant
     public class VirtualAssistant : IBot
     {
         private readonly BotServices _services;
-        private readonly BotConfiguration _botConfig;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
         private readonly EndpointService _endpointService;
@@ -28,23 +27,21 @@ namespace VirtualAssistant
         /// <summary>
         /// Initializes a new instance of the <see cref="VirtualAssistant"/> class.
         /// </summary>
-        /// <param name="botConfig">Bot configuration.</param>
         /// <param name="botServices">Bot services.</param>
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
         /// <param name="endpointService">Bot endpoint service.</param>
         /// <param name="telemetryClient">Bot telemetry client.</param>
-        public VirtualAssistant(BotServices botServices, BotConfiguration botConfig, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
+        public VirtualAssistant(BotServices botServices, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, EndpointService endpointService)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
-            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-            _botConfig = botConfig;
-            
+            _endpointService = endpointService;
+
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(VirtualAssistant)));
-            _dialogs.Add(new MainDialog(_services, _botConfig, _conversationState, _userState, _endpointService, _telemetryClient));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient, _endpointService));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Solutions.Skills
         private bool _skillInitialized;
         private bool _useCachedTokens;
 
-        public SkillDialog(SkillDefinition skillDefinition, SkillConfigurationBase skillConfiguration, EndpointService endpointService, IBotTelemetryClient telemetryClient, bool useCachedTokens = true)
+        public SkillDialog(SkillDefinition skillDefinition, SkillConfigurationBase skillConfiguration, IBotTelemetryClient telemetryClient, EndpointService endpointService, bool useCachedTokens = true)
             : base(skillDefinition.Id)
         {
             _skillDefinition = skillDefinition;
@@ -253,9 +253,9 @@ namespace Microsoft.Bot.Solutions.Skills
                         // if the conversation id from the activity is the same as the context activity, it's reactive message
                         await innerDc.Context.SendActivitiesAsync(queue.ToArray());
                     }
-                    else
+                    else if (_endpointService != null)
                     {
-                        // if the conversation id from the activity is differnt from the context activity, it's proactive message
+                        // if the conversation id from the activity is different from the context activity, it's proactive message
                         await innerDc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, firstActivity.GetConversationReference(), CreateCallback(queue.ToArray()), default(CancellationToken));
                     }
                 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Solutions.Skills
         private bool _skillInitialized;
         private bool _useCachedTokens;
 
-        public SkillDialog(SkillDefinition skillDefinition, SkillConfigurationBase skillConfiguration, IBotTelemetryClient telemetryClient, EndpointService endpointService, bool useCachedTokens = true)
+        public SkillDialog(SkillDefinition skillDefinition, SkillConfigurationBase skillConfiguration, EndpointService endpointService, IBotTelemetryClient telemetryClient, bool useCachedTokens = true)
             : base(skillDefinition.Id)
         {
             _skillDefinition = skillDefinition;
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Solutions.Skills
                         // if the conversation id from the activity is the same as the context activity, it's reactive message
                         await innerDc.Context.SendActivitiesAsync(queue.ToArray());
                     }
-                    else if (_endpointService != null)
+                    else
                     {
                         // if the conversation id from the activity is different from the context activity, it's proactive message
                         await innerDc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, firstActivity.GetConversationReference(), CreateCallback(queue.ToArray()), default(CancellationToken));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Removed botConfig from VA constructor

@darrenj You will still need to mock the EndpointService in the constructor for the VA tests. This is required for the SkillDialog to support proactive and should be simple to mock.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
