### PR TITLE
[Enterprise Bot Generator][TypeScript] Update structure and new tests

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintignore
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/.eslintignore
@@ -1,2 +1,6 @@
+# Generator's templates
 /generators/app/templates
 /generators/dialog/templates
+
+# Generator's tests
+/test

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.dialog.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.dialog.test.suite.js
@@ -6,92 +6,158 @@ const rimraf = require("rimraf");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
 
-describe("The generator-botbuilder-enterprise dialog tests ", () => {
-  var dialogName = "customDialog";
-  var responsesName = "customResponses";
-  const dialogNameCamelCase = _camelCase(dialogName);
-  const dialogNamePascalCase = _upperFirst(_camelCase(dialogName));
-  const responsesNameCamelCase = _camelCase(responsesName);
-  const responsesNamePascalCase = _upperFirst(_camelCase(responsesName));
-  const dialogGenerationPath = path.join("tmp", dialogName);
+describe("The generator-botbuilder-enterprise dialog tests", function() {
+  var dialogName;
+  var responsesName;
+  var dialogNameCamelCase;
+  var dialogNamePascalCase;
+  var responsesNameCamelCase;
+  var responsesNamePascalCase;
+  var dialogGenerationPath;
+  var confirmationPath;
+  var finalConfirmation;
 
-  before(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/dialog"))
-      .inDir(path.join(__dirname, "tmp"))
-      .withPrompts({
-        dialogName: dialogName,
-        confirmationPath: true,
-        dialogPath: process.cwd(),
-        finalConfirmation: true
+  describe("should create", function() {
+    dialogName = "customDialog";
+    responsesName = "customResponses";
+    dialogNameCamelCase = _camelCase(dialogName);
+    dialogNamePascalCase = _upperFirst(_camelCase(dialogName));
+    responsesNameCamelCase = _camelCase(responsesName);
+    responsesNamePascalCase = _upperFirst(_camelCase(responsesName));
+    dialogGenerationPath = path.join("tmp", dialogName);
+    confirmationPath = true;
+    finalConfirmation = true;
+
+    before(function() {
+      return helpers
+        .run(path.join(__dirname, "../generators/dialog"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          dialogName: dialogName,
+          confirmationPath: confirmationPath,
+          dialogGenerationPath: dialogGenerationPath,
+          finalConfirmation: finalConfirmation
+        });
+    });
+
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
+    });
+
+    describe("the files", function() {
+      const files = [
+        dialogNameCamelCase + ".ts",
+        responsesNameCamelCase + ".ts"
+      ];
+
+      files.forEach(fileName =>
+        it(fileName + " file", function(done) {
+          assert.file(path.join(__dirname, dialogGenerationPath, fileName));
+          done();
+        })
+      );
+    });
+
+    describe("and have in the dialog file with the given name", function() {
+      it("an import component containing the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            dialogNameCamelCase + ".ts"
+          ),
+          `import { ${responsesNamePascalCase} } from './${responsesNameCamelCase}'`
+        );
+        done();
       });
+
+      it("an export component with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            dialogNameCamelCase + ".ts"
+          ),
+          `export class ${dialogNamePascalCase}`
+        );
+        done();
+      });
+
+      it("an initialized attribute with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            dialogNameCamelCase + ".ts"
+          ),
+          `RESPONDER: ${responsesNamePascalCase} = new ${responsesNamePascalCase}()`
+        );
+        done();
+      });
+
+      it("a super method with the given name as parameter", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            dialogNameCamelCase + ".ts"
+          ),
+          `super(${dialogNamePascalCase}.name)`
+        );
+        done();
+      });
+    });
+
+    describe("and have in the responses file with the given name", function() {
+      it("an export component with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            responsesNameCamelCase + ".ts"
+          ),
+          `export class ${responsesNamePascalCase}`
+        );
+        done();
+      });
+
+      it("a parameter with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            dialogGenerationPath,
+            responsesNameCamelCase + ".ts"
+          ),
+          `new DictionaryRenderer(${responsesNamePascalCase}.RESPONSE_TEMPLATES)`
+        );
+        done();
+      });
+    });
   });
 
