### PR TITLE
[Enterprise Bot Generator][TypeScript] Create Middleware Subgenerator

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/README.md
@@ -23,6 +23,7 @@ To install the generator using npm:
 |-----------------------------------------------------|-------------------------------------------------|
 | [botbuilder-enterprise](generators/app/README.md)             | Generator that creates a basic sample            |
 | [botbuilder-enterprise:dialog](generators/dialog/README.md)   | Generator that creates a basic dialog            |
+| [botbuilder-enterprise:middleware](generators/middleware/README.md)   | Generator that creates a basic middleware        |
 
 ## License
 

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/README.md
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/README.md
@@ -1,0 +1,77 @@
+# Bot Builder Enterprise Middleware Generator
+
+## Generate middleware
+
+- Open a terminal. 
+    - (Optional) In the desired folder for generating the middleware.
+- Run the following command for generating your new component.
+
+```bash
+> yo botbuilder-enterprise:middleware
+```
+**At this point you have two different options to procedure**
+
+### Generate middleware using prompts
+
+- The generator will start prompting for some information that is needed for generating the middleware:
+    - `What's the name of your middleware? (custom)`
+        > The name of your middleware (used also as the root folder's name).
+    - `Do you want to change the location of the generation?`
+        > A confirmation to change the destination for the generation.
+        - `Where do you want to generate the middleware? (by default takes the path where you are running the generator)`
+            > The destination path for the generation.
+    - `Looking good. Shall I go ahead and create your new middleware?`
+        > Final confirmation for creating the desired middleware.
+
+### Generate the middleware using CLI parameters
+
+
+| Option                                 | Description                                                                                                  |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| -n, --middlewareName <name>            | name of new middleware (by default takes `custom`)                                                           |
+| -p, --middlewareGenerationPath <path>  | destination path for the new middleware (by default takes the path where you are runnning the generator)     |
+| --noPrompt                             | indicates to avoid the prompts                                                                               |
+
+**NOTE:** If you don't use the _--noPrompt_ option, the process will keep prompting, but using the input values by default.
+
+#### Example
+
+```bash
+> yo botbuilder-enterprise:middleware -n newmiddleware -p "\aPath" --noPrompt
+```
+
+After this, you can check the summary in your screen:
+
+```bash
+- Folder: <amiddlewareFolder>
+- Middleware file: <amiddlewareFile> (with .ts extension)
+- Path: <aPath>
+```
+
+## How to use it
+After using the generator, you can add the middleware with the next steps
+
+> NOTE: The following examples are based on a bot created using the Enterprise Bot Template.
+
+### Adding Middleware file
+
+To link your middleware into a bot 
+
+```typescript
+export class aBot {
+    private readonly MIDDLEWARES: MiddlewareName;
+    
+    constructor(middlewareName: MiddlewareName) {
+        this.MIDDLEWARES = middlewareName;
+    }
+    
+    public async onTurn(Context: TurnContext, next: () => Promise<void>): Promise<void>{
+     
+        await next();
+    }
+}
+```
+
+## License
+
+MIT © [Microsoft](http://dev.botframework.com)

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/index.js
@@ -72,7 +72,9 @@ module.exports = class extends Generator {
         type: "input",
         name: "middlewareName",
         message: `What's the name of your middleware?`,
-        default: this.options.middlewareName ? this.options.middlewareName : "custom"
+        default: this.options.middlewareName
+          ? this.options.middlewareName
+          : "custom"
       },
       {
         type: "confirm",
@@ -106,13 +108,17 @@ module.exports = class extends Generator {
       {
         type: "confirm",
         name: "finalConfirmation",
-        message: "Looking good. Shall I go ahead and create your new middleware?",
+        message:
+          "Looking good. Shall I go ahead and create your new middleware?",
         default: true
       }
     ];
 
     if (this.options.noPrompt) {
-      this.props = _pick(this.options, ["middlewareName", "middlewareGenerationPath"]);
+      this.props = _pick(this.options, [
+        "middlewareName",
+        "middlewareGenerationPath"
+      ]);
 
       // Validate we have what we need, or we'll need to throw
       if (!this.props.middlewareName) {
@@ -145,7 +151,10 @@ module.exports = class extends Generator {
       this.props.middlewareName = templateName;
     }
 
-    this.props.middlewareName = this.props.middlewareName.replace(/([^a-z0-9]+)/gi, "");
+    this.props.middlewareName = this.props.middlewareName.replace(
+      /([^a-z0-9]+)/gi,
+      ""
+    );
 
     var middlewareName;
     const middlewareNameFolder = this.props.middlewareName;
@@ -153,12 +162,14 @@ module.exports = class extends Generator {
       middlewareName = this.props.middlewareName;
     } else {
       middlewareName = this.props.middlewareName.concat("Middleware");
-
     }
 
     const middlewareNameCamelCase = _camelCase(middlewareName);
     const middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
-    middlewareGenerationPath = path.join(middlewareGenerationPath, middlewareName);
+    middlewareGenerationPath = path.join(
+      middlewareGenerationPath,
+      middlewareName
+    );
 
     if (this.props.middlewareGenerationPath !== undefined) {
       middlewareGenerationPath = path.join(
@@ -179,9 +190,12 @@ module.exports = class extends Generator {
 
     this.fs.copyTpl(
       this.templatePath(templateName, "_middleware.ts"),
-      this.destinationPath(middlewareGenerationPath, `${middlewareNameCamelCase}.ts`),
+      this.destinationPath(
+        middlewareGenerationPath,
+        `${middlewareNameCamelCase}.ts`
+      ),
       {
-        middlewareNameClass: middlewareNamePascalCase,
+        middlewareNameClass: middlewareNamePascalCase
       }
     );
   }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/index.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/index.js
@@ -1,0 +1,226 @@
+"use strict";
+var Generator = require("yeoman-generator");
+const chalk = require("chalk");
+const path = require("path");
+const _pick = require("lodash/pick");
+const pkg = require("../../package.json");
+const _camelCase = require("lodash/camelCase");
+const _upperFirst = require("lodash/upperFirst");
+const fs = require("fs");
+
+const middlewareRegExp = /\w*middleware\b/i;
+const bigBot =
+  "               ╭───────────────────────────────────╮\n" +
+  "   " +
+  chalk.blue.bold("//") +
+  "     " +
+  chalk.blue.bold("\\\\") +
+  "   │         Welcome to the            │\n" +
+  "  " +
+  chalk.blue.bold("//") +
+  " () () " +
+  chalk.blue.bold("\\\\") +
+  "  │  BotBuilder Enterprise Middlewares│\n" +
+  "  " +
+  chalk.blue.bold("\\\\") +
+  "       " +
+  chalk.blue.bold("//") +
+  " /│           generator!              │\n" +
+  "   " +
+  chalk.blue.bold("\\\\") +
+  "     " +
+  chalk.blue.bold("//") +
+  "   ╰───────────────────────────────────╯\n" +
+  `                                    v${pkg.version}`;
+
+const tinyBot =
+  " " + chalk.blue.bold("<") + " ** " + chalk.blue.bold(">") + " ";
+
+var middlewareGenerationPath = process.cwd();
+var isAlreadyCreated = false;
+
+module.exports = class extends Generator {
+  constructor(args, opts) {
+    super(args, opts);
+
+    this.option("middlewareName", {
+      description: "The name you want to give to your middleware.",
+      type: String,
+      optional: false,
+      alias: "n"
+    });
+
+    this.option("middlewareGenerationPath", {
+      description: "The path where the middleware will be generated.",
+      type: String,
+      default: process.cwd(),
+      alias: "p"
+    });
+
+    this.option("noPrompt", {
+      description: "Do not prompt for any information or confirmation.",
+      type: Boolean,
+      default: false
+    });
+  }
+
+  prompting() {
+    this.log(bigBot);
+
+    const prompts = [
+      {
+        type: "input",
+        name: "middlewareName",
+        message: `What's the name of your middleware?`,
+        default: this.options.middlewareName ? this.options.middlewareName : "custom"
+      },
+      {
+        type: "confirm",
+        name: "pathConfirmation",
+        message: "Do you want to change the location of the generation?",
+        default: false
+      },
+      {
+        when: function(response) {
+          return response.pathConfirmation === true;
+        },
+        type: "input",
+        name: "middlewareGenerationPath",
+        message: `Where do you want to generate the middleware?`,
+        default: this.options.middlewareGenerationPath
+          ? this.options.middlewareGenerationPath
+          : process.cwd(),
+        validate: path => {
+          if (fs.existsSync(path)) {
+            return true;
+          }
+
+          this.log(
+            chalk.red(
+              "\n",
+              "ERROR: This is not a valid path. Please try again."
+            )
+          );
+        }
+      },
+      {
+        type: "confirm",
+        name: "finalConfirmation",
+        message: "Looking good. Shall I go ahead and create your new middleware?",
+        default: true
+      }
+    ];
+
+    if (this.options.noPrompt) {
+      this.props = _pick(this.options, ["middlewareName", "middlewareGenerationPath"]);
+
+      // Validate we have what we need, or we'll need to throw
+      if (!this.props.middlewareName) {
+        this.log.error(
+          "ERROR: Must specify a name for your middleware when using --noPrompt argument. Use --middlewareName or -n option."
+        );
+        process.exit(1);
+      }
+
+      this.props.finalConfirmation = true;
+      return;
+    }
+
+    return this.prompt(prompts).then(props => {
+      this.props = props;
+    });
+  }
+
+  writing() {
+    const templateName = "customMiddleware";
+    if (this.props.finalConfirmation !== true) {
+      return;
+    }
+
+    if (this.props.middlewareGenerationPath !== undefined) {
+      middlewareGenerationPath = path.join(this.props.middlewareGenerationPath);
+    }
+
+    if (!this.props.middlewareName.replace(/\s/g, "").length) {
+      this.props.middlewareName = templateName;
+    }
+
+    this.props.middlewareName = this.props.middlewareName.replace(/([^a-z0-9]+)/gi, "");
+
+    var middlewareName;
+    const middlewareNameFolder = this.props.middlewareName;
+    if (middlewareRegExp.test(this.props.middlewareName)) {
+      middlewareName = this.props.middlewareName;
+    } else {
+      middlewareName = this.props.middlewareName.concat("Middleware");
+
+    }
+
+    const middlewareNameCamelCase = _camelCase(middlewareName);
+    const middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
+    middlewareGenerationPath = path.join(middlewareGenerationPath, middlewareName);
+
+    if (this.props.middlewareGenerationPath !== undefined) {
+      middlewareGenerationPath = path.join(
+        this.props.middlewareGenerationPath,
+        middlewareNameFolder
+      );
+    }
+
+    if (fs.existsSync(middlewareGenerationPath)) {
+      isAlreadyCreated = true;
+      return;
+    }
+
+    this.log(chalk.magenta("\nCurrent values for the new middleware:"));
+    this.log(chalk.magenta("Folder: " + middlewareNameFolder));
+    this.log(chalk.magenta("Middleware file: " + middlewareName.concat(".ts")));
+    this.log(chalk.magenta("Path: " + middlewareGenerationPath + "\n"));
+
+    this.fs.copyTpl(
+      this.templatePath(templateName, "_middleware.ts"),
+      this.destinationPath(middlewareGenerationPath, `${middlewareNameCamelCase}.ts`),
+      {
+        middlewareNameClass: middlewareNamePascalCase,
+      }
+    );
+  }
+
+  end() {
+    if (this.props.finalConfirmation === true) {
+      if (isAlreadyCreated) {
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " ERROR: It's seems like you already have a middleware with the same name in the destination path. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " Try again changing the name or the destination path or deleting the previous middleware. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+      } else {
+        this.log(chalk.green("------------------------ "));
+        this.log(chalk.green(" Your new middleware is ready!  "));
+        this.log(chalk.green("------------------------ "));
+      }
+    } else {
+      this.log(chalk.red.bold("-------------------------------- "));
+      this.log(chalk.red.bold(" New middleware creation was canceled. "));
+      this.log(chalk.red.bold("-------------------------------- "));
+    }
+
+    this.log("Thank you for using the Microsoft Bot Framework. ");
+    this.log("\n" + tinyBot + "The Bot Framework Team");
+  }
+};

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/templates/customMiddleware/_middleware.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/templates/customMiddleware/_middleware.ts
@@ -5,17 +5,11 @@ import { ActivityTypes, Middleware, TurnContext } from 'botbuilder';
 
 export class <%=middlewareNameClass%> implements Middleware {
 
-    public static readonly SERVICE: string = '<%=middlewareNameClass%>';
-
     /**
      * @param context The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline
      */
-
-    /**
-     * 
-     */
-    public async onTurn(context: TurnContext, next: () => Promise<void>(): Promise<void> {
+    public onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         
         return next;
     }

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/templates/customMiddleware/_middleware.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/middleware/templates/customMiddleware/_middleware.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+
+import { ActivityTypes, Middleware, TurnContext } from 'botbuilder';
+
+export class <%=middlewareNameClass%> implements Middleware {
+
+    public static readonly SERVICE: string = '<%=middlewareNameClass%>';
+
+    /**
+     * @param context The context object for this turn.
+     * @param next The delegate to call to continue the bot middleware pipeline
+     */
+
+    /**
+     * 
+     */
+    public async onTurn(context: TurnContext, next: () => Promise<void>(): Promise<void> {
+        
+        return next;
+    }
+}

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/package.json
@@ -12,6 +12,7 @@
     "generators",
     "app",
     "dialog",
+    "middleware",
     ".gitignore",
     ".npmignore"
   ],

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
@@ -1,0 +1,57 @@
+"use strict";
+const path = require("path");
+const assert = require("yeoman-assert");
+const helpers = require("yeoman-test");
+const rimraf = require("rimraf");
+const _camelCase = require("lodash/camelCase");
+const _upperFirst = require("lodash/upperFirst");
+
+describe("The generator-botbuilder-enterprise middleware tests ", () => {
+  var middlewareName = "customMiddleware";
+  const middlwareNameCamelCase = _camelCase(middlewareName);
+  const middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
+  const middlewareGenerationPath = path.join("tmp", middlewareName);
+
+  before(() => {
+    return helpers
+      .run(path.join(__dirname, "../generators/dialog"))
+      .inDir(path.join(__dirname, "tmp"))
+      .withPrompts({
+        middlewareName: middlewareName,
+        confirmationPath: true,
+        middlewarePath: process.cwd(),
+        finalConfirmation: true
+      });
+  });
+
+  after(() => {
+    rimraf.sync(path.join(__dirname, "tmp/*"));
+  });
+
+  describe("should create", () => {
+    const files = [middlwareNameCamelCase + ".ts"];
+
+    files.forEach(fileName =>
+      it(fileName + " file", () => {
+        assert.file(path.join(__dirname, middlewareGenerationPath, fileName));
+      })
+    );
+  });
+
+  describe("should have in the dialog file with the given name", () => {
+      
+    it("an export component with the given name", () => {
+      assert.fileContent(
+        path.join(__dirname, middlewareGenerationPath, middlwareNameCamelCase + ".ts"),
+        `export class ${middlewareNamePascalCase}`
+      );
+    });
+
+    it("a super method with the given name as parameter", () => {
+      assert.fileContent(
+        path.join(__dirname, middlewareGenerationPath, middlwareNameCamelCase + ".ts"),
+        `super(${middlewareNamePascalCase}.name)`
+      );
+    });
+  });
+});

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
@@ -6,47 +6,89 @@ const rimraf = require("rimraf");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
 
-describe("The generator-botbuilder-enterprise middleware tests ", () => {
-  var middlewareName = "customMiddleware";
-  const middlewareNameCamelCase = _camelCase(middlewareName);
-  const middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
-  const middlewareGenerationPath = path.join("tmp", middlewareName);
+describe("The generator-botbuilder-enterprise middleware tests ", function() {
+  var middlewareName;
+  var middlewareNameCamelCase;
+  var middlewareNamePascalCase;
+  var middlewareGenerationPath;
+  var confirmationPath;
+  var finalConfirmation;
 
-  before(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/middleware"))
-      .inDir(path.join(__dirname, "tmp"))
-      .withPrompts({
-        middlewareName: middlewareName,
-        confirmationPath: true,
-        middlewarePath: process.cwd(),
-        finalConfirmation: true
+  describe("should create", function() {
+    middlewareName = "customMiddleware";
+    middlewareNameCamelCase = _camelCase(middlewareName);
+    middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
+    middlewareGenerationPath = path.join("tmp", middlewareName);
+    confirmationPath = true;
+    finalConfirmation = true;
+
+    before(() => {
+      return helpers
+        .run(path.join(__dirname, "../generators/middleware"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          middlewareName: middlewareName,
+          confirmationPath: true,
+          middlewarePath: process.cwd(),
+          finalConfirmation: true
+        });
+    });
+
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
+    });
+
+    describe("the file", function() {
+      const file = [middlewareNameCamelCase + ".ts"];
+
+      file.forEach(fileName =>
+        it(fileName + " file", function(done) {
+          assert.file(path.join(__dirname, middlewareGenerationPath, fileName));
+          done();
+        })
+      );
+    });
+
+    describe("and have in the middleware file with the given name", () => {
+      it("an export component with the given name", function(done) {
+        assert.fileContent(
+          path.join(
+            __dirname,
+            middlewareGenerationPath,
+            middlewareNameCamelCase + ".ts"
+          ),
+          `export class ${middlewareNamePascalCase}`
+        );
+        done();
       });
+    });
   });
 
-  after(() => {
-    rimraf.sync(path.join(__dirname, "tmp/*"));
-  });
+  describe("should not create", function() {
+    before(function() {
+      finalConfirmation = false;
+      return helpers
+        .run(path.join(__dirname, "../generators/middleware"))
+        .inDir(path.join(__dirname, "tmp"))
+        .withPrompts({
+          middlewareName: middlewareName,
+          confirmationPath: confirmationPath,
+          middlewareGenerationPath: middlewareGenerationPath,
+          finalConfirmation: finalConfirmation
+        });
+    });
 
-  describe("should create", () => {
-    const files = [middlewareNameCamelCase + ".ts"];
+    after(function() {
+      rimraf.sync(path.join(__dirname, "tmp/*"));
+    });
 
-    files.forEach(fileName =>
-      it(fileName + " file", () => {
-        assert.file(path.join(__dirname, middlewareGenerationPath, fileName));
-      })
-    );
-  });
-
-  describe("should have in the middleware file with the given name", () => {
-    it("an export component with the given name", () => {
-      assert.fileContent(
-        path.join(
-          __dirname,
-          middlewareGenerationPath,
-          middlewareNameCamelCase + ".ts"
-        ),
-        `export class ${middlewareNamePascalCase}`
+    describe("the base", function() {
+      it(
+        middlewareName + " folder when the final confirmation is deny",
+        function(done) {
+          assert.noFile(path.join(__dirname, middlewareGenerationPath));
+          done();
+        }
       );
     });
   });

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
@@ -8,13 +8,13 @@ const _upperFirst = require("lodash/upperFirst");
 
 describe("The generator-botbuilder-enterprise middleware tests ", () => {
   var middlewareName = "customMiddleware";
-  const middlwareNameCamelCase = _camelCase(middlewareName);
+  const middlewareNameCamelCase = _camelCase(middlewareName);
   const middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
   const middlewareGenerationPath = path.join("tmp", middlewareName);
 
   before(() => {
     return helpers
-      .run(path.join(__dirname, "../generators/dialog"))
+      .run(path.join(__dirname, "../generators/middleware"))
       .inDir(path.join(__dirname, "tmp"))
       .withPrompts({
         middlewareName: middlewareName,
@@ -29,7 +29,7 @@ describe("The generator-botbuilder-enterprise middleware tests ", () => {
   });
 
   describe("should create", () => {
-    const files = [middlwareNameCamelCase + ".ts"];
+    const files = [middlewareNameCamelCase + ".ts"];
 
     files.forEach(fileName =>
       it(fileName + " file", () => {
@@ -38,19 +38,15 @@ describe("The generator-botbuilder-enterprise middleware tests ", () => {
     );
   });
 
-  describe("should have in the dialog file with the given name", () => {
-      
+  describe("should have in the middleware file with the given name", () => {
     it("an export component with the given name", () => {
       assert.fileContent(
-        path.join(__dirname, middlewareGenerationPath, middlwareNameCamelCase + ".ts"),
+        path.join(
+          __dirname,
+          middlewareGenerationPath,
+          middlewareNameCamelCase + ".ts"
+        ),
         `export class ${middlewareNamePascalCase}`
-      );
-    });
-
-    it("a super method with the given name as parameter", () => {
-      assert.fileContent(
-        path.join(__dirname, middlewareGenerationPath, middlwareNameCamelCase + ".ts"),
-        `super(${middlewareNamePascalCase}.name)`
       );
     });
   });


### PR DESCRIPTION
## Description
- Add middleware generator. 
- Add test.
- Add readme.

## Related Issue
Fix #707 

## Testing Steps
1. Install Yeoman `npm install -g yo`
2. Go to `.\templates\Enterprise-Template\src\typescript\generator-botbuilder-enterprise` and run `npm i` and `npm link` to symlink the package folder
3. Open a terminal wherever you want to create a middleware
4. Run `yo botbuilder-enterprise:middleware`
5. Follow the generator's prompts
6. Check that the middleware was created successfully

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [X] I have added or updated the appropriate unit tests
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak]~~(https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
