### PR TITLE
Enterprise Bot Generator][TypeScript] Update the structure of the READMEs

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/README.md
@@ -19,53 +19,10 @@ To install the generator using npm:
 > npm install -g generator-botbuilder-enterprise
 ```
 
-## Generate sample
-
-- Open a terminal in the desired folder for generating the sample.
-- Run the following command for generating your new project.
-
-```bash
-> yo botbuilder-enterprise
-```
-
-- The generator will start prompting for some information that is needed for generating the sample:
-    - `What's the name of your bot? (enterprise-bot)`
-        > The name of your bot (used also as your project's name and for the root folder's name).
-    - `What will your bot do? (Demonstrate advanced capabilities of a Conversational AI bot)`
-        > The description of your bot.
-    - `What language will your bot use?`
-        > The language that will understand your bot while chatting with it. A full list of supported languages is displayed.
-    - `Do you want to change the location of the generation?`
-        > A confirmation to change the destination for the generation.
-        - `Where do you want to generate the bot? (by default takes the path where you are running the generator)`
-            > The destination path for the generation.
-    - `Looking good. Shall I go ahead and create your new bot?`
-        > Final confirmation for creating the desired bot.
-
-
-### Generate the sample using CLI parameters.
-
-| Option                            | Description                                                                                                  |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------|
-| -n, --botName <name>              | name of new bot (by default takes `enterprise-bot`)                                                          |
-| -d, --botDesc <description>       | description of the new bot (by default takes `Demonstrate advanced capabilities of a Conversational AI bot`) |
-| -l, --botLang <language>          | language for the new bot. Possible values are `de`, `en`, `es`, `fr`, `it`, `zh` (by default takes `en`)     |
-| -p, --botGenerationPath <path>    | destination path for the new bot (by default takes the path where you are runnning the generator)            |
-| --noPrompt                        | indicates to avoid the prompts                                                                               |
-
-**NOTE:** If you don't use the _--noPrompt_ option, the process will keep prompting, but using the input values by default.
-
-#### Example
-
-```bash
-> yo botbuilder-enterprise -n newBot -d "A description for my new bot" -l en -p "\aPath" --noPrompt
-```
-
-**WARNING:** The process will fail if it finds another folder with the same name of the new bot.
-
-**NOTE:** Remind to have an **unique** bot's name for deployment steps. 
-
-**NOTE:** After generating your sample, you can check its README for more information on how to deploy and test it. You can find it in the root folder of your newly created sample or [here](https://github.com/Microsoft/AI/blob/master/templates/Enterprise-Template/src/typescript/enterprise-bot/README.md).
+| Generator                                           | Description                                     |
+|-----------------------------------------------------|-------------------------------------------------|
+| [botbuilder-enterprise](generators/app/README.md)             | Generator that creates a basic sample            |
+| [botbuilder-enterprise:dialog](generators/dialog/README.md)   | Generator that creates a basic dialog            |
 
 ## License
 

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/README.md
@@ -1,0 +1,65 @@
+# Bot Builder Enterprise Generator
+
+## Generate sample
+
+- Open a terminal in the desired folder for generating the sample.
+- Run the following command for generating your new project.
+
+```bash
+> yo botbuilder-enterprise
+```
+
+#### **At this point you have two different options to procedure**
+
+### Generate the sample using prompts
+
+- The generator will start prompting for some information that is needed for generating the sample:
+    - `What's the name of your bot? (enterprise-bot)`
+        > The name of your bot (used also as your project's name and for the root folder's name).
+    - `What will your bot do? (Demonstrate advanced capabilities of a Conversational AI bot)`
+        > The description of your bot.
+    - `What language will your bot use?`
+        > The language that will understand your bot while chatting with it. A full list of supported languages is displayed.
+    - `Do you want to change the location of the generation?`
+        > A confirmation to change the destination for the generation.
+        - `Where do you want to generate the bot? (by default takes the path where you are running the generator)`
+            > The destination path for the generation.
+    - `Looking good. Shall I go ahead and create your new bot?`
+        > Final confirmation for creating the desired bot.
+
+
+### Generate the sample using CLI parameters
+
+| Option                            | Description                                                                                                  |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------------|
+| -n, --botName <name>              | name of new bot (by default takes `enterprise-bot`)                                                          |
+| -d, --botDesc <description>       | description of the new bot (by default takes `Demonstrate advanced capabilities of a Conversational AI bot`) |
+| -l, --botLang <language>          | language for the new bot. Possible values are `de`, `en`, `es`, `fr`, `it`, `zh` (by default takes `en`)     |
+| -p, --botGenerationPath <path>    | destination path for the new bot (by default takes the path where you are runnning the generator)            |
+| --noPrompt                        | indicates to avoid the prompts                                                                               |
+
+**NOTE:** If you don't use the _--noPrompt_ option, the process will keep prompting, but using the input values by default.
+
+#### Example
+
+```bash
+> yo botbuilder-enterprise -n newBot -d "A description for my new bot" -l en -p "\aPath" --noPrompt
+```
+
+After this, you can check the summary in your screen:
+```bash
+- Name: <aName>
+- Description: <aDescription>
+- Language: <aLanguage>
+- Path: <aPath>
+```
+
+**WARNING:** The process will fail if it finds another folder with the same name of the new bot.
+
+**NOTE:** Remind to have an **unique** bot's name for deployment steps. 
+
+**NOTE:** After generating your sample, you can check its README for more information on how to deploy and test it. You can find it in the root folder of your newly created sample or [here](https://github.com/Microsoft/AI/blob/master/templates/Enterprise-Template/src/typescript/enterprise-bot/README.md).
+
+## License
+
+MIT © [Microsoft](http://dev.botframework.com)

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/README.md
@@ -1,0 +1,53 @@
+# Bot Builder Enterprise Dialog Generator
+
+## Generate dialog
+
+- Open a terminal in the desired folder for generating the dialog.
+- Run the following command for generating your new component.
+
+```bash
+> yo botbuilder-enterprise:dialog
+```
+#### **At this point you have two different options to procedure**
+
+### Generate the sample using prompts
+
+- The generator will start prompting for some information that is needed for generating the dialog:
+    - `What's the name of your dialog? (custom)`
+        > The name of your dialog (used also as the root folder's name).
+    - `Do you want to change the location of the generation?`
+        > A confirmation to change the destination for the generation.
+        - `Where do you want to generate the dialog? (by default takes the path where you are running the generator)`
+            > The destination path for the generation.
+    - `Looking good. Shall i go ahead and create your new dialog?`
+        > Final confirmation for creating the desired dialog.
+
+### Generate the dialog using CLI parameters
+
+
+| Option                               | Description                                                                                                  |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| -n, --dialogName <name>              | name of new dialog (by default takes `custom`)                                                               |
+| -p, --dialogGenerationPath <path>    | destination path for the new dialog (by default takes the path where you are runnning the generator)         |
+| --noPrompt                           | indicates to avoid the prompts                                                                               |
+
+**NOTE:** If you don't use the _--noPrompt_ option, the process will keep prompting, but using the input values by default.
+
+#### Example
+
+```bash
+> yo botbuilder-enterprise:dialog -n newDialog -p "\aPath" --noPrompt
+```
+
+After this, you can check the summary in your screen:
+
+```bash
+- Folder: <aDialogFolder>
+- Dialog file: <aDialogFile> (with .ts extension)
+- Responses file: <aResponsesFile> (with .ts extension)
+- Path: <aPath>
+```
+
+## License
+
+MIT © [Microsoft](http://dev.botframework.com)


### PR DESCRIPTION
## Description
- Update the README of the generator folder to redirect the user to each generator's documentation
- Create and update the instructions of the README for Bot Builder Enterprise Generator
- Create and add the instructions of the README for Bot Builder Enterprise Dialog Generator

## Related Issue
Fix #675 

## Testing Steps
1. Go to `AI/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/`
2. Read the new instructions in the README and check each Generator's READMEs.

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
- [x] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
