### PR TITLE
[Calendar] fix calendar skill bugs

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/CreateEventDialog.cs
@@ -13,6 +13,7 @@ using CalendarSkill.Dialogs.FindContact;
 using CalendarSkill.Dialogs.FindContact.Resources;
 using CalendarSkill.Dialogs.Shared;
 using CalendarSkill.Dialogs.Shared.Resources;
+using CalendarSkill.Dialogs.Shared.Resources.Strings;
 using CalendarSkill.Models;
 using CalendarSkill.ServiceClients;
 using Luis;
@@ -380,9 +381,9 @@ namespace CalendarSkill.Dialogs.CreateEvent
                     { "Date", startDateTimeInUserTimeZone.ToSpeechDateString(true) },
                     { "Time", startDateTimeInUserTimeZone.ToSpeechTimeString(true) },
                     { "EndTime", endDateTimeInUserTimeZone.ToSpeechTimeString(true) },
-                    { "Subject", state.Title },
-                    { "Location", state.Location },
-                    { "Content", state.Content },
+                    { "Subject", string.IsNullOrEmpty(state.Title) ? CalendarCommonStrings.Empty : state.Title },
+                    { "Location", string.IsNullOrEmpty(state.Location) ? CalendarCommonStrings.Empty : state.Location },
+                    { "Content", string.IsNullOrEmpty(state.Content) ? CalendarCommonStrings.Empty : state.Content },
                 };
 
                 var card = new Card()

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
@@ -169,6 +169,15 @@ namespace CalendarSkill.Dialogs.Shared.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to empty.
+        /// </summary>
+        public static string Empty {
+            get {
+                return ResourceManager.GetString("Empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to monthly.
         /// </summary>
         public static string MonthlyToken {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.de.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.de.resx
@@ -117,34 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AllDay" xml:space="preserve">
-    <value>Ganztägig</value>
-  </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>Keine Teilnehmer</value>
-  </data>
-  <data name="DailyToken" xml:space="preserve">
-    <value>Täglich</value>
-  </data>
-  <data name="Today" xml:space="preserve">
-    <value>Heute</value>
-  </data>
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} und {1} mehr</value>
   </data>
-  <data name="WeeklyToken" xml:space="preserve">
-    <value>Wöchentliche</value>
+  <data name="AllDayLower" xml:space="preserve">
+    <value>Ganztägig</value>
   </data>
-  <data name="WithTheSubject" xml:space="preserve">
-    <value>Mit einem Subjekt von {0}</value>
+  <data name="AllDay" xml:space="preserve">
+    <value>Ganztägig</value>
   </data>
   <data name="AtTime" xml:space="preserve">
     <value>at {0}</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^ (no | abbrechen/nop/nicht/nicht)</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>Keine Teilnehmer</value>
+  </data>
+  <data name="WeeklyToken" xml:space="preserve">
+    <value>Wöchentliche</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>Leer</value>
+  </data>
+  <data name="WithTheSubject" xml:space="preserve">
+    <value>Mit einem Subjekt von {0}</value>
+  </data>
+  <data name="DailyToken" xml:space="preserve">
+    <value>Täglich</value>
+  </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Monatliche</value>
   </data>
-  <data name="AllDayLower" xml:space="preserve">
-    <value>Ganztägig</value>
+  <data name="Today" xml:space="preserve">
+    <value>Heute</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.es.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.es.resx
@@ -117,34 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AllDay" xml:space="preserve">
-    <value>Todo el día</value>
-  </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>no asistentes</value>
-  </data>
-  <data name="DailyToken" xml:space="preserve">
-    <value>Diario</value>
-  </data>
-  <data name="Today" xml:space="preserve">
-    <value>Hoy</value>
-  </data>
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} y {1} más</value>
   </data>
-  <data name="WeeklyToken" xml:space="preserve">
-    <value>Semanal</value>
+  <data name="AllDayLower" xml:space="preserve">
+    <value>todo el día</value>
   </data>
-  <data name="WithTheSubject" xml:space="preserve">
-    <value>con un tema de {0}</value>
+  <data name="AllDay" xml:space="preserve">
+    <value>Todo el día</value>
   </data>
   <data name="AtTime" xml:space="preserve">
     <value>en {0}</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^ (no | CANCEL | NOP | no | no)</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>no asistentes</value>
+  </data>
+  <data name="WeeklyToken" xml:space="preserve">
+    <value>Semanal</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>Vacío</value>
+  </data>
+  <data name="WithTheSubject" xml:space="preserve">
+    <value>con un tema de {0}</value>
+  </data>
+  <data name="DailyToken" xml:space="preserve">
+    <value>Diario</value>
+  </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensual</value>
   </data>
-  <data name="AllDayLower" xml:space="preserve">
-    <value>todo el día</value>
+  <data name="Today" xml:space="preserve">
+    <value>Hoy</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.fr.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.fr.resx
@@ -117,34 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AllDay" xml:space="preserve">
-    <value>Toute la journée</value>
-  </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>pas de participants</value>
-  </data>
-  <data name="DailyToken" xml:space="preserve">
-    <value>Quotidienne</value>
-  </data>
-  <data name="Today" xml:space="preserve">
-    <value>Aujourd'hui</value>
-  </data>
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} et {1} en savoir plus</value>
   </data>
-  <data name="WeeklyToken" xml:space="preserve">
-    <value>Hebdomadaire</value>
+  <data name="AllDayLower" xml:space="preserve">
+    <value>toute la journée</value>
   </data>
-  <data name="WithTheSubject" xml:space="preserve">
-    <value>avec un sujet de {0}</value>
+  <data name="AllDay" xml:space="preserve">
+    <value>Toute la journée</value>
   </data>
   <data name="AtTime" xml:space="preserve">
     <value>à {0}</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^ (non | annuler | NOP | non | non)</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>pas de participants</value>
+  </data>
+  <data name="WeeklyToken" xml:space="preserve">
+    <value>Hebdomadaire</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>Vide</value>
+  </data>
+  <data name="WithTheSubject" xml:space="preserve">
+    <value>avec un sujet de {0}</value>
+  </data>
+  <data name="DailyToken" xml:space="preserve">
+    <value>Quotidienne</value>
+  </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensuel</value>
   </data>
-  <data name="AllDayLower" xml:space="preserve">
-    <value>toute la journée</value>
+  <data name="Today" xml:space="preserve">
+    <value>Aujourd'hui</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.it.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.it.resx
@@ -117,34 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AllDay" xml:space="preserve">
-    <value>Tutto il giorno</value>
-  </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>Nessun partecipante</value>
-  </data>
-  <data name="DailyToken" xml:space="preserve">
-    <value>Quotidiana</value>
-  </data>
-  <data name="Today" xml:space="preserve">
-    <value>Oggi</value>
-  </data>
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} e {1} di più</value>
   </data>
