### PR TITLE
Updated WebTest pages so they can be used with unified speech

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Controllers/HomeController.cs
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Controllers/HomeController.cs
@@ -2,36 +2,46 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
 using System.Threading.Tasks;
+using Assistant_WebTest.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Assistant_WebTest.Models;
-using Microsoft.Extensions.Configuration;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using Newtonsoft.Json;using System.Security.Claims;
-using Microsoft.Bot.Schema;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Activity = System.Diagnostics.Activity;
 
 namespace Assistant_WebTest.Controllers
 {
     [Authorize]
     public class HomeController : Controller
-    {        
+    {
         public const string AadObjectidentifierClaim = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+        private readonly ICredentialProvider _credentialProvider;
+        private readonly string _directLineEndpoint;
+
+        private readonly string _directLineSecret;
+        private readonly ILinkedAccountRepository _repository = new LinkedAccountRepository();
+        private readonly string _speechKey;
+        private readonly string _voiceName;
+        private readonly string _speechRegion;
+
         public HomeController(ICredentialProvider provider, IConfiguration configuration)
         {
             // Retrieve the Bot configuration
-            directLineSecret = configuration.GetSection("DirectLineSecret").Value;
-            directLineEndpoint = configuration.GetSection("DirectLineEndpoint").Value;
-            speechKey = configuration.GetSection("SpeechKey").Value;
-            voiceName = configuration.GetSection("VoiceName").Value;
-            credentialProvider = provider;
+            _directLineSecret = configuration.GetSection("DirectLineSecret").Value;
+            _directLineEndpoint = configuration.GetSection("DirectLineEndpoint").Value;
+            _speechKey = configuration.GetSection("SpeechKey").Value;
+            _speechRegion = configuration.GetSection("SpeechRegion").Value;
+            _voiceName = configuration.GetSection("VoiceName").Value;
+            _credentialProvider = provider;
         }
 
         public IActionResult Index()
@@ -44,68 +54,63 @@ namespace Assistant_WebTest.Controllers
             // Get DirectLine Token
             // Pass the DirectLine Token, Speech Key and Voice Name
             // Note this approach will require magic code validation
-            var directLineToken = string.Empty;
-            HttpResponseMessage response = GetDirectLineTokenResponse();
+            var response = GetDirectLineTokenResponse();
 
             if (response.IsSuccessStatusCode)
             {
                 var responseString = response.Content.ReadAsStringAsync().Result;
                 var directLineResponse = JsonConvert.DeserializeObject<DirectLineResponse>(responseString);
-                directLineToken = directLineResponse.Token;
+                var directLineToken = directLineResponse.Token;
 
                 // Update as appropriate for your scenario to the unique identifier claim
-                return View(new WebChatViewModel()
+                return View(new WebChatViewModel
                 {
                     DirectLineToken = directLineToken,
-                    SpeechKey = speechKey,
-                    VoiceName = voiceName,
-                    UserID = this.GetUserId(),
-                    UserName = this.GetUserName()
+                    SpeechKey = _speechKey,
+                    SpeechRegion = _speechRegion,
+                    VoiceName = _voiceName,
+                    UserID = GetUserId(),
+                    UserName = GetUserName()
                 });
             }
-            else
-            {
-                throw new InvalidOperationException($"Exchanging a DirectLine Secret for a Token failed, check your configuration settings. Error: {response.ReasonPhrase}");
-            }
+
+            throw new InvalidOperationException($"Exchanging a DirectLine Secret for a Token failed, check your configuration settings. Error: {response.ReasonPhrase}");
         }
 
         public async Task<IActionResult> LinkedAccounts()
         {
-            var directLineToken = string.Empty;
-            HttpResponseMessage response = GetDirectLineTokenResponse();
+            var response = GetDirectLineTokenResponse();
 
             if (response.IsSuccessStatusCode)
             {
                 var responseString = response.Content.ReadAsStringAsync().Result;
                 var directLineResponse = JsonConvert.DeserializeObject<DirectLineResponse>(responseString);
-                directLineToken = directLineResponse.Token;
+                var directLineToken = directLineResponse.Token;
 
                 // Retrieve the object identifier for the user which will be the userID (fromID) passed to the Bot
-                var userId = this.GetUserId();
+                var userId = GetUserId();
 
                 // Retrieve the status
-                TokenStatus[] tokenStatuses = await repository.GetTokenStatusAsync(userId, credentialProvider);
+                var tokenStatuses = await _repository.GetTokenStatusAsync(userId, _credentialProvider);
 
                 // Pass the User Id, Direct Line Token, Endpoint and Token Status to the View model
-                return View(new LinkedAccountsViewModel()
+                return View(new LinkedAccountsViewModel
                 {
                     UserId = userId,
                     DirectLineToken = directLineToken,
-                    Endpoint = directLineEndpoint,
+                    Endpoint = _directLineEndpoint,
                     Status = tokenStatuses
                 });
             }
-            else
-            {
-                throw new InvalidOperationException($"Exchanging a DirectLine Secret for a Token failed, check your configuration settings. Error: {response.ReasonPhrase}");
-            }
+
+            throw new InvalidOperationException($"Exchanging a DirectLine Secret for a Token failed, check your configuration settings. Error: {response.ReasonPhrase}");
         }
 
         [AllowAnonymous]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {
-            return View(new ErrorViewModel { RequestId = System.Diagnostics.Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
 
         [HttpPost]
@@ -113,7 +118,7 @@ namespace Assistant_WebTest.Controllers
         {
             if (ModelState.IsValid)
             {
-                this.HttpContext.Session.SetString("ChangedUserId", model.UserId);
+                HttpContext.Session.SetString("ChangedUserId", model.UserId);
             }
 
             return RedirectToAction("LinkedAccounts");
@@ -126,30 +131,28 @@ namespace Assistant_WebTest.Controllers
             {
                 return HttpContext.Session.GetString("ChangedUserId");
             }
-            else
+
+            var claimsIdentity = User?.Identity as ClaimsIdentity;
+
+            if (claimsIdentity == null)
             {
-                var claimsIdentity = this.User?.Identity as System.Security.Claims.ClaimsIdentity;
-
-                if (claimsIdentity == null)
-                {
-                    throw new InvalidOperationException("User is not logged in and needs to be.");
-                }
-
-                var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == AadObjectidentifierClaim)?.Value;
-
-                if (objectId == null)
-                {
-                    throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
-                }
-
-                return objectId;
+                throw new InvalidOperationException("User is not logged in and needs to be.");
             }
+
+            var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == AadObjectidentifierClaim)?.Value;
+
+            if (objectId == null)
+            {
+                throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
+            }
+
+            return objectId;
         }
 
         private string GetUserName()
         {
-            // Retrieve the object idenitifer for the user which will be the userID (fromID) passed to the Bot
-            var claimsIdentity = this.User?.Identity as ClaimsIdentity;
+            // Retrieve the object identifier for the user which will be the userID (fromID) passed to the Bot
+            var claimsIdentity = User?.Identity as ClaimsIdentity;
 
             if (claimsIdentity == null)
             {
@@ -169,13 +172,13 @@ namespace Assistant_WebTest.Controllers
         private HttpResponseMessage GetDirectLineTokenResponse()
         {
             var directLineClient = new HttpClient();
-            directLineClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", directLineSecret);
+            directLineClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _directLineSecret);
 
             // In order to avoid magic code prompts we need to set a TrustedOrigin, therefore requests using the token can be validated
             // as coming from this web-site and protecting against scenarios where a URL is shared with someone else
-            string trustedOrigin = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
+            var trustedOrigin = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
 
-            var response = directLineClient.PostAsync($"{directLineEndpoint}/tokens/generate", new StringContent(JsonConvert.SerializeObject(new { TrustedOrigins = new string[] { trustedOrigin } }), Encoding.UTF8, "application/json")).Result;
+            var response = directLineClient.PostAsync($"{_directLineEndpoint}/tokens/generate", new StringContent(JsonConvert.SerializeObject(new { TrustedOrigins = new[] { trustedOrigin } }), Encoding.UTF8, "application/json")).Result;
             return response;
         }
 
@@ -188,7 +191,7 @@ namespace Assistant_WebTest.Controllers
         {
             var userId = GetUserId();
 
-            string link = await repository.GetSignInLinkAsync(userId, credentialProvider, account.ConnectionName, $"{this.Request.Scheme}://{this.Request.Host.Value}/Home/LinkedAccounts");
+            var link = await _repository.GetSignInLinkAsync(userId, _credentialProvider, account.ConnectionName, $"{Request.Scheme}://{Request.Host.Value}/Home/LinkedAccounts");
 
             return Redirect(link);
         }
@@ -202,7 +205,7 @@ namespace Assistant_WebTest.Controllers
         {
             var userId = GetUserId();
 
-            await this.repository.SignOutAsync(userId, credentialProvider, account.ConnectionName);
+            await _repository.SignOutAsync(userId, _credentialProvider, account.ConnectionName);
 
             return RedirectToAction("LinkedAccounts");
         }
@@ -211,16 +214,9 @@ namespace Assistant_WebTest.Controllers
         {
             var userId = GetUserId();
 
-            await this.repository.SignOutAsync(userId, credentialProvider);
+            await _repository.SignOutAsync(userId, _credentialProvider);
 
             return RedirectToAction("LinkedAccounts");
         }
-
-        private string directLineSecret;
-        private string directLineEndpoint;
-        private string speechKey;
-        private string voiceName;
-        private ICredentialProvider credentialProvider;
-        private ILinkedAccountRepository repository = new LinkedAccountRepository();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Models/WebChatViewModel.cs
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Models/WebChatViewModel.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Assistant_WebTest.Models
 {
@@ -16,5 +13,7 @@ namespace Assistant_WebTest.Models
         public string VoiceName { get; set; }
 
         public string SpeechKey { get; set; }
+
+        public string SpeechRegion { get; set; }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Views/Home/WebChat.cshtml
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/Views/Home/WebChat.cshtml
@@ -2,40 +2,41 @@
 @{
     ViewData["Title"] = "Web Chat";
 }
-    <div class="content-row">
-        <div id="webchat" role="main"></div>
-    </div>
-    <script src="https://cdn.botframework.com/botframework-webchat/latest/CognitiveServices.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
-    <script>
+<div class="content-row">
+    <div id="webchat" role="main"></div>
+</div>
+<script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+<script>
+    (async function() {
         var userId = '@Model.UserID';
         var userName = '@Model.UserName';
+        var speechKey = '@Model.SpeechKey';
+        var speechRegion = '@Model.SpeechRegion';
+        var directLineToken = '@Model.DirectLineToken';
 
         // Initials are captured used for user avatar
         var userInitials = userName.replace(/(\S)\S*\s*/ig, "$1");
 
-        const speechOptions = {
-            speechRecognizer: new CognitiveServices.SpeechRecognizer({ subscriptionKey: '@Model.SpeechKey' }),
-            speechSynthesizer: new CognitiveServices.SpeechSynthesizer({
-                gender: CognitiveServices.SynthesisGender.Female,
-                subscriptionKey: '@Model.SpeechKey',
-                voiceName: '@Model.VoiceName'
-            })
-        };
+        let speechFactory;
 
-        var user = { id: userId, role: 'user'};
-
+        if (speechKey != '' && speechRegion != '') {
+            speechFactory  = await window.WebChat.createCognitiveServicesSpeechServicesPonyfillFactory({
+                region: speechRegion,
+                subscriptionKey: speechKey
+            });
+        }
+        
         var bot = window.WebChat.createDirectLine({
-            token: '@Model.DirectLineToken',
-            userID: userId,
-            speechOptions: speechOptions,
-            resize: 'detect'
+            token: directLineToken,
+            userID: userId
         });
 
         window.WebChat.renderWebChat({
-            directLine: bot,
+            directLine: bot, 
             userID: userId,
             botAvatarInitials: 'VA',
-            userAvatarInitials: userInitials
+            userAvatarInitials: userInitials,
+            webSpeechPonyfillFactory: speechFactory
         }, document.getElementById('webchat'));
-    </script>
+    })().catch(err => alert(err));
+</script>

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/appsettings.json
@@ -17,5 +17,6 @@
   "BotMicrosoftAppId": "",
   "BotMicrosoftAppPassword": "",
   "SpeechKey": "",
-  "VoiceName": ""
+  "SpeechRegion": "",
+  "VoiceName": "Not suported yet"
 }

--- a/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/testharnesses/assistant-WebTest/Assistant-WebTest/appsettings.json
@@ -14,9 +14,9 @@
   "AllowedHosts": "*",
   "DirectLineSecret": "",
   "DirectLineEndpoint": "https://directline.botframework.com/v3/directline/",
-  "BotMicrosoftAppId": "",
-  "BotMicrosoftAppPassword": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
   "SpeechKey": "",
   "SpeechRegion": "",
-  "VoiceName": "Not suported yet"
+  "VoiceName": "Not supported yet"
 }


### PR DESCRIPTION
## Description
Fixes to the web test project so it can be used with Unified speech.
Added a SpeechRegion config setting and updated WebChat.cshtml to use unified speech.
If SpeechKey and SpeechRegion (westus, eastus, etc.) are provided in app settings then the microphone will render and you will be able to use speech with webchat.
Note: the latest webchat does not support changing the voice font yet, I left the parameter in config for future use. 

## Related Issue
Need to be able to test the assistant on WebChat with speech.

## Testing Steps
1. Create a Speech service in azure.
2. Update appsettings.json with the service key and region.
3. Add the other parameters required by the project (auth keys, directline, etc.)
4. Run the project and you should be able to use speech.
