### PR TITLE
Automotive: Send machine-readable data in events

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Dialogs/VehicleSettings/VehicleSettingsDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Dialogs/VehicleSettings/VehicleSettingsDialog.cs
@@ -421,6 +421,7 @@ namespace AutomotiveSkill.Dialogs.VehicleSettings
         {
             var state = await Accessor.GetAsync(sc.Context);
 
+            var change = state.Changes[0];
             var settingChangeConfirmed = false;
 
             // If we skip the ConfirmPrompt due to no confirmation needed then Result will be NULL
@@ -431,12 +432,11 @@ namespace AutomotiveSkill.Dialogs.VehicleSettings
             else
             {
                 settingChangeConfirmed = (bool)sc.Result;
+                change.IsConfirmed = settingChangeConfirmed;
             }
 
             if (settingChangeConfirmed)
             {
-                var change = state.Changes[0];
-
                 // If the change involves an amount then we add this to the change event
                 if (change.Amount != null)
                 {
@@ -458,16 +458,16 @@ namespace AutomotiveSkill.Dialogs.VehicleSettings
                             promptReplacements["increasingDecreasing"] = VehicleSettingsStrings.INCREASING;
                         }
 
-                        // Send an event to the device along with the text confirmation
-                        await SendActionToDevice(sc, change, promptReplacements);
+                        // Send an event to the device along with the text
+                        await SendActionToDevice(sc, change);
 
                         await sc.Context.SendActivityAsync(ResponseManager.GetResponse(
                             VehicleSettingsResponses.VehicleSettingsChangingRelativeAmount, promptReplacements));
                     }
                     else
                     {
-                        // Send an event to the device along with the text confirmation
-                        await SendActionToDevice(sc, change, promptReplacements);
+                        // Send an event to the device along with the text
+                        await SendActionToDevice(sc, change);
 
                         await sc.Context.SendActivityAsync(ResponseManager.GetResponse(
                             VehicleSettingsResponses.VehicleSettingsChangingAmount, promptReplacements));
@@ -489,8 +489,8 @@ namespace AutomotiveSkill.Dialogs.VehicleSettings
                         promptReplacements["value"] = change.Value;
                     }
 
-                    // Send an event to the device along with the text confirmation
-                    await SendActionToDevice(sc, change, promptReplacements);
+                    // Send an event to the device along with the text
+                    await SendActionToDevice(sc, change);
 
                     await sc.Context.SendActivityAsync(ResponseManager.GetResponse(promptTemplate, promptReplacements));
                 }
@@ -515,15 +515,20 @@ namespace AutomotiveSkill.Dialogs.VehicleSettings
             }
         }
 
-        private async Task SendActionToDevice(WaterfallStepContext sc, SettingChange setting, StringDictionary settingDetail)
+        /// <summary>
+        /// Send an event activity to communicate to the client which change to make to the actual setting.
+        /// This event is meant to be processed by client code rather than shown to the user.
+        /// </summary>
+        /// <param name="sc">The WaterfallStepContext.</param>
+        /// <param name="change">The change that we want the client to make.</param>
+        /// <returns>A Task.</returns>
+        private async Task SendActionToDevice(WaterfallStepContext sc, SettingChange change)
         {
-            // remove whitespace to create Event Name and prefix with Automotive Skill
-            string reducedName = $"AutomotiveSkill.{Regex.Replace(setting.SettingName, @"\s+", string.Empty)}";
-
             var actionEvent = sc.Context.Activity.CreateReply();
             actionEvent.Type = ActivityTypes.Event;
-            actionEvent.Name = reducedName;
-            actionEvent.Value = settingDetail;
+            // The name of the event is the intent (changing vs checking, the latter of which is not yet supported).
+            actionEvent.Name = "AutomotiveSkill.SettingChange";
+            actionEvent.Value = change;
 
             await sc.Context.SendActivityAsync(actionEvent);
         }

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Models/SettingAmount.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Models/SettingAmount.cs
@@ -10,7 +10,7 @@ namespace AutomotiveSkill.Models
     /// enum-like values like "On" or "Off", a string is used instead.
     /// MIN and MAX are represented as 0% and 100%, respectively.
     /// </summary>
-    public class SettingAmount : ICloneable
+    public class SettingAmount : ICloneable, IEquatable<SettingAmount>
     {
         /// <summary>
         /// Gets or sets the numeric amount.
@@ -32,6 +32,28 @@ namespace AutomotiveSkill.Models
                 Unit = Unit
             };
             return clone;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SettingAmount);
