### PR TITLE
[Enterprise Bot Generator][TypeScript] Add tests to the Dialog Generator

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/templates/customDialog/myFile.txt
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/templates/customDialog/myFile.txt
@@ -1,1 +1,0 @@
-This is an example

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.dialog.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.dialog.test.suite.js
@@ -1,0 +1,97 @@
+"use strict";
+const path = require("path");
+const assert = require("yeoman-assert");
+const helpers = require("yeoman-test");
+const rimraf = require("rimraf");
+const _camelCase = require("lodash/camelCase");
+const _upperFirst = require("lodash/upperFirst");
+
+describe("The generator-botbuilder-enterprise dialog tests ", () => {
+  var dialogName = "customDialog";
+  var responsesName = "customResponses";
+  const dialogNameCamelCase = _camelCase(dialogName);
+  const dialogNamePascalCase = _upperFirst(_camelCase(dialogName));
+  const responsesNameCamelCase = _camelCase(responsesName);
+  const responsesNamePascalCase = _upperFirst(_camelCase(responsesName));
+  const dialogGenerationPath = path.join("tmp", dialogName);
+
+  before(() => {
+    return helpers
+      .run(path.join(__dirname, "../generators/dialog"))
+      .inDir(path.join(__dirname, "tmp"))
+      .withPrompts({
+        dialogName: dialogName,
+        confirmationPath: true,
+        dialogPath: process.cwd(),
+        finalConfirmation: true
+      });
+  });
+
+  after(() => {
+    rimraf.sync(path.join(__dirname, "tmp/*"));
+  });
+
+  describe("should create", () => {
+    const files = [dialogNameCamelCase + ".ts", responsesNameCamelCase + ".ts"];
+
+    files.forEach(fileName =>
+      it(fileName + " file", () => {
+        assert.file(path.join(__dirname, dialogGenerationPath, fileName));
+      })
+    );
+  });
+
+  describe("should have in the dialog file with the given name", () => {
+    it("an import component containing the given name", () => {
+      assert.fileContent(
+        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
+        `import { ${responsesNamePascalCase} } from './${responsesNameCamelCase}'`
+      );
+    });
+
+    it("an export component with the given name", () => {
+      assert.fileContent(
+        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
+        `export class ${dialogNamePascalCase}`
+      );
+    });
+
+    it("an initialized attribute with the given name", () => {
+      assert.fileContent(
+        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
+        `RESPONDER: ${responsesNamePascalCase} = new ${responsesNamePascalCase}()`
+      );
+    });
+
+    it("a super method with the given name as parameter", () => {
+      assert.fileContent(
+        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
+        `super(${dialogNamePascalCase}.name)`
+      );
+    });
+  });
+
+  describe("should have in the responses file with the given name", () => {
+    it("an export component with the given name", () => {
+      assert.fileContent(
+        path.join(
+          __dirname,
+          dialogGenerationPath,
+          responsesNameCamelCase + ".ts"
+        ),
+        `export class ${responsesNamePascalCase}`
+      );
+    });
+
+    it("a parameter with the given name", () => {
+      assert.fileContent(
+        path.join(
+          __dirname,
+          dialogGenerationPath,
+          responsesNameCamelCase + ".ts"
+        ),
+        `new DictionaryRenderer(${responsesNamePascalCase}.RESPONSE_TEMPLATES)`
+      );
+    });
+  });
+});

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
@@ -7,7 +7,7 @@ const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
 const _kebabCase = require("lodash/kebabCase");
 
-describe("The generator-botbuilder-enterprise ", () => {
+describe("The generator-botbuilder-enterprise tests", () => {
   var botName = "myBot";
   const botDesc = "A description for myBot";
   const botLang = "en";
@@ -25,7 +25,7 @@ describe("The generator-botbuilder-enterprise ", () => {
         botDesc: botDesc,
         botLang: botLang,
         confirmationPath: true,
-        botPath: process.cwd(),
+        botGenerationPath: process.cwd(),
         finalConfirmation: true
       });
   });
@@ -76,7 +76,7 @@ describe("The generator-botbuilder-enterprise ", () => {
       "package.json"
     ];
     rootFiles.forEach(fileName =>
-      it(fileName + "file", () => {
+      it(fileName + " file", () => {
         assert.file(path.join(__dirname, botGenerationPath, fileName));
       })
     );


### PR DESCRIPTION
## Description
- Rename the test files using the botbuilder-tools (like [msbot](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot/test)) nomenclature `generator-botbuilder-enterprise.<generator_name>.test.suite.js`
- Add tests to the dialog generator
- Remove unnecessary template file (myFile.txt)

## Related Issue
Fix #661 

## Testing Steps
1. Open `AI\templates\Enterprise-Template\src\typescript\generator-botbuilder-enterprise`
2. Run `npm i`
3. Run `npm run test` and check the running tests.

![image](https://user-images.githubusercontent.com/11904023/52055077-2544a800-253d-11e9-8051-db9fe123172b.png)

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