-  after(() => {
-    rimraf.sync(path.join(__dirname, "tmp/*"));
-  });
-
-  describe("should create", () => {
-    const files = [dialogNameCamelCase + ".ts", responsesNameCamelCase + ".ts"];
-
-    files.forEach(fileName =>
-      it(fileName + " file", () => {
-        assert.file(path.join(__dirname, dialogGenerationPath, fileName));
-      })
-    );
-  });
-
-  describe("should have in the dialog file with the given name", () => {
-    it("an import component containing the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
-        `import { ${responsesNamePascalCase} } from './${responsesNameCamelCase}'`
-      );
+  describe("should not create", function() {
+    before(function() {
+      finalConfirmation = false;
+      return helpers
+        .run(path.join(__dirname, "../generators/dialog"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          dialogName: dialogName,
+          confirmationPath: confirmationPath,
+          dialogGenerationPath: dialogGenerationPath,
+          finalConfirmation: finalConfirmation
+        });
     });
 
-    it("an export component with the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
-        `export class ${dialogNamePascalCase}`
-      );
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
     });
 
-    it("an initialized attribute with the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
-        `RESPONDER: ${responsesNamePascalCase} = new ${responsesNamePascalCase}()`
-      );
-    });
-
-    it("a super method with the given name as parameter", () => {
-      assert.fileContent(
-        path.join(__dirname, dialogGenerationPath, dialogNameCamelCase + ".ts"),
-        `super(${dialogNamePascalCase}.name)`
-      );
-    });
-  });
-
-  describe("should have in the responses file with the given name", () => {
-    it("an export component with the given name", () => {
-      assert.fileContent(
-        path.join(
-          __dirname,
-          dialogGenerationPath,
-          responsesNameCamelCase + ".ts"
-        ),
-        `export class ${responsesNamePascalCase}`
-      );
-    });
-
-    it("a parameter with the given name", () => {
-      assert.fileContent(
-        path.join(
-          __dirname,
-          dialogGenerationPath,
-          responsesNameCamelCase + ".ts"
-        ),
-        `new DictionaryRenderer(${responsesNamePascalCase}.RESPONSE_TEMPLATES)`
-      );
+    describe("the base", function() {
+      it(dialogName + " folder when the final confirmation is deny", function(done) {
+        assert.noFile(path.join(__dirname, dialogGenerationPath));
+        done();
+      });
     });
   });
 });

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.test.suite.js
@@ -7,185 +7,251 @@ const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
 const _kebabCase = require("lodash/kebabCase");
 