-  <data name="WeeklyToken" xml:space="preserve">
-    <value>Settimanale</value>
+  <data name="AllDayLower" xml:space="preserve">
+    <value>tutto il giorno</value>
   </data>
-  <data name="WithTheSubject" xml:space="preserve">
-    <value>con un oggetto di {0}</value>
+  <data name="AllDay" xml:space="preserve">
+    <value>Tutto il giorno</value>
   </data>
   <data name="AtTime" xml:space="preserve">
     <value>alle {0}</value>
   </data>
+  <data name="CancelAdjust" xml:space="preserve">
+    <value>^ (No | Annulla | NOP | non | not)</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>Nessun partecipante</value>
+  </data>
+  <data name="WeeklyToken" xml:space="preserve">
+    <value>Settimanale</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>Vuoto</value>
+  </data>
+  <data name="WithTheSubject" xml:space="preserve">
+    <value>con un oggetto di {0}</value>
+  </data>
+  <data name="DailyToken" xml:space="preserve">
+    <value>Quotidiana</value>
+  </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensile</value>
   </data>
-  <data name="AllDayLower" xml:space="preserve">
-    <value>tutto il giorno</value>
+  <data name="Today" xml:space="preserve">
+    <value>Oggi</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
@@ -168,4 +168,7 @@
   <data name="NoAttendees" xml:space="preserve">
     <value>no attendees</value>
   </data>
+  <data name="Empty" xml:space="preserve">
+    <value>empty</value>
+  </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
@@ -150,4 +150,7 @@
   <data name="NoAttendees" xml:space="preserve">
     <value>无与会人</value>
   </data>
+  <data name="Empty" xml:space="preserve">
+    <value>空</value>
+  </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -285,9 +285,14 @@ namespace CalendarSkill.Dialogs.Summary
                     state.Clear();
                     return await sc.CancelAllDialogsAsync();
                 }
-                else if ((promptRecognizerResult.Succeeded && promptRecognizerResult.Value == true) || state.SummaryEvents.Count == 1)
+                else if (promptRecognizerResult.Succeeded && promptRecognizerResult.Value == true)
                 {
                     state.ReadOutEvents = new List<EventModel>() { state.SummaryEvents[0] };
+                }
+                else if (state.SummaryEvents.Count == 1)
+                {
+                    state.Clear();
+                    return await sc.CancelAllDialogsAsync();
                 }
 
                 if (state.SummaryEvents.Count > 1 && (state.ReadOutEvents == null || state.ReadOutEvents.Count <= 0))
@@ -308,7 +313,7 @@ namespace CalendarSkill.Dialogs.Summary
 
                     if (filteredMeetingList.Count <= 0 && luisResult.Entities.number != null && (luisResult.Entities.ordinal == null || luisResult.Entities.ordinal.Length == 0))
                     {
-                        var value = luisResult.Entities.ordinal[0];
+                        var value = luisResult.Entities.number[0];
                         var num = int.Parse(value.ToString());
                         var currentList = GetCurrentPageMeetings(state.SummaryEvents, state);
                         if (num > 0 && num <= currentList.Count)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
fix bugs:
1. Incorrect meeting display message after skip location and message
2. Exception when try to book a meeting after display meeting

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can enable automation to close related issues, using keyword Close #ISSUENUMBER -->
<!--- See https://help.github.com/articles/closing-issues-using-keywords/ for more information -->
<!--- Please link to the issue here: -->
https://fuselabs.visualstudio.com/Solutions/_workitems/edit/27307/
https://fuselabs.visualstudio.com/Solutions/_workitems/edit/27308/

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
1. Create a meeting without location and content, then check the confirm wording
2. Show the meeting list then choose meeting by number like "1", should be no exception here

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
