### PR TITLE
[Enterprise Bot Generator][TypeScript] Create eslintignore and eslintrc files

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintignore
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintignore
@@ -1,0 +1,2 @@
+/generators/app/templates
+/generators/dialog/templates

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintrc
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintrc
@@ -1,0 +1,16 @@
+{
+    "extends": [
+        "xo",
+        "prettier"
+    ],
+    "env": {
+        "mocha": true,
+        "node": true
+    },
+    "rules": {
+        "prettier/prettier": "error"
+    },
+    "plugins": [
+        "prettier"
+    ]
+}

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/package.json
@@ -52,22 +52,6 @@
       "git add"
     ]
   },
-  "eslintConfig": {
-    "extends": [
-      "xo",
-      "prettier"
-    ],
-    "env": {
-      "mocha": true,
-      "node": true
-    },
-    "rules": {
-      "prettier/prettier": "error"
-    },
-    "plugins": [
-      "prettier"
-    ]
-  },
   "scripts": {
     "pretest": "eslint .",
     "test": "cd test/ && mocha --opts mocha.opts"

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
@@ -69,7 +69,7 @@ describe("The generator-botbuilder-enterprise tests", () => {
     const rootFiles = [
       ".env.development",
       ".env.production",
-      ".gitignore",
+      "gitignore",
       "README.md",
       "tsconfig.json",
       "deploymentScripts/webConfigPrep.js",


### PR DESCRIPTION
## Description

- Create ._eslintignore_ file and exclude template folders
- Create _eslintrc_ file with eslint configuration
- Update generator's test

## Related Issue
Fix #689 

## Testing Steps

1. Open `AI/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/`
2. Run `npm i`
3. Run `npm run test` and check that the running tests are using the eslintrc rules from _eslintrc_ file, and excluding template folders from _eslintignore_ file

![image](https://user-images.githubusercontent.com/11904023/52129627-c2bfda80-2616-11e9-9c75-6028f124a6a3.png)


## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
