### PR TITLE
[Enterprise Bot Generator][TypeScript] Update hooks to use withArguments instead of withPrompts

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/test/generator-botbuilder-enterprise.middleware.test.suite.js
@@ -5,37 +5,40 @@ const helpers = require("yeoman-test");
 const rimraf = require("rimraf");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
+const semver = require('semver');
 
 describe("The generator-botbuilder-enterprise middleware tests ", function() {
   var middlewareName;
   var middlewareNameCamelCase;
   var middlewareNamePascalCase;
   var middlewareGenerationPath;
-  var confirmationPath;
+  var pathConfirmation;
   var finalConfirmation;
+  var run = true;
 
   describe("should create", function() {
     middlewareName = "customMiddleware";
     middlewareNameCamelCase = _camelCase(middlewareName);
     middlewareNamePascalCase = _upperFirst(_camelCase(middlewareName));
-    middlewareGenerationPath = path.join("tmp", middlewareName);
-    confirmationPath = true;
+    middlewareGenerationPath = path.join(__dirname, "tmp");
+    pathConfirmation = true;
     finalConfirmation = true;
 
-    before(() => {
-      return helpers
-        .run(path.join(__dirname, "../generators/middleware"))
-        .inDir(path.join(__dirname, "tmp"))
-        .withPrompts({
-          middlewareName: middlewareName,
-          confirmationPath: true,
-          middlewarePath: process.cwd(),
-          finalConfirmation: true
-        });
+    before(async function() {
+      await helpers
+        .run(path.join(__dirname, "..", "generators", "middleware"))
+        .inDir(middlewareGenerationPath)
+        .withArguments([
+          '-n',
+          middlewareName,
+          '-p',
+          middlewareGenerationPath,
+          '--noPrompt'
+        ])
     });
 
     after(function() {
-      rimraf.sync(path.join(__dirname, "tmp/*"));
+      rimraf.sync(path.join(__dirname, "tmp", "*"));
     });
 
     describe("the file", function() {
@@ -43,18 +46,18 @@ describe("The generator-botbuilder-enterprise middleware tests ", function() {
 
       file.forEach(fileName =>
         it(fileName + " file", function(done) {
-          assert.file(path.join(__dirname, middlewareGenerationPath, fileName));
+          assert.file(path.join(middlewareGenerationPath, middlewareName, fileName));
           done();
         })
       );
     });
 
-    describe("and have in the middleware file with the given name", () => {
+    describe("and have in the middleware file with the given name", function() {
       it("an export component with the given name", function(done) {
         assert.fileContent(
           path.join(
-            __dirname,
             middlewareGenerationPath,
+            middlewareName,
             middlewareNameCamelCase + ".ts"
           ),
           `export class ${middlewareNamePascalCase}`
@@ -65,28 +68,36 @@ describe("The generator-botbuilder-enterprise middleware tests ", function() {
   });
 
   describe("should not create", function() {
-    before(function() {
+    before(async function() {
+      if(semver.gte(process.versions.node,'10.12.0')){
+        run = false;
+      }
+      else{
       finalConfirmation = false;
-      return helpers
-        .run(path.join(__dirname, "../generators/middleware"))
-        .inDir(path.join(__dirname, "tmp"))
+      await helpers
+        .run(path.join(__dirname, "..", "generators", "middleware"))
+        .inDir(middlewareGenerationPath)
         .withPrompts({
           middlewareName: middlewareName,
-          confirmationPath: confirmationPath,
+          pathConfirmation: pathConfirmation,
           middlewareGenerationPath: middlewareGenerationPath,
           finalConfirmation: finalConfirmation
         });
+      }
     });
 
     after(function() {
-      rimraf.sync(path.join(__dirname, "tmp/*"));
+      rimraf.sync(path.join(__dirname, "tmp", "*"));
     });
 
     describe("the base", function() {
       it(
         middlewareName + " folder when the final confirmation is deny",
         function(done) {
-          assert.noFile(path.join(__dirname, middlewareGenerationPath));
+          if(!run){
+            this.skip()          
+          }
+          assert.noFile(path.join(middlewareGenerationPath, middlewareName));
           done();
         }
       );


### PR DESCRIPTION
## Description
- Change the hooks of the generators' tests to use _withArguments_ instead of _withPrompts_.
- Validate the NodeJS version to skip or not some tests.

## Related Issue
Fix #744 

## Testing Steps
1. Install a NodeJS version >= 10.12.0
2. Go to `AI/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise`
3. Run `npm i`
4. Run `npm run test` and check that the generators' tests runs successfully.

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added or updated the appropriate unit tests

~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
