### PR TITLE
[Enterprise Bot Generator][TypeScript] Improve Dialog Subgenerator Documentation

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog/README.md
@@ -48,6 +48,53 @@ After this, you can check the summary in your screen:
 - Path: <aPath>
 ```
 
+## How to use it
+After using the generator, you have available two different files, one for Dialog itself and other for Responses.
+
+> NOTE: The following examples are based on a bot created using the Enterprise Bot Template.
+
+### Adding Dialog file
+
+To link your dialog into a bot 
+
+```typescript
+export class aBot {
+    private readonly DIALOGS: DialogSet;
+
+    constructor(dialogSet: DialogSet) {
+        this.DIALOGS = dialogSet;
+        this.DIALOGS.add(new <dialogName>());
+    }
+    
+    public async onTurn(turnContext: TurnContext): Promise<void> {
+        const dc: DialogContext = await this.DIALOGS.createContext(turnContext);
+        const result: DialogTurnResult<any> = await dc.continueDialog();
+
+        if (result.status === DialogTurnStatus.empty) {
+            await dc.beginDialog('<dialogName>');
+        }
+    }
+}
+```
+
+### Using Responses file
+You can configure the responses for the language that you have selected to deploy your bot.\
+First, open the locale file for the language selected in the generator (eg. `locales/en.json`) and add a new key to identify your dialog, and inside another one with the value for your response.\
+For this, go to your responses file created and add the response you want like below.
+```typescript
+public static RESPONSE_IDS: {
+    <keyName>: string;
+} = {
+    <keyName>: '<keyName>'
+};
+
+private static readonly RESPONSE_TEMPLATES: LanguageTemplateDictionary = new Map([
+    ['default', new Map([
+        [<responsesClassName>.RESPONSE_IDS.<keyName>, <responsesClassName>.fromResources('<responsesClassName>.<keyName>')]
+    ])]
+])
+```
+
 ## License
 
 MIT © [Microsoft](http://dev.botframework.com)


### PR DESCRIPTION
## Description

- More detailed instructions of how to use a dialog generated

## Related Issue
Fix #696 

## Testing Steps

1. Go to `AI/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/dialog`
2. Read the new instructions in the **README**

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
- [x] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
