### PR TITLE
[Enterprise Bot Generator][TypeScript] Improve BotBuilder Enterprise Generator

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -248,17 +248,17 @@ module.exports = class extends Generator {
 
     this.fs.copy(
       this.templatePath(templateName, "cognitiveModels", "LUIS", botLang, "*"),
-      this.destinationPath(botGenerationPath, "cognitiveModels", "LUIS")
+      this.destinationPath(botGenerationPath, "cognitiveModels", "LUIS", botLang)
     );
 
     this.fs.copy(
       this.templatePath(templateName, "cognitiveModels", "QnA", botLang, "*"),
-      this.destinationPath(botGenerationPath, "cognitiveModels", "QnA")
+      this.destinationPath(botGenerationPath, "cognitiveModels", "QnA", botLang)
     );
 
     this.fs.copy(
       this.templatePath(templateName, "deploymentScripts", botLang, "*"),
-      this.destinationPath(botGenerationPath, "deploymentScripts")
+      this.destinationPath(botGenerationPath, "deploymentScripts", botLang)
     );
 
     this.fs.copyTpl(

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -248,7 +248,12 @@ module.exports = class extends Generator {
 
     this.fs.copy(
       this.templatePath(templateName, "cognitiveModels", "LUIS", botLang, "*"),
-      this.destinationPath(botGenerationPath, "cognitiveModels", "LUIS", botLang)
+      this.destinationPath(
+        botGenerationPath,
+        "cognitiveModels",
+        "LUIS",
+        botLang
+      )
     );
 
     this.fs.copy(
@@ -259,6 +264,16 @@ module.exports = class extends Generator {
     this.fs.copy(
       this.templatePath(templateName, "deploymentScripts", botLang, "*"),
       this.destinationPath(botGenerationPath, "deploymentScripts", botLang)
+    );
+
+    this.fs.copy(
+      this.templatePath(templateName, "src", "locales", botLang + ".json"),
+      this.destinationPath(
+        botGenerationPath,
+        "src",
+        "locales",
+        botLang + ".json"
+      )
     );
 
     this.fs.copyTpl(
@@ -317,7 +332,6 @@ module.exports = class extends Generator {
     const commonDirectories = [
       "dialogs",
       "extensions",
-      "locales",
       "middleware",
       "serviceClients"
     ];

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/index.js
@@ -133,18 +133,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "botName",
         message: `What's the name of your bot?`,
-        default: this.options.botName ? this.options.botName : "enterprise-bot",
-        validate: input => {
-          if (input.length > 12) {
-            this.log(
-              chalk.yellow(
-                "\nWARNING: If the name of the bot has more than 12 characters, it could have some problems deploying some services."
-              )
-            );
-          }
-
-          return true;
-        }
+        default: this.options.botName ? this.options.botName : "enterprise-bot"
       },
       {
         type: "input",

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
@@ -63,6 +63,38 @@ describe("The generator-botbuilder-enterprise tests", () => {
         );
       })
     );
+
+    cognitiveDirectories.forEach(directoryName =>
+      it("language '" + botLang + "' folder in " + directoryName, () => {
+        assert.file(
+          path.join(
+            __dirname,
+            botGenerationPath,
+            "cognitiveModels",
+            directoryName,
+            botLang
+          )
+        );
+      })
+    );
+
+    it("language '" + botLang + "' folder in deploymentScript", () => {
+      assert.file(
+        path.join(__dirname, botGenerationPath, "deploymentScripts", botLang)
+      );
+    });
+
+    it("language '" + botLang + "' file in locales", () => {
+      assert.file(
+        path.join(
+          __dirname,
+          botGenerationPath,
+          "src",
+          "locales",
+          botLang + ".json"
+        )
+      );
+    });
   });
 
   describe("should create in the root folder", () => {


### PR DESCRIPTION
## Description

- Create a parent folder named with the selected language (in _deploymentScripts_ and _cognitiveModels_ folders).
- Leave only the locale of the selected language.
- Delete unnecessary warning (if the bot's name had more than > 12 characters).
- Add new tests for the generator.

## Related Issue
Fix #699 

## Testing Steps

1.  Open `AI\templates\Enterprise-Template\src\typescript\generator-botbuilder-enterprise`.
2.  Run `npm i`.
3.  Check the following steps.
3.1. Run `yo botbuilder-enterprise` and check the following steps.
3.1.1. Check that there is no warning if you add a bot's name with more than 12 characters.
3.1.2. Check there is a `cognitiveModels/LUIS/<selectedLanguage>` folder.
3.1.3. Check there is a `cognitiveModels/QnA/<selectedLanguage>` folder.
3.1.4. Check there is a `deploymentScripts/<selectedLanguage>` folder.
3.1.5. Check there is a `locales/<selectedLanguage>` file.
3.2. Run `npm run test` and check the running tests.


![image](https://user-images.githubusercontent.com/11904023/52278869-dd57c380-2936-11e9-8b72-291858c5e3e0.png)

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
