### PR TITLE
Not show intro card when no locale

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-knownissues.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-knownissues.md
@@ -78,4 +78,26 @@ Add the middleware to Startup.cs:
         }
 ```
 
+## No Intro Card when no locale setting
+
+There is a known issue in the Virtual Assistant when the bot doesn't pass a Locale setting at the beginning of the conversation, the Intro Card won't show up. This is due to a design flaw in the current channel protocol. The StartConversation call doesn't accept Locale as a parameter. 
+
+When you're testing in Bot Emulator, you can get around this issue by setting the Locale in Emulator Settings. Emulator will pass the locale setting to the bot as the first ConversationUpdate call.
+When you're testing in other environments, if it's something that you own the code, make sure you send an additional activity to the bot between the StartConversation call, and the user sends the first message:
+
+```
+    directLine.postActivity({
+      from   : { id: userID, name: "User", role: "user"},
+      name   : 'startConversation',
+      type   : 'event',
+      locale : this.props.locale,
+      value  : ''
+    })
+    .subscribe(function (id) {
+      console.log('trigger "conversationUpdate" sent');
+    });
+```
+
+When you're testing in an environment you don't own the code for, chances are you won't be able to see the Intro Card. Because of the current design flaw in channel protocol, we made this tradeoff so that we don't show an Intro Card with a default culture that doesn't match your actual locale. Once the StartConversation supports passing in metadata such as Locale, we will make the change immediately to support properly localized Intro Card.
+
 Our backlog is fully accessible within the [GitHub repo](https://github.com/Microsoft/AI/)

--- a/solutions/Virtual-Assistant/docs/virtualassistant-knownissues.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-knownissues.md
@@ -83,6 +83,7 @@ Add the middleware to Startup.cs:
 There is a known issue in the Virtual Assistant when the bot doesn't pass a Locale setting at the beginning of the conversation, the Intro Card won't show up. This is due to a design flaw in the current channel protocol. The StartConversation call doesn't accept Locale as a parameter. 
 
 When you're testing in Bot Emulator, you can get around this issue by setting the Locale in Emulator Settings. Emulator will pass the locale setting to the bot as the first ConversationUpdate call.
+
 When you're testing in other environments, if it's something that you own the code, make sure you send an additional activity to the bot between the StartConversation call, and the user sends the first message:
 
 ```

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/SetLocaleMiddleware.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/SetLocaleMiddleware.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Bot.Solutions.Middleware
 
             CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture = cultureInfo;
 
-            context.Activity.Locale = cultureInfo.Name;
-
             await next(cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Not set default locale when it's not passed in. This way we can determine to not show an Intro Card when no locale, which is better than showing an Intro Card that doesn't match user's locale

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can enable automation to close related issues, using keyword Close #ISSUENUMBER -->
<!--- See https://help.github.com/articles/closing-issues-using-keywords/ for more information -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [x] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
