### PR TITLE
Escape appSecret when passing to msbot clone

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
@@ -25,7 +25,8 @@ if (!$languagesOnly)
 
 	# Deploy the common resources (Azure Bot Service, App Insights, Azure Storage, Cosmos DB, etc)
 	Write-Host "Deploying common resources..."
-	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --folder "$($PSScriptRoot)" --appId $appId --appSecret $appSecret --force --quiet 
+	Write-Host $appSecret
+	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --folder "$($PSScriptRoot)" --appId $appId --% --appSecret $appSecret --force --quiet 
 }
 
 $localeArr = $locales.Split(',')

--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
@@ -25,7 +25,6 @@ if (!$languagesOnly)
 
 	# Deploy the common resources (Azure Bot Service, App Insights, Azure Storage, Cosmos DB, etc)
 	Write-Host "Deploying common resources..."
-	Write-Host $appSecret
 	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --folder "$($PSScriptRoot)" --appId $appId --% --appSecret $appSecret --force --quiet 
 }
 


### PR DESCRIPTION
## Description
Add `--%` as [documented on this page](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/MSBot/docs/export-clone.md) for powershell calls 

## Related Issue
#790 

## Testing Steps
Start the deployment of the virtual assistant using following appSecret. It will output an error without the fix.
`PowerShell.exe -ExecutionPolicy Bypass -File DeploymentScripts\deploy_bot.ps1 --appId "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" --appSecret "5xUzz-I])4(M!LS}73xpTU%n"`

