### PR TITLE
[Enterprise Bot Template][TypeScript] Fix TSLint Warnings

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/deploymentScripts/webConfigPrep.js
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/deploymentScripts/webConfigPrep.js
@@ -5,17 +5,17 @@
 // This script is run as part of the Post Deploy step when
 // deploying the bot to Azure.  It ensures the Azure Web App
 // is configured correctly to host a TypeScript authored bot.
-const fs = require('fs');
-const path = require('path');
-const replace = require('replace');
-const WEB_CONFIG_FILE = path.join(__dirname, '..', 'web.config');
+const fs = require("fs");
+const path = require("path");
+const replace = require("replace");
+const WEB_CONFIG_FILE = path.join(__dirname, "..", "web.config");
 
 if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
-    replace({
-        regex: "url=\"index.js\"",
-        replacement: "url=\"lib/index.js\"",
-        paths: [ WEB_CONFIG_FILE ],
-        recursive: false,
-        silent: true,
-    })
+  replace({
+    regex: 'url="index.js"',
+    replacement: 'url="lib/index.js"',
+    paths: [WEB_CONFIG_FILE],
+    recursive: false,
+    silent: true
+  });
 }

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
@@ -108,6 +108,7 @@
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/@types/documentdb/-/documentdb-1.10.5.tgz",
             "integrity": "sha512-FHQV9Nc1ffrLkQxO0zFlDCRPyHZtuKmAAuJIi278COhtkKBuBRuKOzoO3JlT0yfUrivPjAzNae+gh9fS++r0Ag==",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -616,9 +617,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.40",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
-            "integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ=="
+            "version": "1.6.41",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
+            "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
         },
         "bignumber.js": {
             "version": "7.2.1",
@@ -700,6 +701,27 @@
                     "version": "9.6.41",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.41.tgz",
                     "integrity": "sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA=="
+                },
+                "documentdb": {
+                    "version": "1.14.5",
+                    "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.14.5.tgz",
+                    "integrity": "sha512-0nDoQQiq5jzGIxOQF2y2bUOrFYehvk9pIrXy0dscXc3JsepNYhNVmjIsug5sgYPbt+XUYtMXpsfjzGCnYgNXgw==",
+                    "requires": {
+                        "big-integer": "^1.6.25",
+                        "binary-search-bounds": "2.0.3",
+                        "int64-buffer": "^0.1.9",
+                        "priorityqueuejs": "1.0.0",
+                        "semaphore": "1.0.5",
+                        "tunnel": "0.0.5",
+                        "underscore": "1.8.3"
+                    },
+                    "dependencies": {
+                        "semaphore": {
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",
+                            "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+                        }
+                    }
                 }
             }
         },
@@ -1300,12 +1322,13 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "documentdb": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.14.5.tgz",
-            "integrity": "sha512-0nDoQQiq5jzGIxOQF2y2bUOrFYehvk9pIrXy0dscXc3JsepNYhNVmjIsug5sgYPbt+XUYtMXpsfjzGCnYgNXgw==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.15.1.tgz",
+            "integrity": "sha512-6cqQorYaPFLEiyfylw93PE5WmnMXfiEWGW0pABx0t5BF2L8jdkHNFPcLKyOvXH1e8WDyqo/K3QTDQ+QcBrEoEg==",
             "requires": {
                 "big-integer": "^1.6.25",
                 "binary-search-bounds": "2.0.3",
+                "debug": "^4.1.0",
                 "int64-buffer": "^0.1.9",
                 "priorityqueuejs": "1.0.0",
                 "semaphore": "1.0.5",
@@ -1313,6 +1336,19 @@
                 "underscore": "1.8.3"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                },
                 "semaphore": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package-lock.json
