### PR TITLE
[Enterprise Bot Generator][TypeScript] Fix TSLint ordered-imports error during the compilation of a generated bot

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
@@ -32,9 +32,10 @@ import * as i18n from 'i18n';
 import * as path from 'path';
 import * as restify from 'restify';
 import { BotServices } from './botServices';
-import { EnterpriseBot } from './enterpriseBot';
 // Content Moderation Middleware (analyzes incoming messages for inappropriate content including PII, profanity, etc.)
 import { ContentModeratorMiddleware } from './middleware/contentModeratorMiddleware';
+
+import { EnterpriseBot } from './enterpriseBot';
 
 i18n.configure({
     directory: path.join(__dirname, 'locales'),

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_index.ts
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/src/_index.ts
@@ -32,9 +32,10 @@ import * as i18n from 'i18n';
 import * as path from 'path';
 import * as restify from 'restify';
 import { BotServices } from './botServices';
-import { <%= botNameClass %> } from './<%= botNameFile %>';
 // Content Moderation Middleware (analyzes incoming messages for inappropriate content including PII, profanity, etc.)
 import { ContentModeratorMiddleware } from './middleware/contentModeratorMiddleware';
+
+import { <%= botNameClass %> } from './<%= botNameFile %>';
 
 i18n.configure({
     directory: path.join(__dirname, 'locales'),


### PR DESCRIPTION
## Description

- Separate the bot's import from the rest

## Related Issue
Fix #767 

## Testing Steps

1. Go to `AI/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise`
2. Run `npm link`
3. Open a terminal wherever you want to generate your bot
4. Run `yo botbuilder-enterprise`
5. Use a bot's name alphabetically greater than '**middleware**' (like _testbot_)
6. Verify that the compilation ends correctly

## Checklist
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have added or updated the appropriate unit tests~
~- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~ 
~- [ ] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [ ] All languages have been updated~
~- [ ] You have tested deployment with your new models~
