### PR TITLE
[To Do] Bug fix: show wrong page when complete a task

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/Dialogs/MarkToDo/MarkToDoItemDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/Dialogs/MarkToDo/MarkToDoItemDialog.cs
@@ -104,6 +104,7 @@ namespace ToDoSkill.Dialogs.MarkToDo
                 {
                     await service.MarkTasksCompletedAsync(state.ListType, state.AllTasks);
                     state.AllTasks.ForEach(task => task.IsCompleted = true);
+                    state.ShowTaskPageIndex = 0;
                 }
                 else
                 {
@@ -112,6 +113,7 @@ namespace ToDoSkill.Dialogs.MarkToDo
                     state.TaskIndexes.ForEach(i => tasksToBeMarked.Add(state.AllTasks[i]));
                     await service.MarkTasksCompletedAsync(state.ListType, tasksToBeMarked);
                     state.TaskIndexes.ForEach(i => state.AllTasks[i].IsCompleted = true);
+                    state.ShowTaskPageIndex = state.TaskIndexes[0] / state.PageSize;
                 }
 
                 var allTasksCount = state.AllTasks.Count;


### PR DESCRIPTION
Fix the bug of showing wrong page when complete a task
## Description
Before the fix, when you complete tasks in other pages, it will still display current page. After the fix, when you complete tasks in other pages, it will display the first page which contains the done task.

## Testing Steps
Add 7 tasks
Go to the next page
Complete task in the first page
The task list should show the first page

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the appropriate unit tests
- [x] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak]
