### PR TITLE
first proactive scenario

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Microsoft.Bot.Solutions.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Microsoft.Bot.Solutions.csproj
@@ -62,6 +62,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\utilities\Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Resources\CommonResponses.cs">
       <DependentUpon>CommonResponses.tt</DependentUpon>
       <DesignTime>True</DesignTime>

--- a/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Middleware/ProactiveStateMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Middleware/ProactiveStateMiddleware.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Solutions.Models.Proactive;
+using Utilities;
 using static Microsoft.Bot.Solutions.Models.Proactive.ProactiveModel;
 
 namespace Microsoft.Bot.Solutions.Middleware
@@ -33,11 +36,11 @@ namespace Microsoft.Bot.Solutions.Middleware
             {
                 var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel());
                 ProactiveData data;
-                var userId = turnContext.Activity.From.Id;
+                var hashedUserId = MD5Util.ComputeHash(turnContext.Activity.From.Id);
                 var conversationReference = turnContext.Activity.GetConversationReference();
                 var proactiveData = new ProactiveData { Conversation = conversationReference };
 
-                if (proactiveState.TryGetValue(userId, out data))
+                if (proactiveState.TryGetValue(hashedUserId, out data))
                 {
                     data.Conversation = conversationReference;
                 }
@@ -46,7 +49,7 @@ namespace Microsoft.Bot.Solutions.Middleware
                     data = new ProactiveData { Conversation = conversationReference };
                 }
 
-                proactiveState[userId] = data;
+                proactiveState[hashedUserId] = data;
                 await _proactiveStateAccessor.SetAsync(turnContext, proactiveState);
                 await _proactiveState.SaveChangesAsync(turnContext);
             }

--- a/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Middleware/ProactiveStateMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Middleware/ProactiveStateMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
@@ -26,24 +27,29 @@ namespace Microsoft.Bot.Solutions.Middleware
 
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel());
-            ProactiveData data;
-            var userId = turnContext.Activity.From.Id;
-            var conversationReference = turnContext.Activity.GetConversationReference();
-            var proactiveData = new ProactiveData { Conversation = conversationReference };
+            var activity = turnContext.Activity;
 
-            if (proactiveState.TryGetValue(userId, out data))
+            if (activity.From.Properties["role"].ToString().Equals("user", StringComparison.InvariantCultureIgnoreCase))
             {
-                data.Conversation = conversationReference;
-            }
-            else
-            {
-                data = new ProactiveData { Conversation = conversationReference };
-            }
+                var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel());
+                ProactiveData data;
+                var userId = turnContext.Activity.From.Id;
+                var conversationReference = turnContext.Activity.GetConversationReference();
+                var proactiveData = new ProactiveData { Conversation = conversationReference };
 
-            proactiveState[userId] = data;
-            await _proactiveStateAccessor.SetAsync(turnContext, proactiveState);
-            await _proactiveState.SaveChangesAsync(turnContext);
+                if (proactiveState.TryGetValue(userId, out data))
+                {
+                    data.Conversation = conversationReference;
+                }
+                else
+                {
+                    data = new ProactiveData { Conversation = conversationReference };
+                }
+
+                proactiveState[userId] = data;
+                await _proactiveStateAccessor.SetAsync(turnContext, proactiveState);
+                await _proactiveState.SaveChangesAsync(turnContext);
+            }
 
             await next(cancellationToken).ConfigureAwait(false);
         }

--- a/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Models/Proactive/ProactiveStep.cs
+++ b/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Models/Proactive/ProactiveStep.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Configuration;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Solutions.Model.Proactive
+{
+    public class ProactiveStep : ConnectedService
+    {
+        public ProactiveStep()
+            : base("proactiveStep")
+        {
+        }
+
+        [JsonProperty("event")]
+        public string Event { get; set; }
+
+        [JsonProperty("skillId")]
+        public string SkillId { get; set; }
+
+        [JsonProperty("parameters")]
+        public Dictionary<string, string> Parameters { get; set; }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Util/CommonUtil.cs
+++ b/solutions/Virtual-Assistant/src/csharp/Microsoft.Bot.Solutions/Util/CommonUtil.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Bot.Solutions.Util
         public const int MaxDisplaySize = 6;
 
         public const string DialogTurnResultCancelAllDialogs = "cancelAllDialogs";
+
+        public const string DeliveryModeProactive = "proactive";
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/VirtualAssistant.sln
+++ b/solutions/Virtual-Assistant/src/csharp/VirtualAssistant.sln
@@ -43,6 +43,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CalendarSkill", "skills\cal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VirtualAssistant.Tests", "tests\VirtualAssistant.Tests\VirtualAssistant.Tests.csproj", "{27C52F70-42F8-40C2-AE38-AB75515C3D91}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilities", "utilities\Utilities.csproj", "{54B54E99-2B8C-4FD1-98AE-93F331F88670}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,10 @@ Global
 		{27C52F70-42F8-40C2-AE38-AB75515C3D91}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27C52F70-42F8-40C2-AE38-AB75515C3D91}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27C52F70-42F8-40C2-AE38-AB75515C3D91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54B54E99-2B8C-4FD1-98AE-93F331F88670}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54B54E99-2B8C-4FD1-98AE-93F331F88670}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54B54E99-2B8C-4FD1-98AE-93F331F88670}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54B54E99-2B8C-4FD1-98AE-93F331F88670}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
@@ -12,6 +12,7 @@ using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Model.Proactive;
 using Microsoft.Bot.Solutions.Skills;
 
 namespace VirtualAssistant
@@ -40,7 +41,7 @@ namespace VirtualAssistant
         /// <param name="botConfiguration">The <see cref="BotConfiguration"/> instance for the bot.</param>
         /// <param name="skills">List of <see cref="SkillDefinition"/> for loading skill configurations.</param>
         /// <param name="languageModels">The locale specifc language model configs for each supported language.</param>
-        public BotServices(BotConfiguration botConfiguration, Dictionary<string, Dictionary<string, string>> languageModels, List<SkillDefinition> skills)
+        public BotServices(BotConfiguration botConfiguration, Dictionary<string, Dictionary<string, string>> languageModels, List<SkillDefinition> skills, List<ProactiveStep> proactiveScenariosConfig)
         {
             // Create service clients for each service in the .bot file.
             foreach (var service in botConfiguration.Services)
@@ -227,6 +228,7 @@ namespace VirtualAssistant
 
                 SkillDefinitions.Add(skill);
                 SkillConfigurations.Add(skill.Id, skillConfig);
+                ProactiveSteps = proactiveScenariosConfig.ToDictionary(i => i.Event);
             }
         }
 
@@ -285,5 +287,14 @@ namespace VirtualAssistant
         /// The value is an <see cref="SkillConfigurationBase"/> object containing all the service clients used by the skill.
         /// </value>
         public Dictionary<string, SkillConfigurationBase> SkillConfigurations { get; set; } = new Dictionary<string, SkillConfigurationBase>();
+
+        /// <summary>
+        /// Gets or sets proactive steps that's loaded from proactiveScenarios.json file.
+        /// </summary>
+        /// <value>
+        /// The steps defined in proactiveScenarios.json file that specifies what happens
+        /// when different events are received for proactive scenarios.
+        /// </value>
+        public Dictionary<string, ProactiveStep> ProactiveSteps { get; set; } = new Dictionary<string, ProactiveStep>();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -14,7 +14,10 @@ using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Skills;
+using Newtonsoft.Json;
+using Utilities.TaskExtensions;
 using VirtualAssistant.Dialogs.Escalate;
 using VirtualAssistant.Dialogs.Main.Resources;
 using VirtualAssistant.Dialogs.Onboarding;
@@ -28,7 +31,9 @@ namespace VirtualAssistant.Dialogs.Main
         private BotServices _services;
         private UserState _userState;
         private ConversationState _conversationState;
+        private ProactiveState _proactiveState;
         private EndpointService _endpointService;
+        private IBackgroundTaskQueue _backgroundTaskQueue;
         private IStatePropertyAccessor<OnboardingState> _onboardingState;
         private IStatePropertyAccessor<Dictionary<string, object>> _parametersAccessor;
         private IStatePropertyAccessor<VirtualAssistantState> _virtualAssistantState;
@@ -37,14 +42,16 @@ namespace VirtualAssistant.Dialogs.Main
 
         private bool _conversationStarted = false;
 
-        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
+        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, ProactiveState proactiveState, EndpointService endpointService, IBotTelemetryClient telemetryClient, IBackgroundTaskQueue backgroundTaskQueue)
             : base(nameof(MainDialog), telemetryClient)
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _conversationState = conversationState;
             _userState = userState;
+            _proactiveState = proactiveState;
             _endpointService = endpointService;
             TelemetryClient = telemetryClient;
