### PR TITLE
[Enterprise Bot Template][TypeScript] Fix beginDialog call for Onboarding Dialog

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
@@ -117,13 +117,13 @@ export class MainDialog extends RouterDialog {
         }
     }
 
-    protected onEvent(dc: DialogContext): Promise<void> {
+    protected async onEvent(dc: DialogContext): Promise<void> {
         // Check if there was an action submitted from intro card
         if (dc.context.activity.value) {
             // tslint:disable-next-line:no-any
             const value: any = dc.context.activity.value;
             if (value.action === 'startOnboarding') {
-                dc.beginDialog(OnboardingDialog.name);
+                await dc.beginDialog(OnboardingDialog.name);
             }
         }
 


### PR DESCRIPTION
## Description
- Add `async` to `onEvent` method.
- Add `await` to `beginDialog` call inside `onEvent` method.

## Related Issue
Fixes #758 

## Testing Steps
1. Follow Readme instructions to deploy a Bot
1. Start talking to your Bot
1. When the **Intro Card** is sent, answer with the **Getting Started**
1. The Onboarding Dialog will always work without problem

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
