### PR TITLE
[Calendar] add regex to recreate event prompt

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/GetRecreateInfoPrompt.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/GetRecreateInfoPrompt.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CalendarSkill.Dialogs.CreateEvent.Resources;
+using CalendarSkill.Dialogs.Shared.Resources.Strings;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
@@ -70,8 +72,66 @@ namespace CalendarSkill.Dialogs.CreateEvent.Prompts
         private RecreateEventState? GetStateFromMessage(string message, string culture)
         {
             RecreateEventState? result = null;
+            message = message.ToLower();
 
-            // use exactly match for now. We may discuss about to use white list or Luis in future.
+            // useregex and  exactly match for now. We may discuss about to use white list or Luis in future.
+            // check is no or cancel
+            Regex regex = new Regex(CalendarCommonStrings.CancelAdjust);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Cancel;
+                return result;
+            }
+
+            // check is change time
+            regex = new Regex(CalendarCommonStrings.AdjustTime);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Time;
+                return result;
+            }
+
+            // check is change duration
+            regex = new Regex(CalendarCommonStrings.AdjustDuration);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Duration;
+                return result;
+            }
+
+            // check is change subject
+            regex = new Regex(CalendarCommonStrings.AdjustSubject);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Subject;
+                return result;
+            }
+
+            // check is change content
+            regex = new Regex(CalendarCommonStrings.AdjustContent);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Content;
+                return result;
+            }
+
+            // check is change location
+            regex = new Regex(CalendarCommonStrings.AdjustLocation);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Location;
+                return result;
+            }
+
+            // check is change participants
+            regex = new Regex(CalendarCommonStrings.AdjustParticipants);
+            if (regex.IsMatch(message))
+            {
+                result = RecreateEventState.Participants;
+                return result;
+            }
+
+            // no match, go to exactly match
             try
             {
                 result = (RecreateEventState)Enum.Parse(typeof(RecreateEventState), message, true);

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
@@ -61,6 +61,60 @@ namespace CalendarSkill.Dialogs.Shared.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update).*(content|body|detail|details).
+        /// </summary>
+        public static string AdjustContent {
+            get {
+                return ResourceManager.GetString("AdjustContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update).*(duration|length).
+        /// </summary>
+        public static string AdjustDuration {
+            get {
+                return ResourceManager.GetString("AdjustDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update).*(location|place|where).
+        /// </summary>
+        public static string AdjustLocation {
+            get {
+                return ResourceManager.GetString("AdjustLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update|add|delete).*(participants|attendee|attendees|people|person).
+        /// </summary>
+        public static string AdjustParticipants {
+            get {
+                return ResourceManager.GetString("AdjustParticipants", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update).*(subject|title).
+        /// </summary>
+        public static string AdjustSubject {
+            get {
+                return ResourceManager.GetString("AdjustSubject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (adjust|change|update).*time.
+        /// </summary>
+        public static string AdjustTime {
+            get {
+                return ResourceManager.GetString("AdjustTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All day.
         /// </summary>
         public static string AllDay {
@@ -93,6 +147,15 @@ namespace CalendarSkill.Dialogs.Shared.Resources.Strings {
         public static string AtTime {
             get {
                 return ResourceManager.GetString("AtTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ^(no|cancel|nop|don&apos;t|not).
+        /// </summary>
+        public static string CancelAdjust {
+            get {
+                return ResourceManager.GetString("CancelAdjust", resourceCulture);
             }
         }
         

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
@@ -144,4 +144,25 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>with a subject of {0}</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^(no|cancel|nop|don't|not)</value>
+  </data>
+  <data name="AdjustContent" xml:space="preserve">
+    <value>(adjust|change|update).*(content|body|detail|details)</value>
+  </data>
+  <data name="AdjustDuration" xml:space="preserve">
+    <value>(adjust|change|update).*(duration|length)</value>
+  </data>
+  <data name="AdjustLocation" xml:space="preserve">
+    <value>(adjust|change|update).*(location|place|where)</value>
+  </data>
+  <data name="AdjustParticipants" xml:space="preserve">
+    <value>(adjust|change|update|add|delete).*(participants|attendee|attendees|people|person)</value>
+  </data>
+  <data name="AdjustSubject" xml:space="preserve">
+    <value>(adjust|change|update).*(subject|title)</value>
+  </data>
+  <data name="AdjustTime" xml:space="preserve">
+    <value>(adjust|change|update).*time</value>
+  </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
@@ -144,4 +144,7 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>以{0}为标题</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^(不|不要|不调整|取消)$</value>
+  </data>
 </root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
add regex to get recreate info prompt

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
test with
no
don't change
update the time

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