+            _backgroundTaskQueue = backgroundTaskQueue;
             _onboardingState = _userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
             _parametersAccessor = _userState.CreateProperty<Dictionary<string, object>>("userInfo");
             _virtualAssistantState = _conversationState.CreateProperty<VirtualAssistantState>(nameof(VirtualAssistantState));
@@ -218,100 +225,144 @@ namespace VirtualAssistant.Dialogs.Main
                 var trace = new Activity(type: ActivityTypes.Trace, text: $"Received event: {ev.Name}");
                 await dc.Context.SendActivityAsync(trace);
 
-                switch (ev.Name)
+                // see if there's a proactive step defined with this event
+                var proactiveSteps = _services.ProactiveSteps;
+                if (proactiveSteps != null && proactiveSteps.ContainsKey(ev.Name))
                 {
-                    case Events.TimezoneEvent:
+                    var nextStep = proactiveSteps[ev.Name];
+
+                    var value = ev.Value != null ? JsonConvert.DeserializeObject<Dictionary<string, string>>(ev.Value.ToString()) : null;
+                    var skillId = nextStep.SkillId;
+
+                    if (string.IsNullOrWhiteSpace(skillId))
+                    {
+                        var errorMessage = "SkillId is not defined in the proactive steps. Without it the assistant doesn't know where to route the message to.";
+                        await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: errorMessage));
+                        TelemetryClient.TrackException(new ArgumentException(errorMessage));
+                    }
+
+                    dc.Context.Activity.Value = value;
+                    var matchedSkill = _skillRouter.IdentifyRegisteredSkill(skillId);
+                    if (matchedSkill != null)
+                    {
+                        await RouteToSkillAsync(dc, new SkillDialogOptions()
                         {
-                            try
+                            SkillDefinition = matchedSkill,
+                        });
+
+                        forward = false;
+                    }
+                    else
+                    {
+                        // skill id defined in proactive step config is wrong
+                        var skillList = new List<string>();
+                        _services.SkillDefinitions.ForEach(a => skillList.Add(a.DispatchIntent));
+
+                        var errorMessage = $"SkillId defined in the proactive steps is not supported. It should be one of these: {string.Join(',', skillList.ToArray())}.";
+
+                        await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: errorMessage));
+                        TelemetryClient.TrackException(new ArgumentException(errorMessage));
+                    }
+
+                    // TODO: add handling for other types of proactive events
+                }
+                else
+                {
+                    switch (ev.Name)
+                    {
+                        case Events.TimezoneEvent:
                             {
-                                var timezone = ev.Value.ToString();
-                                var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
-
-                                parameters[ev.Name] = tz;
-                            }
-                            catch
-                            {
-                                await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Timezone passed could not be mapped to a valid Timezone. Property not set."));
-                            }
-
-                            forward = false;
-                            break;
-                        }
-
-                    case Events.LocationEvent:
-                        {
-                            parameters[ev.Name] = ev.Value;
-                            forward = false;
-                            break;
-                        }
-
-                    case Events.TokenResponseEvent:
-                        {
-                            forward = true;
-                            break;
-                        }
-
-                    case Events.ActiveLocationUpdate:
-                    case Events.ActiveRouteUpdate:
-                        {
-                            var matchedSkill = _skillRouter.IdentifyRegisteredSkill(Dispatch.Intent.l_PointOfInterest.ToString());
-
-                            await RouteToSkillAsync(dc, new SkillDialogOptions()
-                            {
-                                SkillDefinition = matchedSkill,
-                            });
-
-                            forward = false;
-                            break;
-                        }
-
-                    case Events.ResetUser:
-                        {
-                            await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: "Reset User Event received, clearing down State and Tokens."));
-
-                            // Clear State
-                            await _onboardingState.DeleteAsync(dc.Context, cancellationToken);
-
-                            // Clear Tokens
-                            var adapter = dc.Context.Adapter as BotFrameworkAdapter;
-                            if (adapter != null)
-                            {
-                                await adapter.SignOutUserAsync(dc.Context, null, dc.Context.Activity.From.Id, cancellationToken);
-                            }
-
-                            forward = false;
-
-                            break;
-                        }
-
-                    case Events.StartConversation:
-                        {
-                            forward = false;
-
-                            if (!_conversationStarted)
-                            {
-                                if (string.IsNullOrWhiteSpace(dc.Context.Activity.Locale))
+                                try
                                 {
-                                    // startConversation activity should have locale in it. if not, log it
-                                    TelemetryClient.TrackEventEx("NoLocaleInStartConversation", dc.Context.Activity, dc.ActiveDialog?.Id);
+                                    var timezone = ev.Value.ToString();
+                                    var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
 
-                                    break;
+                                    parameters[ev.Name] = tz;
+                                }
+                                catch
+                                {
+                                    await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Timezone passed could not be mapped to a valid Timezone. Property not set."));
                                 }
 
-                                await StartConversation(dc);
-
-                                _conversationStarted = true;
+                                forward = false;
+                                break;
                             }
 
-                            break;
-                        }
+                        case Events.LocationEvent:
+                            {
+                                parameters[ev.Name] = ev.Value;
+                                forward = false;
+                                break;
+                            }
 
-                    default:
-                        {
-                            await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Unknown Event {ev.Name} was received but not processed."));
-                            forward = false;
-                            break;
-                        }
+                        case Events.TokenResponseEvent:
+                            {
+                                forward = true;
+                                break;
+                            }
+
+                        case Events.ActiveLocationUpdate:
+                        case Events.ActiveRouteUpdate:
+                            {
+                                var matchedSkill = _skillRouter.IdentifyRegisteredSkill(Dispatch.Intent.l_PointOfInterest.ToString());
+
+                                await RouteToSkillAsync(dc, new SkillDialogOptions()
+                                {
+                                    SkillDefinition = matchedSkill,
+                                });
+
+                                forward = false;
+                                break;
+                            }
+
+                        case Events.ResetUser:
+                            {
+                                await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: "Reset User Event received, clearing down State and Tokens."));
+
+                                // Clear State
+                                await _onboardingState.DeleteAsync(dc.Context, cancellationToken);
+
+                                // Clear Tokens
+                                var adapter = dc.Context.Adapter as BotFrameworkAdapter;
+                                if (adapter != null)
+                                {
+                                    await adapter.SignOutUserAsync(dc.Context, null, dc.Context.Activity.From.Id, cancellationToken);
+                                }
+
+                                forward = false;
+
+                                break;
+                            }
+
+                        case Events.StartConversation:
+                            {
+                                forward = false;
+
+                                if (!_conversationStarted)
+                                {
+                                    if (string.IsNullOrWhiteSpace(dc.Context.Activity.Locale))
+                                    {
+                                        // startConversation activity should have locale in it. if not, log it
+                                        TelemetryClient.TrackEventEx("NoLocaleInStartConversation", dc.Context.Activity, dc.ActiveDialog?.Id);
+
+                                        break;
+                                    }
+
+                                    await StartConversation(dc);
+
+                                    _conversationStarted = true;
+                                }
+
+                                break;
+                            }
+
+                        default:
+                            {
+                                await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Unknown Event {ev.Name} was received but not processed."));
+                                forward = false;
+                                break;
+                            }
+                    }
                 }
 
                 if (forward)
@@ -384,7 +435,7 @@ namespace VirtualAssistant.Dialogs.Main
         {
             foreach (var definition in skillDefinitions)
             {
-                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], _endpointService, TelemetryClient));
+                AddDialog(new SkillDialog(definition, _services.SkillConfigurations[definition.Id], _proactiveState, _endpointService, TelemetryClient, _backgroundTaskQueue));
             }
 
             // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.cs
@@ -8,6 +8,8 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions.Models.Proactive;
+using Utilities.TaskExtensions;
 using VirtualAssistant.Dialogs.Main;
 
 namespace VirtualAssistant
@@ -20,8 +22,10 @@ namespace VirtualAssistant
         private readonly BotServices _services;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
+        private readonly ProactiveState _proactiveState;
         private readonly EndpointService _endpointService;
         private readonly IBotTelemetryClient _telemetryClient;
+        private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private DialogSet _dialogs;
 
         /// <summary>
@@ -30,18 +34,22 @@ namespace VirtualAssistant
         /// <param name="botServices">Bot services.</param>
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
+        /// <param name="proactiveState">Proactive state.</param>
         /// <param name="endpointService">Bot endpoint service.</param>
         /// <param name="telemetryClient">Bot telemetry client.</param>
