### PR TITLE
[Enterprise Bot][TypeScript] Add test base structure

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
@@ -14,7 +14,7 @@
         "lint": "tslint -t vso ./src/**/*.ts",
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "mocha ./test/"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/test/flow/enterpriseBotTestBase.js
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/test/flow/enterpriseBotTestBase.js
@@ -1,0 +1,52 @@
+const { ConversationState, MemoryStorage, NullTelemetryClient, TestAdapter, UserState} = require('botbuilder-core')
+const { BotConfiguration } = require('botframework-config');
+const { config } = require('dotenv');
+const i18n = require('i18n');
+const path = require('path');
+const { BotServices } = require('../../lib/botServices.js');
+const { EnterpriseBot } = require('../../lib/enterpriseBot.js');
+const ENV_NAME = 'development';
+
+    /**
+     * Initializes the properties for the bot to be tested.
+     */
+    var initialize = async function() {
+        i18n.configure({
+            directory: path.join(__dirname, '..', '..', 'src', 'locales'),
+            defaultLocale: 'en',
+            objectNotation: true
+        });
+
+        /**
+         * This will be removed when the mocks are finished, since the env variables will be hardcoded
+         */
+        config({ path: path.join(__dirname, '..', '..', `.env.${ENV_NAME}`) });
+        this.conversationState = new ConversationState(new MemoryStorage());
+        this.userState = new UserState(new MemoryStorage());
+        const telemetryClient = new NullTelemetryClient();
+
+        /*
+         * Here we should pass an instance of { BotServices } from '../../src/botServices',
+         * for the moment we'll deploy a bot and use the .bot file, until we mock the services.
+        */
+        const botConfiguration = await BotConfiguration.load(process.env.BOT_FILE_NAME, process.env.BOT_FILE_SECRET);
+        this.services = new BotServices(botConfiguration);
+    }
+
+    /**
+     * Initializes the TestAdapter.
+     * @returns TestAdapter with the Bot logic configured.
+     */
+    var getTestAdapter = function() {
+        const adapter = new TestAdapter((context) =>{
+            var bot = new EnterpriseBot(this.services, this.conversationState, this.userState);
+            return bot.onTurn(context);
+        });
+
+        return adapter;
+    }
+
+module.exports = {
+  initialize: initialize,
+  getTestAdapter: getTestAdapter
+}

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/test/mocha.opts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/test/mocha.opts
@@ -1,0 +1,4 @@
+--timeout 50000
+--recursive
+./**/*Test.js
+--colors

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
@@ -14,7 +14,7 @@
         "lint": "tslint -t vso ./src/**/*.ts",
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "mocha ./test/"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/test/flow/enterpriseBotTestBase.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/test/flow/enterpriseBotTestBase.js
@@ -1,0 +1,52 @@
+const { ConversationState, MemoryStorage, NullTelemetryClient, TestAdapter, UserState} = require('botbuilder-core')
+const { BotConfiguration } = require('botframework-config');
+const { config } = require('dotenv');
+const i18n = require('i18n');
+const path = require('path');
+const { BotServices } = require('../../lib/botServices.js');
+const { EnterpriseBot } = require('../../lib/enterpriseBot.js');
+const ENV_NAME = 'development';
+
+    /**
+     * Initializes the properties for the bot to be tested.
+     */
+    var initialize = async function() {
+        i18n.configure({
+            directory: path.join(__dirname, '..', '..', 'src', 'locales'),
+            defaultLocale: 'en',
+            objectNotation: true
+        });
+
+        /**
+         * This will be removed when the mocks are finished, since the env variables will be hardcoded
+         */
+        config({ path: path.join(__dirname, '..', '..', `.env.${ENV_NAME}`) });
+        this.conversationState = new ConversationState(new MemoryStorage());
+        this.userState = new UserState(new MemoryStorage());
+        const telemetryClient = new NullTelemetryClient();
+
+        /*
+         * Here we should pass an instance of { BotServices } from '../../src/botServices',
+         * for the moment we'll deploy a bot and use the .bot file, until we mock the services.
+        */
+        const botConfiguration = await BotConfiguration.load(process.env.BOT_FILE_NAME, process.env.BOT_FILE_SECRET);
+        this.services = new BotServices(botConfiguration);
+    }
+
+    /**
+     * Initializes the TestAdapter.
+     * @returns TestAdapter with the Bot logic configured.
+     */
+    var getTestAdapter = function() {
+        const adapter = new TestAdapter((context) =>{
+            var bot = new EnterpriseBot(this.services, this.conversationState, this.userState);
+            return bot.onTurn(context);
+        });
+
+        return adapter;
+    }
+
+module.exports = {
+  initialize: initialize,
+  getTestAdapter: getTestAdapter
+}

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/test/mocha.opts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/test/mocha.opts
@@ -1,0 +1,4 @@
+--timeout 50000
+--recursive
+./**/*Test.js
+--colors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Add base structure for the initialization of test's configuration.
- Edit `test` script in `package.json` file.
- Copy changes to template for parity.

## Related Issue
#704

## Testing Steps
1. Add a file inside [`templates/Enterprise-Template/src/typescript/enterprise-bot/test/flow/`](https://github.com/Microsoft/AI/tree/df6ff69e576e4ac3e2a03d1022831ca31a662c59/templates/Enterprise-Template/src/typescript/enterprise-bot/test/flow) with its name ending in `Test.js` (i.e. `mainDialogTest.js`)
1. Insert the following test:
  ```JavaScript
  const enterpriseBotTestBase = require('./enterpriseBotTestBase.js');
  
describe("The generator-botbuilder-enterprise ", function() {
    before(() => {
      enterpriseBotTestBase.initialize();
    });
    describe("Greeting", function () {
      it("Send Hello and check you get the expected response", (done) => {
        const testAdapter = enterpriseBotTestBase.getTestAdapter();
        testAdapter.send('Hi')
        .assertReply('Hello.')
        .then(done);
      });
    });
});
```
3. Open a terminal in `templates/Enterprise-Template/src/typescript/enterprise-bot/`
4. Run the test script with `npm run test`

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas

~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