-describe("The generator-botbuilder-enterprise tests", () => {
-  var botName = "myBot";
-  const botDesc = "A description for myBot";
-  const botLang = "en";
-  botName = _kebabCase(botName).replace(/([^a-z0-9-]+)/gi, "");
-  const botNamePascalCase = _upperFirst(_camelCase(botName));
-  const botNameCamelCase = _camelCase(botName);
-  const botGenerationPath = path.join("tmp", botName);
-
-  before(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/app"))
-      .inDir(path.join(__dirname, "tmp"))
-      .withPrompts({
-        botName: botName,
-        botDesc: botDesc,
-        botLang: botLang,
-        confirmationPath: true,
-        botGenerationPath: process.cwd(),
-        finalConfirmation: true
-      });
-  });
-
-  after(() => {
-    rimraf.sync(path.join(__dirname, "tmp/*"));
-  });
-
-  describe("should create", () => {
-    const commonDirectories = [
-      "dialogs",
-      "extensions",
-      "locales",
-      "middleware",
-      "serviceClients"
-    ];
-    commonDirectories.forEach(directoryName =>
-      it(directoryName + " folder", () => {
-        assert.file(
-          path.join(__dirname, botGenerationPath, "src", directoryName)
-        );
-      })
-    );
-
-    const cognitiveDirectories = ["LUIS", "QnA"];
-    cognitiveDirectories.forEach(directoryName =>
-      it(directoryName + " folder", () => {
-        assert.file(
-          path.join(
-            __dirname,
-            botGenerationPath,
-            "cognitiveModels",
-            directoryName
-          )
-        );
-      })
-    );
-
-    cognitiveDirectories.forEach(directoryName =>
-      it("language '" + botLang + "' folder in " + directoryName, () => {
-        assert.file(
-          path.join(
-            __dirname,
-            botGenerationPath,
-            "cognitiveModels",
-            directoryName,
-            botLang
-          )
-        );
-      })
-    );
-
-    it("language '" + botLang + "' folder in deploymentScript", () => {
-      assert.file(
-        path.join(__dirname, botGenerationPath, "deploymentScripts", botLang)
-      );
-    });
-
-    it("language '" + botLang + "' file in locales", () => {
-      assert.file(
-        path.join(
-          __dirname,
-          botGenerationPath,
-          "src",
-          "locales",
-          botLang + ".json"
-        )
-      );
-    });
-  });
-
-  describe("should create in the root folder", () => {
-    const rootFiles = [
-      ".env.development",
-      ".env.production",
-      "gitignore",
-      "README.md",
-      "tsconfig.json",
-      "deploymentScripts/webConfigPrep.js",
-      "package.json",
-      "tslint.json"
-    ];
-    rootFiles.forEach(fileName =>
-      it(fileName + " file", () => {
-        assert.file(path.join(__dirname, botGenerationPath, fileName));
-      })
-    );
-  });
-
-  describe("should create in the src folder", () => {
+describe("The generator-botbuilder-enterprise tests", function() {
+  var botName;
+  var botDesc;
+  var botLang;
+  var botNamePascalCase;
+  var botNameCamelCase;
+  var botGenerationPath;
+  var confirmationPath;
+  var finalConfirmation;
+  const cognitiveDirectories = ["LUIS", "QnA"];
+  const commonDirectories = [
+    "dialogs",
+    "extensions",
+    "locales",
+    "middleware",
+    "serviceClients"
+  ];
+  const rootFiles = [
+    ".env.development",
+    ".env.production",
+    "gitignore",
+    "README.md",
+    "tsconfig.json",
+    "deploymentScripts/webConfigPrep.js",
+    "package.json",
+    "tslint.json"
+  ];
+  
+  describe("should create", function() {
+    botName = "myBot";
+    botDesc = "A description for myBot";
+    botLang = "en";
+    botName = _kebabCase(botName).replace(/([^a-z0-9-]+)/gi, "");
+    botNamePascalCase = _upperFirst(_camelCase(botName));
+    botNameCamelCase = _camelCase(botName);
+    botGenerationPath = path.join("tmp", botName);
+    confirmationPath = true;
+    finalConfirmation = true;
     const srcFiles = [botNameCamelCase + ".ts", "botServices.ts"];
-    srcFiles.forEach(fileName =>
-      it(fileName + " file", () => {
-        assert.file(path.join(__dirname, botGenerationPath, "src", fileName));
-      })
-    );
+
+    before(function() {
+      return helpers
+        .run(path.join(__dirname, "../generators/app"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          botName: botName,
+          botDesc: botDesc,
+          botLang: botLang,
+          confirmationPath: confirmationPath,
+          botGenerationPath: botGenerationPath,
+          finalConfirmation: finalConfirmation
+        });
+    });
+
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
+    });
+
+    describe("the base", function() {
+      it(botName + " folder", function(done) {
+        assert.file(path.join(__dirname, botGenerationPath));
+        done();
+      });
+    });
+
+    describe("the folders", function() {
+      commonDirectories.forEach(directoryName =>
+        it(directoryName + " folder", function(done) {
+          assert.file(
+            path.join(__dirname, botGenerationPath, "src", directoryName)
+          );
+          done();
+        })
+      );
+
+      
+      cognitiveDirectories.forEach(directoryName =>
+        it(directoryName + " folder", function(done) {
+          assert.file(
+            path.join(
+              __dirname,
+              botGenerationPath,
+              "cognitiveModels",
+              directoryName
+            )
+          );
+          done();
+        })
+      );
+    });
+
+    describe("the languages", function() {
+
+      cognitiveDirectories.forEach(directoryName =>
+        it("language '" + botLang + "' folder in " + directoryName, () => {
+          assert.file(
+            path.join(
+              __dirname,
+              botGenerationPath,
+              "cognitiveModels",
+              directoryName,
+              botLang
+            )
+          );
+        })
+      );
+  
+      it("language '" + botLang + "' folder in deploymentScript", () => {
+        assert.file(
+          path.join(__dirname, botGenerationPath, "deploymentScripts", botLang)
+        );
+      });
+  
+      it("language '" + botLang + "' file in locales", () => {
+        assert.file(
+          path.join(
+            __dirname,
+            botGenerationPath,
+            "src",
+            "locales",
+            botLang + ".json"
+          )
+        );
+      });
+    });
+
+    describe("in the root folder", function() {
+      rootFiles.forEach(fileName =>
+        it(fileName + " file", function(done) {
+          assert.file(path.join(__dirname, botGenerationPath, fileName));
+          done();
+        })
+      );
+    });
+
+    describe("in the src folder", function() {
+      
+      srcFiles.forEach(fileName =>
+        it(fileName + " file", function(done) {
+          assert.file(path.join(__dirname, botGenerationPath, "src", fileName));
+          done();
+        })
+      );
+    });
+
+    describe("and have in the package.json", function() {
+      it("a name property with the given name", function(done) {
+        assert.fileContent(
+          path.join(__dirname, botGenerationPath, "/package.json"),
+          `"name": "${botName}"`
+        );
+        done();
+      });
+
+      it("a description property with given description", function(done) {
+        assert.fileContent(
+          path.join(__dirname, botGenerationPath, "/package.json"),
+          `"description": "${botDesc}"`
+        );
+        done();
+      });
+    });
+
+    describe("and have in the index file", function() {
+      it("an import component containing the given name", function(done) {
+        assert.fileContent(
+          path.join(__dirname, botGenerationPath, "/src/index.ts"),
+          `import { ${botNamePascalCase} } from './${botNameCamelCase}'`
+        );
+        done();
+      });
+
+      it("a declaration component with the given name", function(done) {
+        assert.fileContent(
+          path.join(__dirname, botGenerationPath, "/src/index.ts"),
+          `let bot: ${botNamePascalCase}`
+        );
+        done();
+      });
+
+      it("an instantiation component with the given name", function(done) {
+        assert.fileContent(
+          path.join(__dirname, botGenerationPath, "/src/index.ts"),
+          `bot = new ${botNamePascalCase}`
+        );
+        done();
+      });
+    });
+
+    describe("and have in the file with the given name", function() {
+      it("an export component with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            botGenerationPath,
+            "src",
+            botNameCamelCase + ".ts"
+          ),
+          `export class ${botNamePascalCase}`
+        );
+        done();
+      });
+
+      it("a parameter component with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            botGenerationPath,
+            "src",
+            botNameCamelCase + ".ts"
+          ),
+          `('${botNamePascalCase}')`
+        );
+        done();
+      });
+    });
   });
 