-        public VirtualAssistant(BotServices botServices, ConversationState conversationState, UserState userState, EndpointService endpointService, IBotTelemetryClient telemetryClient)
+        /// <param name="backgroundTaskQueue">Background task queue.</param>
+        public VirtualAssistant(BotServices botServices, ConversationState conversationState, UserState userState, ProactiveState proactiveState, EndpointService endpointService, IBotTelemetryClient telemetryClient, IBackgroundTaskQueue backgroundTaskQueue)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
+            _proactiveState = proactiveState ?? throw new ArgumentNullException(nameof(proactiveState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
             _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            _backgroundTaskQueue = backgroundTaskQueue;
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(VirtualAssistant)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _endpointService, _telemetryClient));
+            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _proactiveState, _endpointService, _telemetryClient, _backgroundTaskQueue));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
@@ -103,6 +103,7 @@
     <ProjectReference Include="..\skills\emailskill\emailskill\EmailSkill.csproj" />
     <ProjectReference Include="..\skills\pointofinterestskill\pointofinterestskill\PointOfInterestSkill.csproj" />
     <ProjectReference Include="..\skills\todoskill\todoskill\ToDoSkill.csproj" />
+    <ProjectReference Include="..\utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "botFilePath": ".\\YOUR_BOT_PATH.bot",
+  "botFilePath": ".\\bfvainternal.bot",
   "botFileSecret": "",
   "ApplicationInsights": {
     "InstrumentationKey": ""
@@ -7,7 +7,7 @@
   "defaultLocale": "en-us",
   "languageModels": {
     "en": {
-      "botFilePath": ".\\LocaleConfigurations\\YOUR_EN_BOT_PATH.bot",
+      "botFilePath": ".\\LocaleConfigurations\\bfvainternalen.bot",
       "botFileSecret": ""
     },
     "de": {
@@ -27,7 +27,7 @@
       "botFileSecret": ""
     },
     "zh": {
-      "botFilePath": ".\\LocaleConfigurations\\YOUR_ZH_BOT_PATH.bot",
+      "botFilePath": ".\\LocaleConfigurations\\bfvainternalzh.bot",
       "botFileSecret": ""
     }
   },

--- a/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "botFilePath": ".\\bfvainternal.bot",
+  "botFilePath": ".\\YOUR_BOT_PATH.bot",
   "botFileSecret": "",
   "ApplicationInsights": {
     "InstrumentationKey": ""
@@ -7,7 +7,7 @@
   "defaultLocale": "en-us",
   "languageModels": {
     "en": {
-      "botFilePath": ".\\LocaleConfigurations\\bfvainternalen.bot",
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_EN_BOT_PATH.bot",
       "botFileSecret": ""
     },
     "de": {
@@ -27,7 +27,7 @@
       "botFileSecret": ""
     },
     "zh": {
-      "botFilePath": ".\\LocaleConfigurations\\bfvainternalzh.bot",
+      "botFilePath": ".\\LocaleConfigurations\\YOUR_ZH_BOT_PATH.bot",
       "botFileSecret": ""
     }
   },

--- a/solutions/Virtual-Assistant/src/csharp/assistant/proactiveScenarios.json
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/proactiveScenarios.json
@@ -1,0 +1,9 @@
+{
+  "proactiveSteps": [
+    {
+      "event": "CarStart",
+      "skillId": "l_Calendar",
+      "parameters": {}
+    }
+  ]
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.cs
@@ -15,10 +15,13 @@ namespace AutomotiveSkill
     using Microsoft.AspNetCore.Http;
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Builder.Dialogs;
+    using Microsoft.Bot.Configuration;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Solutions.Middleware.Telemetry;
+    using Microsoft.Bot.Solutions.Models.Proactive;
     using Microsoft.Bot.Solutions.Responses;
     using Microsoft.Bot.Solutions.Skills;
+    using Utilities.TaskExtensions;
 
     /// <summary>
     /// Main entry point and orchestration for bot.
@@ -26,6 +29,7 @@ namespace AutomotiveSkill
     public class AutomotiveSkill : IBot
     {
         private readonly SkillConfigurationBase _services;
+        private readonly EndpointService _endpointService;
         private readonly ResponseManager _responseManager;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
@@ -39,18 +43,24 @@ namespace AutomotiveSkill
         /// Initializes a new instance of the <see cref="AutomotiveSkill"/> class.
         /// </summary>
         /// <param name="services">Skill Configuration information.</param>
+        /// <param name="endpointService">Endpoint service for the bot.</param>
         /// <param name="conversationState">Conversation State.</param>
         /// <param name="userState">User State.</param>
+        /// <param name="proactiveState">Proative state.</param>
         /// <param name="telemetryClient">Telemetry Client.</param>
+        /// <param name="backgroundTaskQueue">Background task queue.</param>
         /// <param name="serviceManager">Service Manager.</param>
         /// <param name="skillMode">Indicates whether the skill is running in skill or local mode.</param>
         /// <param name="responseManager">The responses for the bot.</param>
         /// <param name="httpContext">HttpContext accessor used to create relative URIs for images when in local mode.</param>
         public AutomotiveSkill(
             SkillConfigurationBase services,
+            EndpointService endpointService,
             ConversationState conversationState,
             UserState userState,
+            ProactiveState proactiveState,
             IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue,
             bool skillMode = false,
             ResponseManager responseManager = null,
             IServiceManager serviceManager = null,
@@ -58,6 +68,7 @@ namespace AutomotiveSkill
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
+            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
 
             // If we are running in local-mode we need the HttpContext to create image file paths

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.csproj
@@ -131,6 +131,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+    <ProjectReference Include="..\..\..\utilities\Utilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/AutomotiveSkillTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/AutomotiveSkillTestBase.cs
@@ -9,9 +9,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
+using Utilities.TaskExtensions;
 
 namespace AutomotiveSkillTest.Flow
 {
@@ -23,6 +25,8 @@ namespace AutomotiveSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public ProactiveState ProactiveState { get; set; }
+
         public SkillConfigurationBase Services { get; set; }
 
         public BotConfiguration Options { get; set; }
@@ -30,6 +34,10 @@ namespace AutomotiveSkillTest.Flow
         public HttpContext MockHttpContext { get; set; }
 
         public IBotTelemetryClient TelemetryClient { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
+
+        public EndpointService EndpointService { get; set; }
 
         public HttpContextAccessor MockHttpContextAcessor { get; set; }
 
@@ -41,8 +49,11 @@ namespace AutomotiveSkillTest.Flow
 
             ConversationState = new ConversationState(new MemoryStorage());
             UserState = new UserState(new MemoryStorage());
+            ProactiveState = new ProactiveState(new MemoryStorage());
             AutomotiveSkillStateAccessor = ConversationState.CreateProperty<AutomotiveSkillState>(nameof(AutomotiveSkillState));
             Services = new MockSkillConfiguration();
+            BackgroundTaskQueue = new BackgroundTaskQueue();
+            EndpointService = new EndpointService();
 
             ResponseManager = new ResponseManager(
                 responseTemplates: new IResponseIdCollection[] 
@@ -91,7 +102,7 @@ namespace AutomotiveSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new AutomotiveSkill.AutomotiveSkill(Services, ConversationState, UserState, TelemetryClient, true, ResponseManager, null, MockHttpContextAcessor);
+            return new AutomotiveSkill.AutomotiveSkill(Services, EndpointService, ConversationState, UserState, ProactiveState, TelemetryClient, BackgroundTaskQueue, true, ResponseManager, null, MockHttpContextAcessor);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkill.cs
@@ -14,13 +14,17 @@ using CalendarSkill.Dialogs.Main.Resources;
 using CalendarSkill.Dialogs.Shared.Resources;
 using CalendarSkill.Dialogs.Summary.Resources;
 using CalendarSkill.Dialogs.TimeRemaining.Resources;
+using CalendarSkill.Dialogs.UpcomingEvent.Resources;
 using CalendarSkill.Dialogs.UpdateEvent.Resources;
 using CalendarSkill.ServiceClients;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
+using Utilities.TaskExtensions;
 
 namespace CalendarSkill
 {
@@ -30,29 +34,38 @@ namespace CalendarSkill
     public class CalendarSkill : IBot
     {
         private readonly SkillConfigurationBase _services;
+        private readonly EndpointService _endpointService;
         private readonly ResponseManager _responseManager;
         private readonly UserState _userState;
         private readonly ConversationState _conversationState;
+        private readonly ProactiveState _proactiveState;
         private readonly IBotTelemetryClient _telemetryClient;
+        private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private readonly IServiceManager _serviceManager;
         private readonly bool _skillMode;
         private DialogSet _dialogs;
 
         public CalendarSkill(
             SkillConfigurationBase services,
+            EndpointService endpointService,
             ConversationState conversationState,
             UserState userState,
+            ProactiveState proactiveState,
             IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue,
             bool skillMode = false,
             ResponseManager responseManager = null,
             IServiceManager serviceManager = null)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
+            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _proactiveState = proactiveState ?? throw new ArgumentNullException(nameof(proactiveState));
             _serviceManager = serviceManager ?? new ServiceManager(_services);
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            _backgroundTaskQueue = backgroundTaskQueue ?? throw new ArgumentNullException(nameof(backgroundTaskQueue));
 
             if (responseManager == null)
             {
@@ -69,12 +82,13 @@ namespace CalendarSkill
                         new SummaryResponses(),
                         new TimeRemainingResponses(),
                         new UpdateEventResponses(),
+                        new UpcomingEventResponses()
                     }, supportedLanguages);
             }
 
             _responseManager = responseManager;
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof(DialogState)));
-            _dialogs.Add(new MainDialog(_services, _responseManager, _conversationState, _userState, _telemetryClient, _serviceManager, _skillMode));
+            _dialogs.Add(new MainDialog(_services, _endpointService, _responseManager, _conversationState, _userState, _proactiveState, _telemetryClient, _backgroundTaskQueue, _serviceManager, _skillMode));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkill.csproj
@@ -95,6 +95,12 @@
     <EmbeddedResource Include="Dialogs\UpdateEvent\Resources\UpdateEventResponses.it.json" />
     <EmbeddedResource Include="Dialogs\UpdateEvent\Resources\UpdateEventResponses.json" />
     <EmbeddedResource Include="Dialogs\UpdateEvent\Resources\UpdateEventResponses.zh.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.de.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.es.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.fr.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.it.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.json" />
+    <EmbeddedResource Include="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.zh.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -148,6 +154,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>TimeRemainingResponses.tt</DependentUpon>
     </Compile>
+    <Compile Update="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>UpcomingEventResponses.tt</DependentUpon>
+    </Compile>
     <Compile Update="Dialogs\UpdateEvent\Resources\UpdateEventResponses.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -192,6 +203,10 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>TimeRemainingResponses.cs</LastGenOutput>
     </None>
+    <None Update="Dialogs\UpcomingEvent\Resources\UpcomingEventResponses.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>UpcomingEventResponses.cs</LastGenOutput>
+    </None>
     <None Update="Dialogs\UpdateEvent\Resources\UpdateEventResponses.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>UpdateEventResponses.cs</LastGenOutput>
@@ -223,6 +238,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+    <ProjectReference Include="..\..\..\utilities\Utilities.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Actions.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Actions.cs
@@ -39,5 +39,6 @@
         public const string Read = "read";
         public const string Greeting = "greeting";
         public const string GetEventsInit = "getEventsInit";
+        public const string ShowUpcomingMeeting = "ShowUpcomingMeeting";
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -79,14 +79,22 @@ namespace CalendarSkill.Dialogs.Shared
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = await Accessor.GetAsync(dc.Context);
-            await DigestCalendarLuisResult(dc, state.LuisResult, true);
+            if (state.LuisResult != null)
+            {
+                await DigestCalendarLuisResult(dc, state.LuisResult, true);
+            }
+
             return await base.OnBeginDialogAsync(dc, options, cancellationToken);
         }
 
         protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = await Accessor.GetAsync(dc.Context);
-            await DigestCalendarLuisResult(dc, state.LuisResult, false);
+            if (state.LuisResult != null)
+            {
+                await DigestCalendarLuisResult(dc, state.LuisResult, false);
+            }
+
             return await base.OnContinueDialogAsync(dc, cancellationToken);
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.cs
@@ -1,0 +1,18 @@
+﻿// https://docs.microsoft.com/en-us/visualstudio/modeling/t4-include-directive?view=vs-2017
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Solutions.Responses;
+
+namespace CalendarSkill.Dialogs.UpcomingEvent.Resources
+{
+    /// <summary>
+    /// Contains bot responses.
+    /// </summary>
+    public class UpcomingEventResponses : IResponseIdCollection
+    {
+        // Generated accessors
+		public const string UpcomingEventMessage = "UpcomingEventMessage";
+
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.cs
@@ -13,6 +13,7 @@ namespace CalendarSkill.Dialogs.UpcomingEvent.Resources
     {
         // Generated accessors
 		public const string UpcomingEventMessage = "UpcomingEventMessage";
+		public const string UpcomingEventMessageWithLocation = "UpcomingEventMessageWithLocation";
 
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.de.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.de.json
@@ -2,8 +2,17 @@
   "UpcomingEventMessage": {
     "replies": [
       {
-        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
-        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+        "text": "Sie haben ein Meeting in {Minutes} Minuten mit {Attendees}: {Title}",
+        "speak": "Sie haben ein Meeting in {Minutes} Minuten mit {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "Sie haben ein Meeting in {Minutes} Minuten mit {Attendees} im {Location}: {Title}",
+        "speak": "Sie haben ein Meeting in {Minutes} Minuten mit {Attendees} im {Location}: {Title}"
       }
     ],
     "inputHint": "acceptingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.de.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.de.json
@@ -1,0 +1,11 @@
+{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.es.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.es.json
@@ -2,8 +2,17 @@
   "UpcomingEventMessage": {
     "replies": [
       {
-        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
-        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+        "text": "Tienes una reunión en {Minutes} minutos con {Attendees}: {Title}",
+        "speak": "Tienes una reunión en {Minutes} minutos con {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "Tienes una reunión en {Minutes} minutos con {Attendees} en {Location}: {Title}",
+        "speak": "Tienes una reunión en {Minutes} minutos con {Attendees} en {Location}: {Title}"
       }
     ],
     "inputHint": "acceptingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.es.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.es.json
@@ -1,0 +1,11 @@
+{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.fr.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.fr.json
@@ -2,8 +2,17 @@
   "UpcomingEventMessage": {
     "replies": [
       {
-        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
-        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+        "text": "Vous avez une réunion dans {Minutes} minutes avec {Attendees}: {Title}",
+        "speak": "Vous avez une réunion dans {Minutes} minutes avec {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "Vous avez une réunion dans {Minutes} minutes avec {Attendees} au {Location}: {Title}",
+        "speak": "Vous avez une réunion dans {Minutes} minutes avec {Attendees} au {Location}: {Title}"
       }
     ],
     "inputHint": "acceptingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.fr.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.fr.json
@@ -1,0 +1,11 @@
+{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.it.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.it.json
@@ -1,0 +1,11 @@
+{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.it.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.it.json
@@ -2,8 +2,17 @@
   "UpcomingEventMessage": {
     "replies": [
       {
-        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
-        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+        "text": "Hai una riunione in arrivo in {Minutes} minuti con {Attendees}: {Title}",
+        "speak": "Hai una riunione in arrivo in {Minutes} minuti con {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "Hai una riunione in arrivo in {Minutes} minuti con {Attendees} al {Location}: {Title}",
+        "speak": "Hai una riunione in arrivo in {Minutes} minuti con {Attendees} al {Location}: {Title}"
       }
     ],
     "inputHint": "acceptingInput"

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.json
@@ -1,0 +1,11 @@
+{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.json
@@ -7,5 +7,14 @@
       }
     ],
     "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "You have a meeting coming up in {Minutes} minutes with {Attendees} at {Location}: {Title}",
+        "speak": "You have a meeting coming up in {Minutes} minutes with {Attendees} at {Location}: {Title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
   }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.tt
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.tt
@@ -1,0 +1,3 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ include file="..\..\..\..\..\..\Microsoft.Bot.Solutions\Responses\ResponseIdCollection.t4"#>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.zh.json
@@ -1,0 +1,11 @@
+﻿{
+  "UpcomingEventMessage": {
+    "replies": [
+      {
+        "text": "你在{minutes}分钟之后有和{attendees}的会议：{title}",
+        "speak": "你在{minutes}分钟之后有和{attendees}的会议：{title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.zh.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/Resources/UpcomingEventResponses.zh.json
@@ -7,5 +7,14 @@
       }
     ],
     "inputHint": "acceptingInput"
+  },
+  "UpcomingEventMessageWithLocation": {
+    "replies": [
+      {
+        "text": "你在{minutes}分钟之后在{Location}有和{attendees}的会议：{title}",
+        "speak": "你在{minutes}分钟之后在{Location}有和{attendees}的会议：{title}"
+      }
+    ],
+    "inputHint": "acceptingInput"
   }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
@@ -16,6 +16,7 @@ using Microsoft.Bot.Solutions.Resources;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Util;
+using Utilities;
 using Utilities.TaskExtensions;
 using static CalendarSkill.Proactive.CheckUpcomingEventHandler;
 
@@ -96,7 +97,7 @@ namespace CalendarSkill.Dialogs.UpcomingEvent
         {
             return async (eventModel, cancellationToken) =>
             {
-                await sc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, proactiveModel[userId.ToString()].Conversation, UpcomingEventContinueConversationCallback(eventModel, sc), cancellationToken);
+                await sc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, proactiveModel[MD5Util.ComputeHash(userId)].Conversation, UpcomingEventContinueConversationCallback(eventModel, sc), cancellationToken);
             };
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
+using CalendarSkill.Dialogs.Shared;
+using CalendarSkill.Dialogs.UpcomingEvent.Resources;
+using CalendarSkill.Models;
+using CalendarSkill.Proactive;
+using CalendarSkill.ServiceClients;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Solutions.Extensions;
+using Microsoft.Bot.Solutions.Models.Proactive;
+using Microsoft.Bot.Solutions.Resources;
+using Microsoft.Bot.Solutions.Responses;
+using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Bot.Solutions.Util;
+using Utilities.TaskExtensions;
+using static CalendarSkill.Proactive.CheckUpcomingEventHandler;
+
+namespace CalendarSkill.Dialogs.UpcomingEvent
+{
+    public class UpcomingEventDialog : CalendarSkillDialog
+    {
+        private IBackgroundTaskQueue _backgroundTaskQueue;
+        private IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
+        private EndpointService _endpointService;
+        private ResponseManager _responseManager;
+
+        public UpcomingEventDialog(
+            SkillConfigurationBase services,
+            EndpointService endpointService,
+            ResponseManager responseManager,
+            IStatePropertyAccessor<CalendarSkillState> accessor,
+            IStatePropertyAccessor<ProactiveModel> proactiveStateAccessor,
+            IServiceManager serviceManager,
+            IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue)
+            : base(nameof(UpcomingEventDialog), services, responseManager, accessor, serviceManager, telemetryClient)
+        {
+            _backgroundTaskQueue = backgroundTaskQueue;
+            _proactiveStateAccessor = proactiveStateAccessor;
+            _endpointService = endpointService;
+            _responseManager = responseManager;
+
+            var upcomingMeeting = new WaterfallStep[]
+            {
+                GetAuthToken,
+                AfterGetAuthToken,
+                QueueUpcomingEventWorker
+            };
+
+            // Define the conversation flow using a waterfall model.
+            AddDialog(new WaterfallDialog(Actions.ShowUpcomingMeeting, upcomingMeeting));
+
+            // Set starting dialog for component
+            InitialDialogId = Actions.ShowUpcomingMeeting;
+        }
+
+        public async Task<DialogTurnResult> QueueUpcomingEventWorker(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            try
+            {
+                var calendarState = await Accessor.GetAsync(sc.Context, () => new CalendarSkillState());
+
+                if (!string.IsNullOrWhiteSpace(calendarState.APIToken))
+                {
+                    var activity = sc.Context.Activity;
+                    var userId = activity.From.Id;
+
+                    var proactiveState = await _proactiveStateAccessor.GetAsync(sc.Context, () => new ProactiveModel());
+                    var calendarService = ServiceManager.InitCalendarService(calendarState.APIToken, calendarState.EventSource);
+
+                    _backgroundTaskQueue.QueueBackgroundWorkItem(async (token) =>
+                    {
+                        var handler = new CheckUpcomingEventHandler
+                        {
+                            CalendarService = calendarService
+                        };
+                        await handler.Handle(UpcomingEventCallback(userId, sc, proactiveState));
+                    });
+                }
+
+                calendarState.Clear();
+                return EndOfTurn;
+            }
+            catch (Exception ex)
+            {
+                await HandleDialogExceptions(sc, ex);
+                throw;
+            }
+        }
+
+        private UpcomingEventCallback UpcomingEventCallback(string userId, WaterfallStepContext sc, ProactiveModel proactiveModel)
+        {
+            return async (eventModel, cancellationToken) =>
+            {
+                await sc.Context.Adapter.ContinueConversationAsync(_endpointService.AppId, proactiveModel[userId.ToString()].Conversation, UpcomingEventContinueConversationCallback(eventModel, sc), cancellationToken);
+            };
+        }
+
+        // Creates the turn logic to use for the proactive message.
+        private BotCallbackHandler UpcomingEventContinueConversationCallback(EventModel eventModel, WaterfallStepContext sc)
+        {
+            sc.EndDialogAsync();
+
+            return async (turnContext, token) =>
+            {
+                var responseParams = new StringDictionary()
+                {
+                    { "Minutes", (eventModel.StartTime - DateTime.UtcNow).Minutes.ToString() },
+                    { "Attendees", string.Join(",", eventModel.Attendees.ToSpeechString(CommonStrings.And, attendee => attendee.DisplayName ?? attendee.Address)) },
+                    { "Title", eventModel.Title },
+                };
+
+                var activity = turnContext.Activity.CreateReply();
+                var response = _responseManager.GetResponse(UpcomingEventResponses.UpcomingEventMessage, responseParams);
+                activity.Text = response.Text;
+                activity.Speak = response.Speak;
+                activity.InputHint = response.InputHint;
+                activity.SuggestedActions = response.SuggestedActions;
+                activity.DeliveryMode = CommonUtil.DeliveryModeProactive;
+                await turnContext.SendActivityAsync(activity);
+            };
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/UpcomingEvent/UpcomingEventDialog.cs
@@ -108,6 +108,7 @@ namespace CalendarSkill.Dialogs.UpcomingEvent
 
             return async (turnContext, token) =>
             {
+                var responseString = string.Empty;
                 var responseParams = new StringDictionary()
                 {
                     { "Minutes", (eventModel.StartTime - DateTime.UtcNow).Minutes.ToString() },
@@ -115,8 +116,18 @@ namespace CalendarSkill.Dialogs.UpcomingEvent
                     { "Title", eventModel.Title },
                 };
 
+                if (!string.IsNullOrWhiteSpace(eventModel.Location))
+                {
+                    responseString = UpcomingEventResponses.UpcomingEventMessageWithLocation;
+                    responseParams.Add("Location", eventModel.Location);
+                }
+                else
+                {
+                    responseString = UpcomingEventResponses.UpcomingEventMessage;
+                }
+
                 var activity = turnContext.Activity.CreateReply();
-                var response = _responseManager.GetResponse(UpcomingEventResponses.UpcomingEventMessage, responseParams);
+                var response = _responseManager.GetResponse(responseString, responseParams);
                 activity.Text = response.Text;
                 activity.Speak = response.Speak;
                 activity.InputHint = response.InputHint;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Proactive/CheckUpcomingEventHandler.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Proactive/CheckUpcomingEventHandler.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using CalendarSkill.Models;
+using CalendarSkill.ServiceClients;
+
+namespace CalendarSkill.Proactive
+{
+    public class CheckUpcomingEventHandler
+    {
+        public CheckUpcomingEventHandler()
+        {
+        }
+
+        public delegate Task UpcomingEventCallback(EventModel eventModel, CancellationToken cancellationToken);
+
+        public ICalendarService CalendarService { get; set; }
+
+        public async Task Handle(UpcomingEventCallback upcomingEventCallback)
+        {
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
+
+            // only continue checking for 30 minutes for upcoming event
+            while (stopWatch.Elapsed < TimeSpan.FromMinutes(30))
+            {
+                var eventList = await CalendarService.GetUpcomingEvents(TimeSpan.FromMinutes(60));
+                if (eventList != null && eventList.Count > 0)
+                {
+                    await upcomingEventCallback(eventList[0], default(CancellationToken));
+                    break;
+                }
+
+                await Task.Delay(1000);
+            }
+
+            stopWatch.Stop();
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/CalendarService.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/CalendarService.cs
@@ -29,9 +29,9 @@ namespace CalendarSkill.ServiceClients
         }
 
         /// <inheritdoc/>
-        public async Task<List<EventModel>> GetUpcomingEvents()
+        public async Task<List<EventModel>> GetUpcomingEvents(TimeSpan? timeSpan = null)
         {
-            return await calendarAPI.GetUpcomingEvents();
+            return await calendarAPI.GetUpcomingEvents(timeSpan);
         }
 
         /// <inheritdoc/>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/GoogleAPI/GoogleCalendarAPI.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/GoogleAPI/GoogleCalendarAPI.cs
@@ -74,7 +74,7 @@ namespace CalendarSkill.ServiceClients.GoogleAPI
         }
 
         /// <inheritdoc/>
-        public async Task<List<EventModel>> GetUpcomingEvents()
+        public async Task<List<EventModel>> GetUpcomingEvents(TimeSpan? timeSpan = null)
         {
             var events = GetEvents();
             var results = new List<EventModel>();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/ICalendarService.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/ICalendarService.cs
@@ -23,8 +23,9 @@ namespace CalendarSkill.ServiceClients
         /// <summary>
         /// Get the meetings that start time after now. Order by start time.
         /// </summary>
+        /// <param name="timeSpan">Timespan to get upcoming event whthin.</param>
         /// <returns>the meetings list.</returns>
-        Task<List<EventModel>> GetUpcomingEvents();
+        Task<List<EventModel>> GetUpcomingEvents(TimeSpan? timeSpan = null);
 
         /// <summary>
         /// Get the meetings that start time between the two parameters.

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/MSGraphAPI/MSGraphCalendarAPI.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/ServiceClients/MSGraphAPI/MSGraphCalendarAPI.cs
@@ -31,10 +31,10 @@ namespace CalendarSkill.ServiceClients.MSGraphAPI
         }
 
         /// <inheritdoc/>
-        public async Task<List<EventModel>> GetUpcomingEvents()
+        public async Task<List<EventModel>> GetUpcomingEvents(TimeSpan? timeSpan = null)
         {
             var eventList = new List<EventModel>();
-            var msftEvents = await GetMyUpcomingCalendarView();
+            var msftEvents = await GetMyUpcomingCalendarView(timeSpan);
             foreach (var msftEvent in msftEvents)
             {
                 var newEvent = new EventModel(msftEvent);
@@ -198,7 +198,7 @@ namespace CalendarSkill.ServiceClients.MSGraphAPI
 
         // Get user's calendar view.
         // This snippets gets events for the next seven days.
-        private async Task<List<Event>> GetMyUpcomingCalendarView()
+        private async Task<List<Event>> GetMyUpcomingCalendarView(TimeSpan? timeSpan = null)
         {
             var items = new List<Event>();
 
@@ -206,7 +206,7 @@ namespace CalendarSkill.ServiceClients.MSGraphAPI
             var options = new List<QueryOption>
             {
                 new QueryOption("startDateTime", DateTime.UtcNow.ToString("o")),
-                new QueryOption("endDateTime", DateTime.UtcNow.AddDays(1).ToString("o")),
+                new QueryOption("endDateTime", timeSpan == null ? DateTime.UtcNow.AddDays(1).ToString("o") : DateTime.UtcNow.Add(timeSpan.Value).ToString("o")),
                 new QueryOption("$orderBy", "start/dateTime"),
             };
 

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/API/Fakes/MockBaseClient/MockBaseServiceClient.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/API/Fakes/MockBaseClient/MockBaseServiceClient.cs
@@ -15,7 +15,7 @@ namespace CalendarSkillTest.API.Fakes.MockBaseClient
         {
             mockCalendarService = new Mock<ICalendarService>();
             mockCalendarService.Setup(service => service.CreateEvent(It.IsAny<EventModel>())).Returns((EventModel body) => Task.FromResult(body));
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(new List<EventModel>()));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(new List<EventModel>()));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(new List<EventModel>()));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(new List<EventModel>()));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(new List<EventModel>()));

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/CalendarBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/CalendarBotTestBase.cs
@@ -9,6 +9,7 @@ using CalendarSkill.Dialogs.Main.Resources;
 using CalendarSkill.Dialogs.Shared.Resources;
 using CalendarSkill.Dialogs.Summary.Resources;
 using CalendarSkill.Dialogs.TimeRemaining.Resources;
+using CalendarSkill.Dialogs.UpcomingEvent.Resources;
 using CalendarSkill.Dialogs.UpdateEvent.Resources;
 using CalendarSkill.Models;
 using CalendarSkill.ServiceClients;
@@ -18,10 +19,12 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities.TaskExtensions;
 
 namespace CalendarSkillTest.Flow
 {
@@ -33,11 +36,17 @@ namespace CalendarSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public ProactiveState ProactiveState { get; set; }
+
         public IBotTelemetryClient TelemetryClient { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
 
         public IServiceManager ServiceManager { get; set; }
 
         public SkillConfiguration Services { get; set; }
+
+        public EndpointService EndpointService { get; set; }
 
         public BotConfiguration Options { get; set; }
 
@@ -48,9 +57,12 @@ namespace CalendarSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.ProactiveState = new ProactiveState(new MemoryStorage());
             this.TelemetryClient = new NullBotTelemetryClient();
+            this.BackgroundTaskQueue = new BackgroundTaskQueue();
             this.CalendarStateAccessor = this.ConversationState.CreateProperty<CalendarSkillState>(nameof(CalendarSkillState));
             this.Services = new MockSkillConfiguration();
+            this.EndpointService = new EndpointService();
 
             builder.RegisterInstance(new BotStateSet(this.UserState, this.ConversationState));
 
@@ -69,6 +81,7 @@ namespace CalendarSkillTest.Flow
                     new SummaryResponses(),
                     new TimeRemainingResponses(),
                     new UpdateEventResponses(),
+                    new UpcomingEventResponses()
                 },
                 locales: new string[] { "en", "de", "es", "fr", "it", "zh" });
         }
@@ -107,7 +120,7 @@ namespace CalendarSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new CalendarSkill.CalendarSkill(this.Services, this.ConversationState, this.UserState, this.TelemetryClient, true, ResponseManager, this.ServiceManager);
+            return new CalendarSkill.CalendarSkill(this.Services, this.EndpointService, this.ConversationState, this.UserState, this.ProactiveState, this.TelemetryClient, this.BackgroundTaskQueue, true, ResponseManager, this.ServiceManager);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockCalendarService.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockCalendarService.cs
@@ -155,7 +155,7 @@ namespace CalendarSkillTest.Flow.Fakes
             return await Task.FromResult(newEvent);
         }
 
-        public async Task<List<EventModel>> GetUpcomingEvents()
+        public async Task<List<EventModel>> GetUpcomingEvents(TimeSpan? timeSpan = null)
         {
             return await Task.FromResult(this.FakeEvents);
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockServiceManager.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockServiceManager.cs
@@ -29,7 +29,7 @@ namespace CalendarSkillTest.Flow.Fakes
             // calendar
             mockCalendarService = new Mock<ICalendarService>();
             mockCalendarService.Setup(service => service.CreateEvent(It.IsAny<EventModel>())).Returns((EventModel body) => Task.FromResult(body));
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(BuildinEvents));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(BuildinEvents));
@@ -76,7 +76,7 @@ namespace CalendarSkillTest.Flow.Fakes
 
         public static IServiceManager SetMeetingsToSpecial(List<EventModel> eventList)
         {
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(eventList));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(eventList));
@@ -87,7 +87,7 @@ namespace CalendarSkillTest.Flow.Fakes
         {
             List<EventModel> eventList = new List<EventModel>();
 
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(eventList));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(eventList));
@@ -102,7 +102,7 @@ namespace CalendarSkillTest.Flow.Fakes
                 eventList.Add(CreateEventModel());
             }
 
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(eventList));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(eventList));
@@ -149,7 +149,7 @@ namespace CalendarSkillTest.Flow.Fakes
 
         public static IServiceManager SetAllToDefault()
         {
-            mockCalendarService.Setup(service => service.GetUpcomingEvents()).Returns(Task.FromResult(BuildinEvents));
+            mockCalendarService.Setup(service => service.GetUpcomingEvents(null)).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByTime(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByStartTime(It.IsAny<DateTime>())).Returns(Task.FromResult(BuildinEvents));
             mockCalendarService.Setup(service => service.GetEventsByTitle(It.IsAny<string>())).Returns(Task.FromResult(BuildinEvents));

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/EmailSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/EmailSkill.cs
@@ -17,9 +17,12 @@ using EmailSkill.Dialogs.ShowEmail.Resources;
 using EmailSkill.ServiceClients;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
+using Utilities.TaskExtensions;
 
 namespace EmailSkill
 {
@@ -39,9 +42,12 @@ namespace EmailSkill
 
         public EmailSkill(
             SkillConfigurationBase services,
+            EndpointService endpointService,
             ConversationState conversationState,
             UserState userState,
+            ProactiveState proactiveState,
             IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue,
             bool skillMode = false,
             ResponseManager responseManager = null,
             IServiceManager serviceManager = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/EmailSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/EmailSkill.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+    <ProjectReference Include="..\..\..\utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/EmailBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/EmailBotTestBase.cs
@@ -14,13 +14,16 @@ using EmailSkill.ServiceClients;
 using EmailSkillTest.Flow.Fakes;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Data;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities.TaskExtensions;
 
 namespace EmailSkillTest.Flow
 {
@@ -32,7 +35,13 @@ namespace EmailSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public ProactiveState ProactiveState { get; set; }
+
         public IBotTelemetryClient TelemetryClient { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
+
+        public EndpointService EndpointService { get; set; }
 
         public IServiceManager ServiceManager { get; set; }
 
@@ -45,9 +54,12 @@ namespace EmailSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.ProactiveState = new ProactiveState(new MemoryStorage());
             this.TelemetryClient = new NullBotTelemetryClient();
+            this.BackgroundTaskQueue = new BackgroundTaskQueue();
             this.EmailStateAccessor = this.ConversationState.CreateProperty<EmailSkillState>(nameof(EmailSkillState));
             this.Services = new MockSkillConfiguration();
+            this.EndpointService = new EndpointService();
 
             builder.RegisterInstance(new BotStateSet(this.UserState, this.ConversationState));
             var fakeServiceManager = new MockServiceManager();
@@ -104,7 +116,7 @@ namespace EmailSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new EmailSkill.EmailSkill(Services, ConversationState, UserState, TelemetryClient, true, ResponseManager, ServiceManager);
+            return new EmailSkill.EmailSkill(Services, EndpointService, ConversationState, UserState, ProactiveState, TelemetryClient, BackgroundTaskQueue, true, ResponseManager, ServiceManager);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/PointOfInterestSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/PointOfInterestSkill.cs
@@ -7,7 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using PointOfInterestSkill.Dialogs.CancelRoute.Resources;
@@ -17,6 +19,7 @@ using PointOfInterestSkill.Dialogs.Main.Resources;
 using PointOfInterestSkill.Dialogs.Route.Resources;
 using PointOfInterestSkill.Dialogs.Shared.Resources;
 using PointOfInterestSkill.ServiceClients;
+using Utilities.TaskExtensions;
 
 namespace PointOfInterestSkill
 {
@@ -36,9 +39,12 @@ namespace PointOfInterestSkill
 
         public PointOfInterestSkill(
             SkillConfigurationBase services,
+            EndpointService endpointService,
             ConversationState conversationState,
             UserState userState,
+            ProactiveState proactiveState,
             IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue,
             bool skillMode = false,
             ResponseManager responseManager = null,
             IServiceManager serviceManager = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/PointOfInterestSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/PointOfInterestSkill.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+    <ProjectReference Include="..\..\..\utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/ToDoSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/ToDoSkill.cs
@@ -7,7 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using ToDoSkill.Dialogs.AddToDo.Resources;
@@ -18,6 +20,7 @@ using ToDoSkill.Dialogs.MarkToDo.Resources;
 using ToDoSkill.Dialogs.Shared.Resources;
 using ToDoSkill.Dialogs.ShowToDo.Resources;
 using ToDoSkill.ServiceClients;
+using Utilities.TaskExtensions;
 
 namespace ToDoSkill
 {
@@ -37,9 +40,12 @@ namespace ToDoSkill
 
         public ToDoSkill(
             SkillConfigurationBase services,
+            EndpointService endpointService,
             ConversationState conversationState,
             UserState userState,
+            ProactiveState proactiveState,
             IBotTelemetryClient telemetryClient,
+            IBackgroundTaskQueue backgroundTaskQueue,
             bool skillMode = false,
             ResponseManager responseManager = null,
             IServiceManager serviceManager = null)

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/ToDoSkill.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/ToDoSkill.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Microsoft.Bot.Solutions\Microsoft.Bot.Solutions.csproj" />
+    <ProjectReference Include="..\..\..\utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskilltest/Flow/ToDoBotTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskilltest/Flow/ToDoBotTestBase.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -20,6 +21,7 @@ using ToDoSkill.Dialogs.Shared.Resources;
 using ToDoSkill.Dialogs.ShowToDo.Resources;
 using ToDoSkill.ServiceClients;
 using ToDoSkillTest.Flow.Fakes;
+using Utilities.TaskExtensions;
 
 namespace ToDoSkillTest.Flow
 {
@@ -29,7 +31,13 @@ namespace ToDoSkillTest.Flow
 
         public UserState UserState { get; set; }
 
+        public ProactiveState ProactiveState { get; set; }
+
         public IBotTelemetryClient TelemetryClient { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
+
+        public EndpointService EndpointService { get; set; }
 
         public IStatePropertyAccessor<ToDoSkillState> ToDoStateAccessor { get; set; }
 
@@ -48,10 +56,13 @@ namespace ToDoSkillTest.Flow
 
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.UserState = new UserState(new MemoryStorage());
+            this.ProactiveState = new ProactiveState(new MemoryStorage());
             this.TelemetryClient = new NullBotTelemetryClient();
+            this.BackgroundTaskQueue = new BackgroundTaskQueue();
             this.ToDoStateAccessor = this.ConversationState.CreateProperty<ToDoSkillState>(nameof(ToDoSkillState));
             this.UserStateAccessor = this.UserState.CreateProperty<ToDoSkillUserState>(nameof(ToDoSkillUserState));
             this.Services = new MockSkillConfiguration();
+            this.EndpointService = new EndpointService();
 
             builder.RegisterInstance(new BotStateSet(this.UserState, this.ConversationState));
             var fakeServiceManager = new MockServiceManager();
@@ -100,7 +111,7 @@ namespace ToDoSkillTest.Flow
 
         public override IBot BuildBot()
         {
-            return new ToDoSkill.ToDoSkill(Services, ConversationState, UserState, TelemetryClient, true, ResponseManager, ServiceManager);
+            return new ToDoSkill.ToDoSkill(Services, EndpointService, ConversationState, UserState, ProactiveState, TelemetryClient, BackgroundTaskQueue, true, ResponseManager, ServiceManager);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/Fakes/FakeSkill/FakeSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/Fakes/FakeSkill/FakeSkill.cs
@@ -14,6 +14,9 @@ using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Auth.Resource
 using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Main.Resources;
 using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Shared.Resources;
 using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Sample.Resources;
+using Utilities.TaskExtensions;
+using Microsoft.Bot.Solutions.Models.Proactive;
+using Microsoft.Bot.Configuration;
 
 namespace FakeSkill
 {
@@ -26,17 +29,23 @@ namespace FakeSkill
         private readonly ResponseManager _responseManager;
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
+        private readonly ProactiveState _proactiveState;
         private readonly IBotTelemetryClient _telemetryClient;
+        private readonly IBackgroundTaskQueue _backgroundTaskQueue;
+        private readonly EndpointService _endpointService;
         private IServiceManager _serviceManager;
         private DialogSet _dialogs;
         private bool _skillMode;
 
-        public FakeSkill(SkillConfigurationBase services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient, bool skillMode = false, ResponseManager responseManager = null, ServiceManager serviceManager = null)
+        public FakeSkill(SkillConfigurationBase services, EndpointService endpointService, ConversationState conversationState, UserState userState, ProactiveState proactiveState, IBotTelemetryClient telemetryClient, IBackgroundTaskQueue backgroundTaskQueue, bool skillMode = false, ResponseManager responseManager = null, ServiceManager serviceManager = null)
         {
             _skillMode = skillMode;
             _services = services ?? throw new ArgumentNullException(nameof(services));
             _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _proactiveState = proactiveState;
+            _endpointService = endpointService;
+            _backgroundTaskQueue = backgroundTaskQueue;
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _serviceManager = serviceManager ?? new ServiceManager();
 

--- a/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/InvokeSkillTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/InvokeSkillTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Solutions.Tests.Skills
             };
 
             // Add the SkillDialog to the available dialogs passing the initialized FakeSkill
-            Dialogs.Add(new SkillDialog(fakeSkillDefinition, Services, null, TelemetryClient));
+            Dialogs.Add(new SkillDialog(fakeSkillDefinition, Services, null, null, TelemetryClient, null));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/MisconfiguredSkillTest.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/MisconfiguredSkillTest.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Tests.Skills.Utterances;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Solutions.Tests.Skills
@@ -31,7 +28,7 @@ namespace Microsoft.Bot.Solutions.Tests.Skills
             SkillDialogOptions.SkillDefinition = fakeSkillDefinition;
 
             // Add the SkillDialog to the available dialogs passing the initialized FakeSkill
-            Dialogs.Add(new SkillDialog(fakeSkillDefinition, Services, null, TelemetryClient));
+            Dialogs.Add(new SkillDialog(fakeSkillDefinition, Services, null, null, TelemetryClient, null));
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/SkillTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/Microsoft.Bot.Solutions.Tests/Skills/SkillTestBase.cs
@@ -3,8 +3,10 @@ using Autofac;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
@@ -15,6 +17,7 @@ using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Sample.Resour
 using Microsoft.Bot.Solutions.Tests.Skills.Fakes.FakeSkill.Dialogs.Shared.Resources;
 using Microsoft.Bot.Solutions.Tests.Skills.LuisTestUtils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities.TaskExtensions;
 
 namespace Microsoft.Bot.Solutions.Tests.Skills
 {
@@ -27,9 +30,15 @@ namespace Microsoft.Bot.Solutions.Tests.Skills
 
         public ConversationState ConversationState { get; set; }
 
+        public ProactiveState ProactiveState { get; set; }
+
         public IStatePropertyAccessor<DialogState> DialogState { get; set; }
 
         public IBotTelemetryClient TelemetryClient { get; set; }
+        
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
+
+        public EndpointService EndpointService { get; set; }
 
         public SkillConfigurationBase Services { get; set; }
 
@@ -47,7 +56,10 @@ namespace Microsoft.Bot.Solutions.Tests.Skills
             ConversationState = new ConversationState(new MemoryStorage());
             DialogState = ConversationState.CreateProperty<DialogState>(nameof(DialogState));
             UserState = new UserState(new MemoryStorage());
+            ProactiveState = new ProactiveState(new MemoryStorage());
             TelemetryClient = new NullBotTelemetryClient();
+            BackgroundTaskQueue = new BackgroundTaskQueue();
+            EndpointService = new EndpointService();
             SkillConfigurations = new Dictionary<string, SkillConfigurationBase>();
 
             // Add the LUIS model fakes used by the Skill
@@ -137,7 +149,7 @@ namespace Microsoft.Bot.Solutions.Tests.Skills
 
         public override IBot BuildBot()
         {
-            return new FakeSkill.FakeSkill(Services, ConversationState, UserState, TelemetryClient, true, ResponseManager, null);
+            return new FakeSkill.FakeSkill(Services, EndpointService, ConversationState, UserState, ProactiveState, TelemetryClient, BackgroundTaskQueue, true, ResponseManager, null);
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/AssistantTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/AssistantTestBase.cs
@@ -9,12 +9,14 @@ using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Dialogs;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Resources;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
 using Microsoft.Bot.Solutions.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities.TaskExtensions;
 using VirtualAssistant.Tests.LuisTestUtils;
 
 namespace VirtualAssistant.Tests
@@ -28,6 +30,10 @@ namespace VirtualAssistant.Tests
         public UserState UserState { get; set; }
 
         public ConversationState ConversationState { get; set; }
+
+        public ProactiveState ProactiveState { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
 
         public IStatePropertyAccessor<DialogState> DialogState { get; set; }
 
@@ -45,7 +51,9 @@ namespace VirtualAssistant.Tests
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.DialogState = this.ConversationState.CreateProperty<DialogState>(nameof(this.DialogState));
             this.UserState = new UserState(new MemoryStorage());
+            this.ProactiveState = new ProactiveState(new MemoryStorage());
             this.TelemetryClient = new NullBotTelemetryClient();
+            this.BackgroundTaskQueue = new BackgroundTaskQueue();
 
             this.EndPointService = new EndpointService();
 
@@ -146,7 +154,7 @@ namespace VirtualAssistant.Tests
 
         public override IBot BuildBot()
         {
-            return new VirtualAssistant(this.BotServices, this.ConversationState, this.UserState, this.EndPointService, this.TelemetryClient);
+            return new VirtualAssistant(this.BotServices, this.ConversationState, this.UserState, this.ProactiveState, this.EndPointService, this.TelemetryClient, this.BackgroundTaskQueue);
         }
 
         /// <summary>

--- a/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/SkillInvocationTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/SkillInvocationTests.cs
@@ -26,7 +26,7 @@ namespace VirtualAssistant.Tests.SkillInvocationTests
             foreach (SkillDefinition skill in this.skillDefinitions.Values)
             {
                 // Add the SkillDialog to the available dialogs passing the initialized FakeSkill
-                this.Dialogs.Add(new SkillDialog(skill, this.Services, null, this.TelemetryClient));
+                this.Dialogs.Add(new SkillDialog(skill, this.Services, this.ProactiveState, this.EndpointService, this.TelemetryClient, this.BackgroundTaskQueue));
             }
         }
 

--- a/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/SkillTestBase.cs
+++ b/solutions/Virtual-Assistant/src/csharp/tests/VirtualAssistant.Tests/SkillTestBase.cs
@@ -4,12 +4,15 @@ using Autofac;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Middleware.Telemetry;
+using Microsoft.Bot.Solutions.Models.Proactive;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Testing;
 using Microsoft.Bot.Solutions.Testing.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities.TaskExtensions;
 
 namespace VirtualAssistant.Tests
 {
@@ -22,6 +25,12 @@ namespace VirtualAssistant.Tests
         public DialogSet Dialogs { get; set; }
 
         public UserState UserState { get; set; }
+
+        public ProactiveState ProactiveState { get; set; }
+
+        public EndpointService EndpointService { get; set; }
+
+        public IBackgroundTaskQueue BackgroundTaskQueue { get; set; }
 
         public ConversationState ConversationState { get; set; }
 
@@ -45,7 +54,10 @@ namespace VirtualAssistant.Tests
             this.ConversationState = new ConversationState(new MemoryStorage());
             this.DialogState = this.ConversationState.CreateProperty<DialogState>(nameof(this.DialogState));
             this.UserState = new UserState(new MemoryStorage());
+            this.ProactiveState = new ProactiveState(new MemoryStorage());
+            this.EndpointService = new EndpointService();
             this.TelemetryClient = new NullBotTelemetryClient();
+            this.BackgroundTaskQueue = new BackgroundTaskQueue();
             this.SkillConfigurations = new Dictionary<string, SkillConfigurationBase>();
 
             // Add the LUIS model fakes used by the Skill

--- a/solutions/Virtual-Assistant/src/csharp/utilities/MD5Util.cs
+++ b/solutions/Virtual-Assistant/src/csharp/utilities/MD5Util.cs
@@ -1,0 +1,30 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+
+namespace Utilities
+{
+    public class MD5Util
+    {
+        private static MD5 md5 = MD5.Create();
+
+        public static string ComputeHash(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return string.Empty;
+            }
+
+            var hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(input));
+
+            var stringBuilder = new StringBuilder();
+
+            for (int i = 0; i < hashBytes.Length; i++)
+            {
+                stringBuilder.Append(hashBytes[i].ToString("x2"));
+            }
+
+            // Return the hexadecimal string.
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/BackgroundTaskQueue.cs
+++ b/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/BackgroundTaskQueue.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utilities.TaskExtensions
+{
+    public class BackgroundTaskQueue : IBackgroundTaskQueue
+    {
+        private ConcurrentQueue<Func<CancellationToken, Task>> _workItems = new ConcurrentQueue<Func<CancellationToken, Task>>();
+        private SemaphoreSlim _signal = new SemaphoreSlim(0);
+
+        public void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem)
+        {
+            if (workItem == null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            _workItems.Enqueue(workItem);
+            _signal.Release();
+        }
+
+        public async Task<Func<CancellationToken, Task>> DequeueAsync(CancellationToken token)
+        {
+            await _signal.WaitAsync(token);
+
+            _workItems.TryDequeue(out var workItem);
+
+            return workItem;
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/IBackgroundTaskQueue.cs
+++ b/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/IBackgroundTaskQueue.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utilities.TaskExtensions
+{
+    public interface IBackgroundTaskQueue
+    {
+        void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem);
+
+        Task<Func<CancellationToken, Task>> DequeueAsync(CancellationToken token);
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/QueuedHostedService.cs
+++ b/solutions/Virtual-Assistant/src/csharp/utilities/TaskExtensions/QueuedHostedService.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utilities.TaskExtensions
+{
+    public class QueuedHostedService : BackgroundService
+    {
+        public QueuedHostedService(IBackgroundTaskQueue queue)
+        {
+            TaskQueue = queue;
+        }
+
+        public IBackgroundTaskQueue TaskQueue { get; set; }
+
+        protected async override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var workItem = await TaskQueue.DequeueAsync(stoppingToken);
+
+                try
+                {
+                    await workItem(stoppingToken);
+                }
+                catch
+                {
+                    // execution failed. added exception handling later
+                }
+            }
+        }
+    }
+}

--- a/solutions/Virtual-Assistant/src/csharp/utilities/Utilities.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/utilities/Utilities.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.hosting.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description
This change is to enable the first proactive scenario, which is when car sends a CarStart event the bot starts checking if there's a meeting coming up in the next 60 minutes.

## Related Issue

#66 
#103 

## Testing Steps
after building and running the bot, starts with 'what's my meeting today' after finishing the dialog, send 
/event:{ "Name": "CarStart" } 
event to the bot, the bot will start checking for any meeting in the next 60 minutes for 30 minutes. then go to your outlook email account to create a meeting with someone within the next 60 minutes, then you'll see the meeting notification appearing in the chat window

## Checklist
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have added or updated the appropriate unit tests
- [ x ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