@@ -1862,12 +1862,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1882,17 +1884,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2009,7 +2014,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2021,6 +2027,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2035,6 +2042,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2042,12 +2050,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2066,6 +2076,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2146,7 +2157,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2158,6 +2170,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2279,6 +2292,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
@@ -8,16 +8,16 @@
     "scripts": {
         "clean": "rimraf ./lib",
         "copy-templates": "copyfiles --up 1 ./src/**/*.json ./lib",
-        "build": "npm run lint && tsc --p tsconfig.json && npm run copy-templates",
+        "prebuild": "npm run lint",
+        "build": "tsc --p tsconfig.json && npm run copy-templates",
         "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
-        "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "lint": "tslint -t vso ./src/**/*.ts",
+        "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",
-        "@types/documentdb": "1.10.5",
         "@microsoft/microsoft-graph-types": "^1.5.0",
         "applicationinsights": "^1.0.4",
         "azure-cognitiveservices-contentmoderator": "^4.0.0",
@@ -28,6 +28,7 @@
         "botbuilder-dialogs": "^4.2.0",
         "botframework-config": "^4.0.6",
         "botframework-schema": "^4.0.6",
+        "documentdb": "^1.10.5",
         "dotenv": "^6.0.0",
         "i18n": "^0.8.3",
         "ms-rest-azure": "^2.5.0",
@@ -35,6 +36,7 @@
         "mocha": "^5.2.0"
     },
     "devDependencies": {
+        "@types/documentdb": "1.10.5",
         "@types/dotenv": "^4.0.3",
         "@types/i18n": "^0.8.3",
         "@types/node": "^10.10.1",

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/authentication/authenticationDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/authentication/authenticationDialog.ts
@@ -25,6 +25,7 @@ export class AuthenticationDialog extends ComponentDialog {
         this.initialDialogId = AuthenticationDialog.name;
         this.CONNECTION_NAME = connectionName;
 
+        // tslint:disable-next-line:no-any
         const authenticate: ((sc: WaterfallStepContext<{}>) => Promise<DialogTurnResult<any>>)[] = [
             this.prompToLogin.bind(this),
             this.finishLoginhDialog.bind(this)

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/authentication/authenticationResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/authentication/authenticationResponses.ts
@@ -24,7 +24,8 @@ export class AuthenticationResponses extends TemplateManager {
     private static readonly RESPONSE_TEMPLATES: LanguageTemplateDictionary = new Map([
         ['default', new Map([
             [AuthenticationResponses.RESPONSE_IDS.LoginPrompt, AuthenticationResponses.fromResources('authentication.prompt')],
-            [AuthenticationResponses.RESPONSE_IDS.SucceededMessage, async (data: any) => {
+            // tslint:disable-next-line:no-any
+            [AuthenticationResponses.RESPONSE_IDS.SucceededMessage, async (data: any): Promise<string> => {
                 const value: string = i18n.__('authentication.succeeded');
 
                 return value.replace('{0}', data.name);

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/cancel/cancelDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/cancel/cancelDialog.ts
@@ -40,6 +40,7 @@ export class CancelDialog extends ComponentDialog {
         return sc.endDialog(<boolean> sc.result);
     }
 
+    // tslint:disable-next-line:no-any
     protected async endComponent(outerDC: DialogContext, result: any): Promise<DialogTurnResult> {
         const doCancel: boolean = result;
 

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/escalate/escalateDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/escalate/escalateDialog.ts
@@ -18,6 +18,7 @@ export class EscalateDialog extends EnterpriseDialog {
         super(botServices, EscalateDialog.name);
         this.initialDialogId = EscalateDialog.name;
 
+        // tslint:disable-next-line:no-any
         const escalate: ((sc: WaterfallStepContext<{}>) => Promise<DialogTurnResult<any>>)[] = [
             EscalateDialog.sendPhone.bind(this)
         ];

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
@@ -6,16 +6,18 @@ import {
     RecognizerResult,
     StatePropertyAccessor,
     UserState} from 'botbuilder';
-import { LuisRecognizer } from 'botbuilder-ai';
+import {
+        LuisRecognizer,
+        QnAMakerResult } from 'botbuilder-ai';
 import { DialogContext } from 'botbuilder-dialogs';
 import { BotServices } from '../../botServices';
+import { TelemetryLuisRecognizer } from '../../middleware/telemetry/telemetryLuisRecognizer';
+import { TelemetryQnAMaker } from '../../middleware/telemetry/telemetryQnAMaker';
 import { EscalateDialog } from '../escalate/escalateDialog';
 import { OnboardingDialog } from '../onboarding/onboardingDialog';
 import { IOnboardingState } from '../onboarding/onboardingState';
 import { RouterDialog } from '../shared/routerDialog';
 import { MainResponses } from './mainResponses';
-import { TelemetryLuisRecognizer } from '../../middleware/telemetry/telemetryLuisRecognizer';
-import { TelemetryQnAMaker } from '../../middleware/telemetry/telemetryQnAMaker';
 
 export class MainDialog extends RouterDialog {
 
@@ -91,7 +93,7 @@ export class MainDialog extends RouterDialog {
             if (!qnaService) {
                 return Promise.reject(new Error('The specified QnA Maker Service could not be found in your Bot Services configuration.'));
             } else {
-                const answers: any = await qnaService.getAnswersAsync(dc.context);
+                const answers: QnAMakerResult[] = await qnaService.getAnswersAsync(dc.context);
 
                 if (answers && answers.length !== 0) {
                     await dc.context.sendActivity(answers[0].answer);
@@ -102,6 +104,7 @@ export class MainDialog extends RouterDialog {
             if (!qnaService) {
                 return Promise.reject(new Error('The specified QnA Maker Service could not be found in your Bot Services configuration.'));
         } else {
+                // tslint:disable-next-line:no-any
                 const answers: any = await qnaService.getAnswersAsync(dc.context);
 
                 if (answers && answers.length !== 0) {
@@ -117,6 +120,7 @@ export class MainDialog extends RouterDialog {
     protected onEvent(dc: DialogContext): Promise<void> {
         // Check if there was an action submitted from intro card
         if (dc.context.activity.value) {
+            // tslint:disable-next-line:no-any
             const value: any = dc.context.activity.value;
             if (value.action === 'startOnboarding') {
                 dc.beginDialog(OnboardingDialog.name);

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainResponses.ts
@@ -41,8 +41,10 @@ export class MainResponses extends TemplateManager {
             [MainResponses.RESPONSE_IDS.Confused, MainResponses.fromResources('main.confused')],
             [MainResponses.RESPONSE_IDS.Greeting, MainResponses.fromResources('main.greeting')],
             [MainResponses.RESPONSE_IDS.Help,
+                // tslint:disable-next-line:no-any
                 (context: TurnContext, data: any): Promise<Activity> => MainResponses.BUILD_HELP_CARD(context, data)],
             [MainResponses.RESPONSE_IDS.Intro,
+                // tslint:disable-next-line:no-any
                 (context: TurnContext, data: any): Promise<Activity> => MainResponses.BUILD_INTRO_CARD(context, data)]
         ])]
     ]);
@@ -52,8 +54,10 @@ export class MainResponses extends TemplateManager {
         this.register(new DictionaryRenderer(MainResponses.RESPONSE_TEMPLATES));
     }
 
+    // tslint:disable-next-line:no-any
     public static BUILD_INTRO_CARD(turnContext: TurnContext, data: any): Promise<Activity> {
         const introPath: string = i18n.__('main.introPath');
+        // tslint:disable-next-line:no-any non-literal-require
         const introCard: any = require(introPath);
         const attachment: Attachment = CardFactory.adaptiveCard(introCard);
         const response: Partial<Activity> = MessageFactory.attachment(attachment, '', attachment.content.speak, InputHints.AcceptingInput);
@@ -82,6 +86,7 @@ export class MainResponses extends TemplateManager {
         return Promise.resolve(<Activity> response);
     }
 
+    // tslint:disable-next-line:no-any
     public static async BUILD_HELP_CARD(turnContext: TurnContext, data: any): Promise<Activity> {
         const title: string = i18n.__('main.helpTitle');
         const text: string = i18n.__('main.helpText');

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/onboarding/onboardingDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/onboarding/onboardingDialog.ts
@@ -28,6 +28,7 @@ export class OnboardingDialog extends EnterpriseDialog {
         this.ACCESSOR = accessor;
         this.initialDialogId = OnboardingDialog.name;
 
+        // tslint:disable-next-line:no-any
         const onboarding: ((sc: WaterfallStepContext<IOnboardingState>) => Promise<DialogTurnResult<any>>)[] = [
             this.askForName.bind(this),
             this.askForEmail.bind(this),

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/onboarding/onboardingResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/onboarding/onboardingResponses.ts
@@ -31,18 +31,21 @@ export class OnboardingResponses extends TemplateManager {
     private static readonly RESPONSE_TEMPLATES: LanguageTemplateDictionary = new Map([
         ['default', new Map([
             [OnboardingResponses.RESPONSE_IDS.NamePrompt, OnboardingResponses.fromResources('onBoarding.namePrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveNameMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveName');
 
                 return value.replace('{0}', data.name);
             }],
             [OnboardingResponses.RESPONSE_IDS.EmailPrompt, OnboardingResponses.fromResources('onBoarding.emailPrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveEmailMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveEmail');
 
                 return value.replace('{0}', data.email);
             }],
             [OnboardingResponses.RESPONSE_IDS.LocationPrompt, OnboardingResponses.fromResources('onBoarding.locationPrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveLocationMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveLocation');
 

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/shared/routerDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/shared/routerDialog.ts
@@ -29,6 +29,7 @@ export abstract class RouterDialog extends ComponentDialog {
                 if (activity.value !== undefined) {
                     await this.onEvent(dc);
                 } else if (typeof activity.text !== undefined && activity.text) {
+                    // tslint:disable-next-line:no-any
                     const result: DialogTurnResult<any> = await dc.continueDialog();
                     switch (result.status) {
                         case DialogTurnStatus.empty: {
@@ -77,7 +78,7 @@ export abstract class RouterDialog extends ComponentDialog {
     /**
      * Called when an event activity is received.
      * @param innerDC - The dialog context for the component.
-     * @returns A Promise representing the asynchronous operation. 
+     * @returns A Promise representing the asynchronous operation.
      */
     protected onEvent(innerDC: DialogContext): Promise<void> {
         return Promise.resolve();

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/ITemplateRenderer.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/ITemplateRenderer.ts
@@ -15,5 +15,6 @@ export interface ITemplateRenderer {
      * @param templateId - template to render
      * @param data - data object to use to render
      */
+    // tslint:disable-next-line:no-any
     renderTemplate(turnContext: TurnContext, language: string, templateId: string, data: any): Promise<any>;
 }

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/dictionaryRenderer.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/dictionaryRenderer.ts
@@ -4,6 +4,7 @@
 import { TurnContext } from 'botbuilder-core';
 import { ITemplateRenderer } from './ITemplateRenderer';
 
+// tslint:disable-next-line:no-any
 export declare type TemplateFunction = (turnContext: TurnContext, data: any) => Promise<any>;
 
 /**
@@ -35,11 +36,13 @@ export class DictionaryRenderer implements ITemplateRenderer {
         this.LANGUAGES = templates;
     }
 
+    // tslint:disable-next-line:no-any
     public renderTemplate(turnContext: TurnContext, language: string, templateId: string, data: any): Promise<any> {
         const templates: TemplateIdMap | undefined = this.LANGUAGES.get(language);
         if (templates) {
             const template: TemplateFunction | undefined = templates.get(templateId);
             if (template) {
+                // tslint:disable-next-line:no-any
                 const result: Promise<any> = template(turnContext, data);
                 if (result) {
                     return result;

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/templateManager.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/templateManager/templateManager.ts
@@ -40,6 +40,7 @@ export class TemplateManager {
     /**
      * Send a reply with the template
      */
+    // tslint:disable-next-line:no-any
     public async replyWith(turnContext: TurnContext, templateId: string, data?: any): Promise<void> {
         if (!turnContext) { throw new Error('turnContext is null'); }
 
@@ -56,6 +57,7 @@ export class TemplateManager {
 
     public async renderTemplate(turnContext: TurnContext,
                                 templateId: string,
+                                // tslint:disable-next-line:no-any
                                 language?: string, data?: any): Promise<Activity | undefined> {
         const fallbackLocales: string[] = this.LANGUAGE_FALLBACK;
 
@@ -68,6 +70,7 @@ export class TemplateManager {
         // try each locale until successful
         for (const locale of fallbackLocales) {
             for (const renderer of this.TEMPLATE_RENDERS) {
+                // tslint:disable-next-line:no-any
                 const templateOutput: any = await renderer.renderTemplate(turnContext, locale, templateId, data);
                 if (templateOutput) {
                     if (typeof templateOutput === 'string' || templateOutput instanceof String) {

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/enterpriseBot.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/enterpriseBot.ts
@@ -44,6 +44,7 @@ export class EnterpriseBot {
      */
     public async onTurn(turnContext: TurnContext): Promise<void> {
         const dc: DialogContext = await this.DIALOGS.createContext(turnContext);
+        // tslint:disable-next-line:no-any
         const result: DialogTurnResult<any> = await dc.continueDialog();
 
         if (result.status === DialogTurnStatus.empty) {

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
@@ -35,7 +35,6 @@ import { BotServices } from './botServices';
 import { EnterpriseBot } from './enterpriseBot';
 // Content Moderation Middleware (analyzes incoming messages for inappropriate content including PII, profanity, etc.)
 import { ContentModeratorMiddleware } from './middleware/contentModeratorMiddleware';
-import { RequestPolicyOptions } from 'ms-rest-js';
 
 i18n.configure({
     directory: path.join(__dirname, 'locales'),
@@ -71,7 +70,7 @@ const ADAPTER: BotFrameworkAdapter = new BotFrameworkAdapter({
     appPassword: ENDPOINT_CONFIG.appPassword || process.env.microsoftAppPassword
 });
 
-import { TelemetryLoggerMiddleware } from "./middleware/telemetry/telemetryLoggerMiddleware";
+import { TelemetryLoggerMiddleware } from './middleware/telemetry/telemetryLoggerMiddleware';
 // Get AppInsights configuration by service name
 const APPINSIGHTS_CONFIGURATION: string = process.env.APPINSIGHTS_NAME || '';
 const APPINSIGHTS_CONFIG: IAppInsightsService = <IAppInsightsService> BOT_CONFIG.findServiceByNameOrId(APPINSIGHTS_CONFIGURATION);
@@ -82,18 +81,18 @@ if (!APPINSIGHTS_CONFIG) {
 const TELEMETRY_CLIENT: TelemetryClient = new TelemetryClient(APPINSIGHTS_CONFIG.instrumentationKey);
 
 ADAPTER.onTurnError = async (turnContext: TurnContext, error: Error): Promise<void> => {
-let appInsightsLogger = new TelemetryLoggerMiddleware( TELEMETRY_CLIENT, true,  true);
+const appInsightsLogger: TelemetryLoggerMiddleware = new TelemetryLoggerMiddleware(TELEMETRY_CLIENT, true,  true);
 ADAPTER.use(appInsightsLogger);
 
-
-    // CAUTION:  The sample simply logs the error to the console.
-    console.error(error);
-    // For production bots, use AppInsights or similar telemetry system.
-    // tell the user something happen
-    TELEMETRY_CLIENT.trackException({ exception: error });
-    // for multi-turn dialog interactions,
-    // make sure we clear the conversation state
-    await turnContext.sendActivity('Sorry, it looks like something went wrong.');
+// CAUTION:  The sample simply logs the error to the console.
+// tslint:disable-next-line:no-console
+console.error(error);
+// For production bots, use AppInsights or similar telemetry system.
+// tell the user something happen
+TELEMETRY_CLIENT.trackException({ exception: error });
+// for multi-turn dialog interactions,
+// make sure we clear the conversation state
+await turnContext.sendActivity('Sorry, it looks like something went wrong.');
 };
 
 // CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
@@ -112,10 +111,11 @@ const COSMOS_DB_STORAGE_SETTINGS: CosmosDbStorageSettings = {
     serviceEndpoint: COSMOS_CONFIG.endpoint,
     databaseCreationRequestOptions: REQUEST_OPTIONS ,
     documentCollectionRequestOptions: REQUEST_OPTIONS
-}
+};
 const STORAGE: CosmosDbStorage  = new CosmosDbStorage(COSMOS_DB_STORAGE_SETTINGS);
 
 if (!COSMOS_CONFIG) {
+    // tslint:disable-next-line:no-console
     console.log('Please configure your CosmosDB connection in your .bot file.');
     process.exit(BOT_CONFIGURATION_ERROR);
 }
@@ -132,6 +132,7 @@ ADAPTER.use(new AutoSaveStateMiddleware(CONVERSATION_STATE, USER_STATE));
 const BLOB_CONFIGURATION: string = process.env.BLOB_NAME || ''; // this is the name of the BlobStorage configuration in your .bot file
 const BLOB_STORAGE_CONFIG: IBlobStorageService = <IBlobStorageService> BOT_CONFIG.findServiceByNameOrId(BLOB_CONFIGURATION);
 if (!BLOB_STORAGE_CONFIG) {
+    // tslint:disable-next-line:no-console
     console.log('Please configure your Blob storage connection in your .bot file.');
     process.exit(BOT_CONFIGURATION_ERROR);
 }
@@ -172,8 +173,11 @@ try {
 // Create server
 const SERVER: restify.Server = restify.createServer();
 SERVER.listen(process.env.port || process.env.PORT || 3978, (): void => {
+    // tslint:disable-next-line:no-console
     console.log(`${SERVER.name} listening to ${SERVER.url}`);
+    // tslint:disable-next-line:no-console
     console.log(`Get the Emulator: https://aka.ms/botframework-emulator`);
+    // tslint:disable-next-line:no-console
     console.log(`To talk to your bot, open your '.bot' file in the Emulator`);
 });
 

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
@@ -1,53 +1,55 @@
-import { TelemetryClient } from "applicationinsights";
-import { DateTimePrompt } from "botbuilder-dialogs";
-import { start } from "repl";
-import { duration } from "moment";
+import { TelemetryClient } from 'applicationinsights';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
-   
-   export class TelemetryBotDependencyExtension
-    {
-        public static DependencyType: string = "Bot";
-     
-        /**
-         * Send information about a dependency in the Bot Application.
-         * TypeParam <TResult> The type of the return value of the method that this delegate encapsulates.
-         * The action delegate will be timed and an Application Insights dependency record will be created.
-         * @param {TelemetryClient} telemetryClient - The TelemetryClient.
-         * @param {TResult} action - Encapsulates a method that has no parameters and returns a value of the type specified by the TResult parameter.
-         * @param {string} dependencyName - Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.
-         * @param {string} dependencyData - Command initiated by this dependency call. For example, Middleware.
-         * @returns The return value of the method that this delegate encapsulates.
-         */
-          public static trackBotDependency<TResult>(telemetryClient: TelemetryClient, action: () => TResult, dependencyName: string, dependencyData: string): TResult {
-          // return action();
 
-           if (dependencyName === null) {
-             throw new Error("Missing parameter, dependencyName is required"); 
-           }
-           var startTime = Date.now();         
-           var success = true;
+export namespace TelemetryBotDependencyExtension {
 
-           try {
-               return action();
-           }
-           catch (Exception) {
-               success = false;
-               throw Exception;
-           }
-           finally {
-               var endTime = Date.now();
-               let duration = endTime - startTime;
-               // Log the dependency into Application Insights
-               telemetryClient.trackDependency({
-                   dependencyTypeName: TelemetryBotDependencyExtension.DependencyType,
-                   name: dependencyName,
-                   data: dependencyData,
-                   success: success,
-                   duration: duration,
-                   resultCode: 0
-               });
-           }
-       }
+    const DEPENDENCY_TYPE: string = 'Bot';
+
+    /**
+     * Send information about a dependency in the Bot Application.
+     * TypeParam <TResult> The type of the return value of the method that this delegate encapsulates.
+     * The action delegate will be timed and an Application Insights dependency record will be created.
+     * @param telemetryClient - The TelemetryClient.
+     * @param action - Encapsulates a method that has no parameters and returns a value of the type specified by the TResult parameter.
+     * @param dependencyName
+     * - Name of the command initiated with this dependency call.
+     *   Low cardinality value.
+     *   Examples are stored procedure name and URL path template.
+     * @param dependencyData - Command initiated by this dependency call. For example, Middleware.
+     * @returns The return value of the method that this delegate encapsulates.
+     */
+    export function trackBotDependency<TResult>(
+            telemetryClient: TelemetryClient,
+            action: () => TResult,
+            dependencyName: string,
+            dependencyData: string): TResult {
+
+        if (dependencyName === null) {
+            throw new Error('Missing parameter, dependencyName is required');
+        }
+        const startTime: number = Date.now();
+        let success: boolean = true;
+
+        try {
+            return action();
+        } catch (err) {
+            success = false;
+            throw err;
+        }
+        finally {
+            const endTime: number = Date.now();
+            const duration: number = endTime - startTime;
+            // Log the dependency into Application Insights
+            telemetryClient.trackDependency({
+                dependencyTypeName: DEPENDENCY_TYPE,
+                name: dependencyName,
+                data: dependencyData,
+                success: success,
+                duration: duration,
+                resultCode: 0
+            });
+        }
     }
+}

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryLuisRecognizer.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryLuisRecognizer.ts
@@ -73,7 +73,8 @@ export class TelemetryLuisRecognizer extends LuisRecognizer {
             dialogContext.activeDialog ? dialogContext.activeDialog.id : undefined);
     }
     /**
-     * Return results of the analysis (Suggested actions and intents), using the turn context. This is missing a dialog id used for telemetry.
+     * Return results of the analysis (Suggested actions and intents), using the turn context.
+     * This is missing a dialog id used for telemetry.
      * @param context - Context object containing information for a single turn of conversation with a user.
      * @param logOriginalMessage - Determines if the original message is logged into Application Insights.  This is a privacy consideration.
      * @returns The LUIS results of the analysis of the current message text in the current turn's context activity.

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/serviceClients/graphClient.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/serviceClients/graphClient.ts
@@ -1,22 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-import { Client, GraphError } from '@microsoft/microsoft-graph-client';
+import {
+    AuthProviderCallback,
+    Client,
+    GraphError } from '@microsoft/microsoft-graph-client';
 import { User } from '@microsoft/microsoft-graph-types';
 
 export class GraphClient {
-    private readonly _token: string;
+    private readonly TOKEN: string;
 
-    constructor(token: string) {
-        this._token = token;
+    constructor(TOKEN: string) {
+        this.TOKEN = TOKEN;
     }
 
     public getMe(): Promise<User> {
-        return new Promise((resolve, reject) => {
-            const client = this.getAuthenticatedClient();
-            client.api('/me').select('displayName')
+        // tslint:disable-next-line:no-any
+        return new Promise((resolve: (value?: User | PromiseLike<User> | undefined) => any, reject: (reason?: any) => void): void => {
+            const client: Client = this.getAuthenticatedClient();
+            client.api('/me')
+                  .select('displayName')
             .get((err: GraphError, res: User) => {
                 if (err) { return reject(err); }
+
                 return resolve(res);
             });
         });
@@ -24,8 +30,8 @@ export class GraphClient {
 
     private getAuthenticatedClient(): Client {
         return Client.init({
-            authProvider: (done) => {
-                done(null, this._token);
+            authProvider: (done: AuthProviderCallback): void => {
+                done(undefined, this.TOKEN);
             }
         });
     }

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/tslint.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/tslint.json
@@ -1,14 +1,18 @@
 {
-    "defaultSeverity": "warning",
+    "defaultSeverity": "error",
     "extends": [
         "tslint:recommended",
         "tslint-microsoft-contrib"
     ],
     "linterOptions":{
-
+        "exclude": [
+          "src/dialogs/shared/resources/*"
+        ]
     },
     "rules": {
-      "member-ordering": [false]
+      "linebreak-style": [false],
+      "member-ordering": [false],
+      "no-relative-imports": [false]
     },
     "rulesDirectory": [
       "node_modules/tslint-microsoft-contrib"

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -314,7 +314,8 @@ module.exports = class extends Generator {
       "gitignore",
       "README.md",
       "tsconfig.json",
-      "deploymentScripts/webConfigPrep.js"
+      "deploymentScripts/webConfigPrep.js",
+      "tslint.json"
     ];
 
     commonFiles.forEach(fileName =>

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
@@ -8,16 +8,16 @@
     "scripts": {
         "clean": "rimraf ./lib",
         "copy-templates": "copyfiles --up 1 ./src/**/*.json ./lib",
-        "build": "npm run lint && tsc --p tsconfig.json && npm run copy-templates",
+        "prebuild": "npm run lint",
+        "build": "tsc --p tsconfig.json && npm run copy-templates",
         "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
-        "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "lint": "tslint -t vso ./src/**/*.ts",
+        "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",
-        "@types/documentdb": "1.10.5",
         "@microsoft/microsoft-graph-types": "^1.5.0",
         "applicationinsights": "^1.0.4",
         "azure-cognitiveservices-contentmoderator": "^4.0.0",
@@ -28,6 +28,7 @@
         "botbuilder-dialogs": "^4.2.0",
         "botframework-config": "^4.0.6",
         "botframework-schema": "^4.0.6",
+        "documentdb": "^1.10.5",
         "dotenv": "^6.0.0",
         "i18n": "^0.8.3",
         "ms-rest-azure": "^2.5.0",
@@ -35,6 +36,7 @@
         "mocha": "^5.2.0"
     },
     "devDependencies": {
+        "@types/documentdb": "1.10.5",
         "@types/dotenv": "^4.0.3",
         "@types/i18n": "^0.8.3",
         "@types/node": "^10.10.1",

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
@@ -5,17 +5,17 @@
 // This script is run as part of the Post Deploy step when
 // deploying the bot to Azure.  It ensures the Azure Web App
 // is configured correctly to host a TypeScript authored bot.
-const fs = require("fs");
-const path = require("path");
-const replace = require("replace");
-const WEB_CONFIG_FILE = path.join(__dirname, "..", "web.config");
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace');
+const WEB_CONFIG_FILE = path.join(__dirname, '..', 'web.config');
 
 if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
-  replace({
-    regex: 'url="index.js"',
-    replacement: 'url="lib/index.js"',
-    paths: [WEB_CONFIG_FILE],
-    recursive: false,
-    silent: true
-  });
+    replace({
+        regex: "url=\"index.js\"",
+        replacement: "url=\"lib/index.js\"",
+        paths: [ WEB_CONFIG_FILE ],
+        recursive: false,
+        silent: true,
+    })
 }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/deploymentScripts/webConfigPrep.js
@@ -5,17 +5,17 @@
 // This script is run as part of the Post Deploy step when
 // deploying the bot to Azure.  It ensures the Azure Web App
 // is configured correctly to host a TypeScript authored bot.
-const fs = require('fs');
-const path = require('path');
-const replace = require('replace');
-const WEB_CONFIG_FILE = path.join(__dirname, '..', 'web.config');
+const fs = require("fs");
+const path = require("path");
+const replace = require("replace");
+const WEB_CONFIG_FILE = path.join(__dirname, "..", "web.config");
 
 if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
-    replace({
-        regex: "url=\"index.js\"",
-        replacement: "url=\"lib/index.js\"",
-        paths: [ WEB_CONFIG_FILE ],
-        recursive: false,
-        silent: true,
-    })
+  replace({
+    regex: 'url="index.js"',
+    replacement: 'url="lib/index.js"',
+    paths: [WEB_CONFIG_FILE],
+    recursive: false,
+    silent: true
+  });
 }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/package-lock.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/package-lock.json
@@ -108,6 +108,7 @@
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/@types/documentdb/-/documentdb-1.10.5.tgz",
             "integrity": "sha512-FHQV9Nc1ffrLkQxO0zFlDCRPyHZtuKmAAuJIi278COhtkKBuBRuKOzoO3JlT0yfUrivPjAzNae+gh9fS++r0Ag==",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -616,9 +617,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.40",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
-            "integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ=="
+            "version": "1.6.41",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
+            "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
         },
         "bignumber.js": {
             "version": "7.2.1",
@@ -700,6 +701,27 @@
                     "version": "9.6.41",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.41.tgz",
                     "integrity": "sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA=="
+                },
+                "documentdb": {
+                    "version": "1.14.5",
+                    "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.14.5.tgz",
+                    "integrity": "sha512-0nDoQQiq5jzGIxOQF2y2bUOrFYehvk9pIrXy0dscXc3JsepNYhNVmjIsug5sgYPbt+XUYtMXpsfjzGCnYgNXgw==",
+                    "requires": {
+                        "big-integer": "^1.6.25",
+                        "binary-search-bounds": "2.0.3",
+                        "int64-buffer": "^0.1.9",
+                        "priorityqueuejs": "1.0.0",
+                        "semaphore": "1.0.5",
+                        "tunnel": "0.0.5",
+                        "underscore": "1.8.3"
+                    },
+                    "dependencies": {
+                        "semaphore": {
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",
+                            "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+                        }
+                    }
                 }
             }
         },
@@ -854,6 +876,11 @@
                     }
                 }
             }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
         },
         "browserify-mime": {
             "version": "1.2.9",
@@ -1292,16 +1319,16 @@
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "documentdb": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.14.5.tgz",
-            "integrity": "sha512-0nDoQQiq5jzGIxOQF2y2bUOrFYehvk9pIrXy0dscXc3JsepNYhNVmjIsug5sgYPbt+XUYtMXpsfjzGCnYgNXgw==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/documentdb/-/documentdb-1.15.1.tgz",
+            "integrity": "sha512-6cqQorYaPFLEiyfylw93PE5WmnMXfiEWGW0pABx0t5BF2L8jdkHNFPcLKyOvXH1e8WDyqo/K3QTDQ+QcBrEoEg==",
             "requires": {
                 "big-integer": "^1.6.25",
                 "binary-search-bounds": "2.0.3",
+                "debug": "^4.1.0",
                 "int64-buffer": "^0.1.9",
                 "priorityqueuejs": "1.0.0",
                 "semaphore": "1.0.5",
@@ -1309,6 +1336,19 @@
                 "underscore": "1.8.3"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                },
                 "semaphore": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",
@@ -1822,12 +1862,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1842,17 +1884,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1969,7 +2014,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1981,6 +2027,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1995,6 +2042,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2002,12 +2050,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2026,6 +2076,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2106,7 +2157,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2118,6 +2170,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2239,6 +2292,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2413,6 +2467,11 @@
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
         },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+        },
         "handle-thing": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
@@ -2452,8 +2511,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-value": {
             "version": "1.0.0",
@@ -2495,6 +2553,11 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -3287,6 +3350,52 @@
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "requires": {
                 "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "moment": {

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_enterpriseBot.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_enterpriseBot.ts
@@ -44,6 +44,7 @@ export class <%= botNameClass %> {
      */
     public async onTurn(turnContext: TurnContext): Promise<void> {
         const dc: DialogContext = await this.DIALOGS.createContext(turnContext);
+        // tslint:disable-next-line:no-any
         const result: DialogTurnResult<any> = await dc.continueDialog();
 
         if (result.status === DialogTurnStatus.empty) {

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_index.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_index.ts
@@ -35,7 +35,6 @@ import { BotServices } from './botServices';
 import { <%= botNameClass %> } from './<%= botNameFile %>';
 // Content Moderation Middleware (analyzes incoming messages for inappropriate content including PII, profanity, etc.)
 import { ContentModeratorMiddleware } from './middleware/contentModeratorMiddleware';
-import { RequestPolicyOptions } from 'ms-rest-js';
 
 i18n.configure({
     directory: path.join(__dirname, 'locales'),
@@ -71,7 +70,7 @@ const ADAPTER: BotFrameworkAdapter = new BotFrameworkAdapter({
     appPassword: ENDPOINT_CONFIG.appPassword || process.env.microsoftAppPassword
 });
 
-import { TelemetryLoggerMiddleware } from "./middleware/telemetry/telemetryLoggerMiddleware";
+import { TelemetryLoggerMiddleware } from './middleware/telemetry/telemetryLoggerMiddleware';
 // Get AppInsights configuration by service name
 const APPINSIGHTS_CONFIGURATION: string = process.env.APPINSIGHTS_NAME || '';
 const APPINSIGHTS_CONFIG: IAppInsightsService = <IAppInsightsService> BOT_CONFIG.findServiceByNameOrId(APPINSIGHTS_CONFIGURATION);
@@ -82,18 +81,18 @@ if (!APPINSIGHTS_CONFIG) {
 const TELEMETRY_CLIENT: TelemetryClient = new TelemetryClient(APPINSIGHTS_CONFIG.instrumentationKey);
 
 ADAPTER.onTurnError = async (turnContext: TurnContext, error: Error): Promise<void> => {
-let appInsightsLogger = new TelemetryLoggerMiddleware( TELEMETRY_CLIENT, true,  true);
+const appInsightsLogger: TelemetryLoggerMiddleware = new TelemetryLoggerMiddleware(TELEMETRY_CLIENT, true,  true);
 ADAPTER.use(appInsightsLogger);
 
-
-    // CAUTION:  The sample simply logs the error to the console.
-    console.error(error);
-    // For production bots, use AppInsights or similar telemetry system.
-    // tell the user something happen
-    TELEMETRY_CLIENT.trackException({ exception: error });
-    // for multi-turn dialog interactions,
-    // make sure we clear the conversation state
-    await turnContext.sendActivity('Sorry, it looks like something went wrong.');
+// CAUTION:  The sample simply logs the error to the console.
+// tslint:disable-next-line:no-console
+console.error(error);
+// For production bots, use AppInsights or similar telemetry system.
+// tell the user something happen
+TELEMETRY_CLIENT.trackException({ exception: error });
+// for multi-turn dialog interactions,
+// make sure we clear the conversation state
+await turnContext.sendActivity('Sorry, it looks like something went wrong.');
 };
 
 // CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
@@ -112,10 +111,11 @@ const COSMOS_DB_STORAGE_SETTINGS: CosmosDbStorageSettings = {
     serviceEndpoint: COSMOS_CONFIG.endpoint,
     databaseCreationRequestOptions: REQUEST_OPTIONS ,
     documentCollectionRequestOptions: REQUEST_OPTIONS
-}
+};
 const STORAGE: CosmosDbStorage  = new CosmosDbStorage(COSMOS_DB_STORAGE_SETTINGS);
 
 if (!COSMOS_CONFIG) {
+    // tslint:disable-next-line:no-console
     console.log('Please configure your CosmosDB connection in your .bot file.');
     process.exit(BOT_CONFIGURATION_ERROR);
 }
@@ -132,6 +132,7 @@ ADAPTER.use(new AutoSaveStateMiddleware(CONVERSATION_STATE, USER_STATE));
 const BLOB_CONFIGURATION: string = process.env.BLOB_NAME || ''; // this is the name of the BlobStorage configuration in your .bot file
 const BLOB_STORAGE_CONFIG: IBlobStorageService = <IBlobStorageService> BOT_CONFIG.findServiceByNameOrId(BLOB_CONFIGURATION);
 if (!BLOB_STORAGE_CONFIG) {
+    // tslint:disable-next-line:no-console
     console.log('Please configure your Blob storage connection in your .bot file.');
     process.exit(BOT_CONFIGURATION_ERROR);
 }
@@ -172,8 +173,11 @@ try {
 // Create server
 const SERVER: restify.Server = restify.createServer();
 SERVER.listen(process.env.port || process.env.PORT || 3978, (): void => {
+    // tslint:disable-next-line:no-console
     console.log(`${SERVER.name} listening to ${SERVER.url}`);
+    // tslint:disable-next-line:no-console
     console.log(`Get the Emulator: https://aka.ms/botframework-emulator`);
+    // tslint:disable-next-line:no-console
     console.log(`To talk to your bot, open your '.bot' file in the Emulator`);
 });
 

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/authentication/authenticationDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/authentication/authenticationDialog.ts
@@ -25,6 +25,7 @@ export class AuthenticationDialog extends ComponentDialog {
         this.initialDialogId = AuthenticationDialog.name;
         this.CONNECTION_NAME = connectionName;
 
+        // tslint:disable-next-line:no-any
         const authenticate: ((sc: WaterfallStepContext<{}>) => Promise<DialogTurnResult<any>>)[] = [
             this.prompToLogin.bind(this),
             this.finishLoginhDialog.bind(this)

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/authentication/authenticationResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/authentication/authenticationResponses.ts
@@ -24,7 +24,8 @@ export class AuthenticationResponses extends TemplateManager {
     private static readonly RESPONSE_TEMPLATES: LanguageTemplateDictionary = new Map([
         ['default', new Map([
             [AuthenticationResponses.RESPONSE_IDS.LoginPrompt, AuthenticationResponses.fromResources('authentication.prompt')],
-            [AuthenticationResponses.RESPONSE_IDS.SucceededMessage, async (data: any) => {
+            // tslint:disable-next-line:no-any
+            [AuthenticationResponses.RESPONSE_IDS.SucceededMessage, async (data: any): Promise<string> => {
                 const value: string = i18n.__('authentication.succeeded');
 
                 return value.replace('{0}', data.name);

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/cancel/cancelDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/cancel/cancelDialog.ts
@@ -40,6 +40,7 @@ export class CancelDialog extends ComponentDialog {
         return sc.endDialog(<boolean> sc.result);
     }
 
+    // tslint:disable-next-line:no-any
     protected async endComponent(outerDC: DialogContext, result: any): Promise<DialogTurnResult> {
         const doCancel: boolean = result;
 

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/escalate/escalateDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/escalate/escalateDialog.ts
@@ -18,6 +18,7 @@ export class EscalateDialog extends EnterpriseDialog {
         super(botServices, EscalateDialog.name);
         this.initialDialogId = EscalateDialog.name;
 
+        // tslint:disable-next-line:no-any
         const escalate: ((sc: WaterfallStepContext<{}>) => Promise<DialogTurnResult<any>>)[] = [
             EscalateDialog.sendPhone.bind(this)
         ];

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/main/mainDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/main/mainDialog.ts
@@ -6,16 +6,18 @@ import {
     RecognizerResult,
     StatePropertyAccessor,
     UserState} from 'botbuilder';
-import { LuisRecognizer } from 'botbuilder-ai';
+import {
+        LuisRecognizer,
+        QnAMakerResult } from 'botbuilder-ai';
 import { DialogContext } from 'botbuilder-dialogs';
 import { BotServices } from '../../botServices';
+import { TelemetryLuisRecognizer } from '../../middleware/telemetry/telemetryLuisRecognizer';
+import { TelemetryQnAMaker } from '../../middleware/telemetry/telemetryQnAMaker';
 import { EscalateDialog } from '../escalate/escalateDialog';
 import { OnboardingDialog } from '../onboarding/onboardingDialog';
 import { IOnboardingState } from '../onboarding/onboardingState';
 import { RouterDialog } from '../shared/routerDialog';
 import { MainResponses } from './mainResponses';
-import { TelemetryLuisRecognizer } from '../../middleware/telemetry/telemetryLuisRecognizer';
-import { TelemetryQnAMaker } from '../../middleware/telemetry/telemetryQnAMaker';
 
 export class MainDialog extends RouterDialog {
 
@@ -91,7 +93,7 @@ export class MainDialog extends RouterDialog {
             if (!qnaService) {
                 return Promise.reject(new Error('The specified QnA Maker Service could not be found in your Bot Services configuration.'));
             } else {
-                const answers: any = await qnaService.getAnswersAsync(dc.context);
+                const answers: QnAMakerResult[] = await qnaService.getAnswersAsync(dc.context);
 
                 if (answers && answers.length !== 0) {
                     await dc.context.sendActivity(answers[0].answer);
@@ -102,6 +104,7 @@ export class MainDialog extends RouterDialog {
             if (!qnaService) {
                 return Promise.reject(new Error('The specified QnA Maker Service could not be found in your Bot Services configuration.'));
         } else {
+                // tslint:disable-next-line:no-any
                 const answers: any = await qnaService.getAnswersAsync(dc.context);
 
                 if (answers && answers.length !== 0) {
@@ -117,6 +120,7 @@ export class MainDialog extends RouterDialog {
     protected onEvent(dc: DialogContext): Promise<void> {
         // Check if there was an action submitted from intro card
         if (dc.context.activity.value) {
+            // tslint:disable-next-line:no-any
             const value: any = dc.context.activity.value;
             if (value.action === 'startOnboarding') {
                 dc.beginDialog(OnboardingDialog.name);

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/main/mainResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/main/mainResponses.ts
@@ -41,8 +41,10 @@ export class MainResponses extends TemplateManager {
             [MainResponses.RESPONSE_IDS.Confused, MainResponses.fromResources('main.confused')],
             [MainResponses.RESPONSE_IDS.Greeting, MainResponses.fromResources('main.greeting')],
             [MainResponses.RESPONSE_IDS.Help,
+                // tslint:disable-next-line:no-any
                 (context: TurnContext, data: any): Promise<Activity> => MainResponses.BUILD_HELP_CARD(context, data)],
             [MainResponses.RESPONSE_IDS.Intro,
+                // tslint:disable-next-line:no-any
                 (context: TurnContext, data: any): Promise<Activity> => MainResponses.BUILD_INTRO_CARD(context, data)]
         ])]
     ]);
@@ -52,8 +54,10 @@ export class MainResponses extends TemplateManager {
         this.register(new DictionaryRenderer(MainResponses.RESPONSE_TEMPLATES));
     }
 
+    // tslint:disable-next-line:no-any
     public static BUILD_INTRO_CARD(turnContext: TurnContext, data: any): Promise<Activity> {
         const introPath: string = i18n.__('main.introPath');
+        // tslint:disable-next-line:no-any non-literal-require
         const introCard: any = require(introPath);
         const attachment: Attachment = CardFactory.adaptiveCard(introCard);
         const response: Partial<Activity> = MessageFactory.attachment(attachment, '', attachment.content.speak, InputHints.AcceptingInput);
@@ -82,6 +86,7 @@ export class MainResponses extends TemplateManager {
         return Promise.resolve(<Activity> response);
     }
 
+    // tslint:disable-next-line:no-any
     public static async BUILD_HELP_CARD(turnContext: TurnContext, data: any): Promise<Activity> {
         const title: string = i18n.__('main.helpTitle');
         const text: string = i18n.__('main.helpText');

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/onboarding/onboardingDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/onboarding/onboardingDialog.ts
@@ -28,6 +28,7 @@ export class OnboardingDialog extends EnterpriseDialog {
         this.ACCESSOR = accessor;
         this.initialDialogId = OnboardingDialog.name;
 
+        // tslint:disable-next-line:no-any
         const onboarding: ((sc: WaterfallStepContext<IOnboardingState>) => Promise<DialogTurnResult<any>>)[] = [
             this.askForName.bind(this),
             this.askForEmail.bind(this),

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/onboarding/onboardingResponses.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/onboarding/onboardingResponses.ts
@@ -31,18 +31,21 @@ export class OnboardingResponses extends TemplateManager {
     private static readonly RESPONSE_TEMPLATES: LanguageTemplateDictionary = new Map([
         ['default', new Map([
             [OnboardingResponses.RESPONSE_IDS.NamePrompt, OnboardingResponses.fromResources('onBoarding.namePrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveNameMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveName');
 
                 return value.replace('{0}', data.name);
             }],
             [OnboardingResponses.RESPONSE_IDS.EmailPrompt, OnboardingResponses.fromResources('onBoarding.emailPrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveEmailMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveEmail');
 
                 return value.replace('{0}', data.email);
             }],
             [OnboardingResponses.RESPONSE_IDS.LocationPrompt, OnboardingResponses.fromResources('onBoarding.locationPrompt')],
+            // tslint:disable-next-line:no-any
             [OnboardingResponses.RESPONSE_IDS.HaveLocationMessage, async (context: TurnContext, data: any): Promise<string> => {
                 const value: string = i18n.__('onBoarding.haveLocation');
 

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/shared/routerDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/shared/routerDialog.ts
@@ -29,6 +29,7 @@ export abstract class RouterDialog extends ComponentDialog {
                 if (activity.value !== undefined) {
                     await this.onEvent(dc);
                 } else if (typeof activity.text !== undefined && activity.text) {
+                    // tslint:disable-next-line:no-any
                     const result: DialogTurnResult<any> = await dc.continueDialog();
                     switch (result.status) {
                         case DialogTurnStatus.empty: {
@@ -77,7 +78,7 @@ export abstract class RouterDialog extends ComponentDialog {
     /**
      * Called when an event activity is received.
      * @param innerDC - The dialog context for the component.
-     * @returns A Promise representing the asynchronous operation. 
+     * @returns A Promise representing the asynchronous operation.
      */
     protected onEvent(innerDC: DialogContext): Promise<void> {
         return Promise.resolve();

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/ITemplateRenderer.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/ITemplateRenderer.ts
@@ -15,5 +15,6 @@ export interface ITemplateRenderer {
      * @param templateId - template to render
      * @param data - data object to use to render
      */
+    // tslint:disable-next-line:no-any
     renderTemplate(turnContext: TurnContext, language: string, templateId: string, data: any): Promise<any>;
 }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/dictionaryRenderer.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/dictionaryRenderer.ts
@@ -4,6 +4,7 @@
 import { TurnContext } from 'botbuilder-core';
 import { ITemplateRenderer } from './ITemplateRenderer';
 
+// tslint:disable-next-line:no-any
 export declare type TemplateFunction = (turnContext: TurnContext, data: any) => Promise<any>;
 
 /**
@@ -35,11 +36,13 @@ export class DictionaryRenderer implements ITemplateRenderer {
         this.LANGUAGES = templates;
     }
 
+    // tslint:disable-next-line:no-any
     public renderTemplate(turnContext: TurnContext, language: string, templateId: string, data: any): Promise<any> {
         const templates: TemplateIdMap | undefined = this.LANGUAGES.get(language);
         if (templates) {
             const template: TemplateFunction | undefined = templates.get(templateId);
             if (template) {
+                // tslint:disable-next-line:no-any
                 const result: Promise<any> = template(turnContext, data);
                 if (result) {
                     return result;

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/templateManager.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/dialogs/templateManager/templateManager.ts
@@ -40,6 +40,7 @@ export class TemplateManager {
     /**
      * Send a reply with the template
      */
+    // tslint:disable-next-line:no-any
     public async replyWith(turnContext: TurnContext, templateId: string, data?: any): Promise<void> {
         if (!turnContext) { throw new Error('turnContext is null'); }
 
@@ -56,6 +57,7 @@ export class TemplateManager {
 
     public async renderTemplate(turnContext: TurnContext,
                                 templateId: string,
+                                // tslint:disable-next-line:no-any
                                 language?: string, data?: any): Promise<Activity | undefined> {
         const fallbackLocales: string[] = this.LANGUAGE_FALLBACK;
 
@@ -68,6 +70,7 @@ export class TemplateManager {
         // try each locale until successful
         for (const locale of fallbackLocales) {
             for (const renderer of this.TEMPLATE_RENDERS) {
+                // tslint:disable-next-line:no-any
                 const templateOutput: any = await renderer.renderTemplate(turnContext, locale, templateId, data);
                 if (templateOutput) {
                     if (typeof templateOutput === 'string' || templateOutput instanceof String) {

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
@@ -6,7 +6,6 @@
  */
 export class QnATelemetryConstants {
     public readonly KNOWLEDGE_BASE_ID_PROPERTY: string = 'knowledgeBaseId';
-    public readonly ACTIVITY_ID_PROPERTY: string = 'activityId';
     public readonly ANSWER_PROPERTY: string = 'answer';
     public readonly ARTICLE_FOUND_PROPERTY: string = 'articleFound';
     public readonly CHANNEL_ID_PROPERTY: string = 'channelId';

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryBotDependencyExtension.ts
@@ -1,53 +1,55 @@
-import { TelemetryClient } from "applicationinsights";
-import { DateTimePrompt } from "botbuilder-dialogs";
-import { start } from "repl";
-import { duration } from "moment";
+import { TelemetryClient } from 'applicationinsights';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
-   
-   export class TelemetryBotDependencyExtension
-    {
-        public static DependencyType: string = "Bot";
-     
-        /**
-         * Send information about a dependency in the Bot Application.
-         * TypeParam <TResult> The type of the return value of the method that this delegate encapsulates.
-         * The action delegate will be timed and an Application Insights dependency record will be created.
-         * @param {TelemetryClient} telemetryClient - The TelemetryClient.
-         * @param {TResult} action - Encapsulates a method that has no parameters and returns a value of the type specified by the TResult parameter.
-         * @param {string} dependencyName - Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.
-         * @param {string} dependencyData - Command initiated by this dependency call. For example, Middleware.
-         * @returns The return value of the method that this delegate encapsulates.
-         */
-          public static trackBotDependency<TResult>(telemetryClient: TelemetryClient, action: () => TResult, dependencyName: string, dependencyData: string): TResult {
-          // return action();
 
-           if (dependencyName === null) {
-             throw new Error("Missing parameter, dependencyName is required"); 
-           }
-           var startTime = Date.now();         
-           var success = true;
+export namespace TelemetryBotDependencyExtension {
 
-           try {
-               return action();
-           }
-           catch (Exception) {
-               success = false;
-               throw Exception;
-           }
-           finally {
-               var endTime = Date.now();
-               let duration = endTime - startTime;
-               // Log the dependency into Application Insights
-               telemetryClient.trackDependency({
-                   dependencyTypeName: TelemetryBotDependencyExtension.DependencyType,
-                   name: dependencyName,
-                   data: dependencyData,
-                   success: success,
-                   duration: duration,
-                   resultCode: 0
-               });
-           }
-       }
+    const DEPENDENCY_TYPE: string = 'Bot';
+
+    /**
+     * Send information about a dependency in the Bot Application.
+     * TypeParam <TResult> The type of the return value of the method that this delegate encapsulates.
+     * The action delegate will be timed and an Application Insights dependency record will be created.
+     * @param telemetryClient - The TelemetryClient.
+     * @param action - Encapsulates a method that has no parameters and returns a value of the type specified by the TResult parameter.
+     * @param dependencyName
+     * - Name of the command initiated with this dependency call.
+     *   Low cardinality value.
+     *   Examples are stored procedure name and URL path template.
+     * @param dependencyData - Command initiated by this dependency call. For example, Middleware.
+     * @returns The return value of the method that this delegate encapsulates.
+     */
+    export function trackBotDependency<TResult>(
+            telemetryClient: TelemetryClient,
+            action: () => TResult,
+            dependencyName: string,
+            dependencyData: string): TResult {
+
+        if (dependencyName === null) {
+            throw new Error('Missing parameter, dependencyName is required');
+        }
+        const startTime: number = Date.now();
+        let success: boolean = true;
+
+        try {
+            return action();
+        } catch (err) {
+            success = false;
+            throw err;
+        }
+        finally {
+            const endTime: number = Date.now();
+            const duration: number = endTime - startTime;
+            // Log the dependency into Application Insights
+            telemetryClient.trackDependency({
+                dependencyTypeName: DEPENDENCY_TYPE,
+                name: dependencyName,
+                data: dependencyData,
+                success: success,
+                duration: duration,
+                resultCode: 0
+            });
+        }
     }
+}

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryLuisRecognizer.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryLuisRecognizer.ts
@@ -73,7 +73,8 @@ export class TelemetryLuisRecognizer extends LuisRecognizer {
             dialogContext.activeDialog ? dialogContext.activeDialog.id : undefined);
     }
     /**
-     * Return results of the analysis (Suggested actions and intents), using the turn context. This is missing a dialog id used for telemetry.
+     * Return results of the analysis (Suggested actions and intents), using the turn context.
+     * This is missing a dialog id used for telemetry.
      * @param context - Context object containing information for a single turn of conversation with a user.
      * @param logOriginalMessage - Determines if the original message is logged into Application Insights.  This is a privacy consideration.
      * @returns The LUIS results of the analysis of the current message text in the current turn's context activity.

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryQnAMaker.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/middleware/telemetry/telemetryQnAMaker.ts
@@ -69,8 +69,6 @@ export class TelemetryQnAMaker extends QnAMaker {
             const metrics: { [key: string]: number } = {};
 
             properties[this.QNA_TELEMETRY_CONSTANTS.KNOWLEDGE_BASE_ID_PROPERTY] = this.ENDPOINT.knowledgeBaseId;
-            // Make it so we can correlate our reports with Activity or Conversation
-            properties[this.QNA_TELEMETRY_CONSTANTS.ACTIVITY_ID_PROPERTY] = context.activity.id || '';
             const conversationId: string = context.activity.conversation.id;
             if (conversationId && conversationId.trim()) {
                 properties[this.QNA_TELEMETRY_CONSTANTS.CONVERSATION_ID_PROPERTY] = conversationId;

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/serviceClients/graphClient.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/serviceClients/graphClient.ts
@@ -1,22 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-import { Client, GraphError } from '@microsoft/microsoft-graph-client';
+import {
+    AuthProviderCallback,
+    Client,
+    GraphError } from '@microsoft/microsoft-graph-client';
 import { User } from '@microsoft/microsoft-graph-types';
 
 export class GraphClient {
-    private readonly _token: string;
+    private readonly TOKEN: string;
 
-    constructor(token: string) {
-        this._token = token;
+    constructor(TOKEN: string) {
+        this.TOKEN = TOKEN;
     }
 
     public getMe(): Promise<User> {
-        return new Promise((resolve, reject) => {
-            const client = this.getAuthenticatedClient();
-            client.api('/me').select('displayName')
+        // tslint:disable-next-line:no-any
+        return new Promise((resolve: (value?: User | PromiseLike<User> | undefined) => any, reject: (reason?: any) => void): void => {
+            const client: Client = this.getAuthenticatedClient();
+            client.api('/me')
+                  .select('displayName')
             .get((err: GraphError, res: User) => {
                 if (err) { return reject(err); }
+
                 return resolve(res);
             });
         });
@@ -24,8 +30,8 @@ export class GraphClient {
 
     private getAuthenticatedClient(): Client {
         return Client.init({
-            authProvider: (done) => {
-                done(null, this._token);
+            authProvider: (done: AuthProviderCallback): void => {
+                done(undefined, this.TOKEN);
             }
         });
     }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/tslint.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/tslint.json
@@ -1,14 +1,18 @@
 {
-    "defaultSeverity": "warning",
+    "defaultSeverity": "error",
     "extends": [
         "tslint:recommended",
         "tslint-microsoft-contrib"
     ],
     "linterOptions":{
-
+        "exclude": [
+          "src/dialogs/shared/resources/*"
+        ]
     },
     "rules": {
-      "member-ordering": [false]
+      "linebreak-style": [false],
+      "member-ordering": [false],
+      "no-relative-imports": [false]
     },
     "rulesDirectory": [
       "node_modules/tslint-microsoft-contrib"

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
@@ -73,7 +73,8 @@ describe("The generator-botbuilder-enterprise tests", () => {
       "README.md",
       "tsconfig.json",
       "deploymentScripts/webConfigPrep.js",
-      "package.json"
+      "package.json",
+      "tslint.json"
     ];
     rootFiles.forEach(fileName =>
       it(fileName + " file", () => {


### PR DESCRIPTION
## Description
- Change tslint severity to **error**.
- Add tslint's exceptions.
- Fix the TSLint warnings.

## Related Issue
Fix #679 

## Additional context
**Once the TSLint severity is set to "Error", any change made to the sample should follow the TSLint rules; exceptions should be avoided when possible, and if not, they should be properly justified**

## Testing Steps
1. Open `AI/templates/Enterprise-Template/src/typescript/enterprise-bot/`
2. Run `npm i`.
3. Run `npm run lint` and check there is no tslint errors/warnings in the solution.

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