+        }
+
+        public bool Equals(SettingAmount other)
+        {
+            return other != null &&
+                   Amount == other.Amount &&
+                   Unit == other.Unit;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Amount, Unit);
+        }
+
+        public override string ToString()
+        {
+            return $"SettingAmount{{Amount={Amount}, Unit={Unit}}}";
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Models/SettingChange.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Models/SettingChange.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+
 namespace AutomotiveSkill.Models
 {
     /// <summary>
     /// Setting change.
     /// </summary>
-    public class SettingChange : SettingOperation
+    public class SettingChange : SettingOperation, IEquatable<SettingChange>
     {
         /// <summary>
         /// Gets or sets the value to set the setting to or null to only change the numeric amount.
@@ -44,6 +47,30 @@ namespace AutomotiveSkill.Models
             clone.IsRelativeAmount = IsRelativeAmount;
             clone.IsConfirmed = IsConfirmed;
             return clone;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SettingChange);
+        }
+
+        public bool Equals(SettingChange other)
+        {
+            return other != null &&
+                   Value == other.Value &&
+                   EqualityComparer<SettingAmount>.Default.Equals(Amount, other.Amount) &&
+                   IsRelativeAmount == other.IsRelativeAmount &&
+                   IsConfirmed == other.IsConfirmed;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Value, Amount, IsRelativeAmount, IsConfirmed);
+        }
+
+        public override string ToString()
+        {
+            return $"SettingChange{{Value={Value}, Amount={Amount}, IsRelativeAmount={IsRelativeAmount}, IsConfirmed={IsConfirmed}}}";
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
@@ -1,3 +1,4 @@
+using AutomotiveSkill.Models;
 using AutomotiveSkillTest.Flow;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,7 +22,16 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("set temperature to 21 degrees")                
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Temperature",
+                    Value = "Set",
+                    Amount = new SettingAmount()
+                    {
+                        Amount = 21,
+                        Unit = "°",
+                    },
+                }))
                 .AssertReply(this.CheckReply("Setting Temperature to 21°."))
                 .StartTestAsync();
         }
@@ -31,7 +41,16 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("increase temperature by 2")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Temperature",
+                    Value = "Increase",
+                    Amount = new SettingAmount()
+                    {
+                        Amount = 2,
+                    },
+                    IsRelativeAmount = true,
+                }))
                 .AssertReply(this.CheckReply("Increasing Temperature by 2."))
                 .StartTestAsync();
         }
@@ -41,7 +60,15 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("increase temperature to 24")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Temperature",
+                    Value = "Increase",
+                    Amount = new SettingAmount()
+                    {
+                        Amount = 24,
+                    },
+                }))
                 .AssertReply(this.CheckReply("Setting Temperature to 24."))
                 .StartTestAsync();
         }
@@ -53,7 +80,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("change the temperature")
                  .AssertReply(this.CheckReply("Here are the possible values for Temperature. Which one? (1) Decrease(2) Increase"))
                 .Send("Increase")                
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Temperature",
+                    Value = "Increase",
+                }))
                 .AssertReply(this.CheckReply("Increasing Temperature."))
                 .StartTestAsync();
         }
@@ -65,7 +96,12 @@ namespace AutomotiveSkillTest.Flow
                 .Send("turn lane assist off")
                 .AssertReply(this.CheckReply("So, you want to change Lane Change Detection to Off. Is that correct? (1) Yes or (2) No"))
                 .Send("yes")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Lane Change Detection",
+                    Value = "Off",
+                    IsConfirmed = true,
+                }))
                 .AssertReply(this.CheckReply("Setting Lane Change Detection to Off."))
                 .AssertReply(this.CheckForEndOfConversation())
                 .StartTestAsync();
@@ -88,7 +124,11 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("warm up the back of the car")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Rear Combined Set Temperature",
+                    Value = "Increase",
+                }))
                 .AssertReply(this.CheckReply("Increasing Rear Combined Set Temperature."))               
                 .StartTestAsync();
         }
@@ -98,7 +138,11 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("defog my windshield")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Rear Window Defogger",
+                    Value = "On",
+                }))
                 .AssertReply(this.CheckReply("Setting Rear Window Defogger to On."))
                 .StartTestAsync();
         }
@@ -110,7 +154,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("put the air on my feet")
                 .AssertReply(this.CheckReply("Here are the matching settings. Which one? (1) Front Combined Air Delivery Mode Control(2) Rear Combined Air Delivery Mode Control"))
                 .Send("front combined air delivery mode control")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Front Combined Air Delivery Mode Control",
+                    Value = "Floor",
+                }))
                 .AssertReply(this.CheckReply("Setting Front Combined Air Delivery Mode Control to Floor."))
                 .StartTestAsync();
         }
@@ -120,7 +168,11 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("turn off the ac")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Front and Rear HVAC",
+                    Value = "All Off",
+                }))
                 .AssertReply(this.CheckReply("Setting Front and Rear HVAC to All Off."))
                 .StartTestAsync();
         }
@@ -130,7 +182,11 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("I'm feeling cold")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Temperature",
+                    Value = "Increase",
+                }))
                 .AssertReply(this.CheckReply("Increasing Temperature."))
                 .StartTestAsync();
         }