-  describe("should have in the package.json", () => {
-    it("a name property with the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, botGenerationPath, "/package.json"),
-        `"name": "${botName}"`
-      );
+  describe("should not create", function() {
+    before(function() {
+      finalConfirmation = false;
+      return helpers
+        .run(path.join(__dirname, "../generators/app"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          botName: botName,
+          botDesc: botDesc,
+          botLang: botLang,
+          confirmationPath: confirmationPath,
+          botGenerationPath: botGenerationPath,
+          finalConfirmation: finalConfirmation
+        });
     });
 
-    it("a description property with given description", () => {
-      assert.fileContent(
-        path.join(__dirname, botGenerationPath, "/package.json"),
-        `"description": "${botDesc}"`
-      );
-    });
-  });
-
-  describe("should have in the index file", () => {
-    it("an import component containing the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, botGenerationPath, "/src/index.ts"),
-        `import { ${botNamePascalCase} } from './${botNameCamelCase}'`
-      );
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
     });
 
-    it("a declaration component with the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, botGenerationPath, "/src/index.ts"),
-        `let bot: ${botNamePascalCase}`
-      );
-    });
-
-    it("an instantiation component with the given name", () => {
-      assert.fileContent(
-        path.join(__dirname, botGenerationPath, "/src/index.ts"),
-        `bot = new ${botNamePascalCase}`
-      );
-    });
-  });
-
-  describe("should have in the file with the given name", () => {
-    it("an export component with the given name", () => {
-      assert.fileContent(
-        path.join(
-          __dirname,
-          botGenerationPath,
-          "src",
-          botNameCamelCase + ".ts"
-        ),
-        `export class ${botNamePascalCase}`
-      );
-    });
-
-    it("a parameter component with the given name", () => {
-      assert.fileContent(
-        path.join(
-          __dirname,
-          botGenerationPath,
-          "src",
-          botNameCamelCase + ".ts"
-        ),
-        `('${botNamePascalCase}')`
-      );
+    describe("the base", function() {
+      it(botName + " folder when the final confirmation is deny", function(
+        done
+      ) {
+        assert.noFile(path.join(__dirname, botGenerationPath));
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
- Change the structure of the tests (separation of **_should_** and _**should not** create_ describes).
- Add new tests for generator and dialog subgenerator.
- Ignore of _test_ folder for eslint rules.

## Related Issue
Fix #714 

## Testing Steps
1. Open `AI\templates\Enterprise-Template\src\typescript\generator-botbuilder-enterprise`.
2. Run `npm i`.
3. Run `npm run test` and check the running tests.

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
