### PR TITLE
Ensure nested Enterprise Dialogs do not throw error adding luis result to TurnState

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/EnterpriseDialog.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/Bot Framework/Dialogs/Shared/EnterpriseDialog.cs
@@ -12,81 +12,90 @@ using Microsoft.Bot.Builder.Dialogs;
 namespace $safeprojectname$.Dialogs.Shared
 {
     public class EnterpriseDialog : InterruptableDialog
+{
+    protected const string LuisResultKey = "LuisResult";
+
+    // Fields
+    private readonly BotServices _services;
+    private readonly CancelResponses _responder = new CancelResponses();
+
+    public EnterpriseDialog(BotServices botServices, string dialogId)
+        : base(dialogId)
     {
-        protected const string LuisResultKey = "LuisResult";
+        _services = botServices;
 
-        // Fields
-        private readonly BotServices _services;
-        private readonly CancelResponses _responder = new CancelResponses();
+        AddDialog(new CancelDialog());
+    }
 
-        public EnterpriseDialog(BotServices botServices, string dialogId)
-            : base(dialogId)
+    protected override async Task<InterruptionStatus> OnDialogInterruptionAsync(DialogContext dc, CancellationToken cancellationToken)
+    {
+        // check luis intent
+        _services.LuisServices.TryGetValue("general", out var luisService);
+
+        if (luisService == null)
         {
-            _services = botServices;
-
-            AddDialog(new CancelDialog());
+            throw new Exception("The specified LUIS Model could not be found in your Bot Services configuration.");
         }
-
-        protected override async Task<InterruptionStatus> OnDialogInterruptionAsync(DialogContext dc, CancellationToken cancellationToken)
+        else
         {
-            // check luis intent
-            _services.LuisServices.TryGetValue("general", out var luisService);
-
-            if (luisService == null)
+            General luisResult;
+            if (dc.Context.TurnState.ContainsKey(LuisResultKey))
             {
-                throw new Exception("The specified LUIS Model could not be found in your Bot Services configuration.");
+                luisResult = dc.Context.TurnState.Get<General>(LuisResultKey);
             }
             else
             {
-                var luisResult = await luisService.RecognizeAsync<General>(dc.Context, true, cancellationToken);
-                var intent = luisResult.TopIntent().intent;
+                luisResult = await luisService.RecognizeAsync<General>(dc.Context, true, cancellationToken);
 
-                // Only triggers interruption if confidence level is high
-                if (luisResult.TopIntent().score > 0.5)
+                // Add the luis result (intent and entities) for further processing in the derived dialog
+                dc.Context.TurnState.Add(LuisResultKey, luisResult);
+            }
+
+            var intent = luisResult.TopIntent().intent;
+
+            // Only triggers interruption if confidence level is high
+            if (luisResult.TopIntent().score > 0.5)
+            {
+                switch (intent)
                 {
-                    // Add the luis result (intent and entities) for further processing in the derived dialog
-                    dc.Context.TurnState.Add(LuisResultKey, luisResult);
+                    case General.Intent.Cancel:
+                        {
+                            return await OnCancel(dc);
+                        }
 
-                    switch (intent)
-                    {
-                        case General.Intent.Cancel:
-                            {
-                                return await OnCancel(dc);
-                            }
-
-                        case General.Intent.Help:
-                            {
-                                return await OnHelp(dc);
-                            }
-                    }
+                    case General.Intent.Help:
+                        {
+                            return await OnHelp(dc);
+                        }
                 }
             }
-
-            return InterruptionStatus.NoAction;
         }
 
-        protected virtual async Task<InterruptionStatus> OnCancel(DialogContext dc)
-        {
-            if (dc.ActiveDialog.Id != nameof(CancelDialog))
-            {
-                // Don't start restart cancel dialog
-                await dc.BeginDialogAsync(nameof(CancelDialog));
-
-                // Signal that the dialog is waiting on user response
-                return InterruptionStatus.Waiting;
-            }
-
-            // Else, continue
-            return InterruptionStatus.NoAction;
-        }
-
-        protected virtual async Task<InterruptionStatus> OnHelp(DialogContext dc)
-        {
-            var view = new MainResponses();
-            await view.ReplyWith(dc.Context, MainResponses.ResponseIds.Help);
-
-            // Signal the conversation was interrupted and should immediately continue
-            return InterruptionStatus.Interrupted;
-        }
+        return InterruptionStatus.NoAction;
     }
+
+    protected virtual async Task<InterruptionStatus> OnCancel(DialogContext dc)
+    {
+        if (dc.ActiveDialog.Id != nameof(CancelDialog))
+        {
+            // Don't start restart cancel dialog
+            await dc.BeginDialogAsync(nameof(CancelDialog));
+
+            // Signal that the dialog is waiting on user response
+            return InterruptionStatus.Waiting;
+        }
+
+        // Else, continue
+        return InterruptionStatus.NoAction;
+    }
+
+    protected virtual async Task<InterruptionStatus> OnHelp(DialogContext dc)
+    {
+        var view = new MainResponses();
+        await view.ReplyWith(dc.Context, MainResponses.ResponseIds.Help);
+
+        // Signal the conversation was interrupted and should immediately continue
+        return InterruptionStatus.Interrupted;
+    }
+}
 }


### PR DESCRIPTION
## Description
Fix to ensure nested enterprise dialogs do not throw error trying to add LUIS result to TurnState twice and also ensure LUIS is only called once per turn.