@@ -140,7 +196,11 @@ namespace AutomotiveSkillTest.Flow
         {
             await this.GetTestFlow()
                 .Send("it's feeling cold in the back")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Rear Combined Set Temperature",
+                    Value = "Increase",
+                }))
                 .AssertReply(this.CheckReply("Increasing Rear Combined Set Temperature."))
                 .StartTestAsync();
         }
@@ -154,7 +214,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("Equalizer (Bass)")
                 .AssertReply(this.CheckReply("Here are the possible values for Equalizer (Bass). Which one? (1) Decrease(2) Increase"))                
                  .Send("Decrease")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Equalizer (Bass)",
+                    Value = "Decrease",
+                }))
                 .AssertReply(this.CheckReply("Decreasing Equalizer (Bass)."))
                 .StartTestAsync();
         }
@@ -168,7 +232,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("front")
                 .AssertReply(this.CheckReply("Here are the possible values for Front Pedestrian Safety Detection. Which one? (1) Off(2) Alert(3) Alert and Brake(4) Alert, Brake, and Steer"))
                 .Send("steer")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Front Pedestrian Safety Detection",
+                    Value = "Alert, Brake, and Steer",
+                }))
                 .AssertReply(this.CheckReply("Setting Front Pedestrian Safety Detection to Alert, Brake, and Steer."))
                 .StartTestAsync();
         }
@@ -182,7 +250,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("alerts for people in the back")
                 .AssertReply(this.CheckReply("Here are the possible values for Rear Pedestrian Safety Detection. Which one? (1) Off(2) Alert(3) Alert and Brake(4) Alert, Brake, and Steer"))
                 .Send("braking and alerts")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Rear Pedestrian Safety Detection",
+                    Value = "Alert and Brake",
+                }))
                 .AssertReply(this.CheckReply("Setting Rear Pedestrian Safety Detection to Alert and Brake."))
                 .StartTestAsync();
         }
@@ -196,7 +268,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("first one")
                 .AssertReply(this.CheckReply("Here are the possible values for Equalizer (Bass). Which one? (1) Decrease(2) Increase"))
                 .Send("second one")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Equalizer (Bass)",
+                    Value = "Increase",
+                }))
                 .AssertReply(this.CheckReply("Increasing Equalizer (Bass)."))
                 .StartTestAsync();
         }
@@ -214,7 +290,11 @@ namespace AutomotiveSkillTest.Flow
                 .Send("blah blah")
                 .AssertReply(this.CheckReply("Here are the possible values for Equalizer (Bass). Which one? (1) Decrease(2) Increase"))
                 .Send("Decrease")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Equalizer (Bass)",
+                    Value = "Decrease",
+                }))
                 .AssertReply(this.CheckReply("Decreasing Equalizer (Bass)."))
                 .StartTestAsync();
         }
@@ -230,17 +310,24 @@ namespace AutomotiveSkillTest.Flow
                 .Send("blah blah")
                 .AssertReply(this.CheckReply("Here are the possible values for Equalizer (Bass). Which one? (1) Decrease(2) Increase"))
                 .Send("Decrease")
-                .AssertReply(this.CheckForSettingEvent())
+                .AssertReply(this.CheckForSettingEvent(new SettingChange()
+                {
+                    SettingName = "Equalizer (Bass)",
+                    Value = "Decrease",
+                }))
                 .AssertReply(this.CheckReply("Decreasing Equalizer (Bass)."))
                 .StartTestAsync();
         }
 
-        private Action<IActivity> CheckForSettingEvent()
+        private Action<IActivity> CheckForSettingEvent(SettingChange expectedChange)
         {
             return activity =>
             {
                 var eventReceived = activity.AsEventActivity();
-                Assert.IsNotNull(eventReceived,"Activity received is not an Event as expected");             
+                Assert.IsNotNull(eventReceived,"Activity received is not an Event as expected");
+                Assert.AreEqual<string>("AutomotiveSkill.SettingChange", eventReceived.Name);
+                Assert.IsInstanceOfType(eventReceived.Value, typeof(SettingChange));
+                Assert.AreEqual<SettingChange>(expectedChange, (SettingChange)eventReceived.Value);
             };
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Previously, the events being sent to the client contained strings that were intended for speech output. Since the events are intended to be machine-readable and are supposed to instruct the client code which setting to change in which way, they should contain the exact string names that are defined in the YAML/JSON files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can enable automation to close related issues, using keyword Close #ISSUENUMBER -->
<!--- See https://help.github.com/articles/closing-issues-using-keywords/ for more information -->
<!--- Please link to the issue here: -->
No issue created.

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->
Run the unit tests.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the appropriate unit tests
<del>- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
<del>- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
<del>- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
<del>- [ ] All languages have been updated
<del>- [ ] You have tested deployment with your new models
