### PR TITLE
fix skill mode startup extra dependencies

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/Startup.cs
@@ -21,10 +21,12 @@ namespace AutomotiveSkill
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Solutions.Middleware.Telemetry;
+    using Microsoft.Bot.Solutions.Models.Proactive;
     using Microsoft.Bot.Solutions.Responses;
     using Microsoft.Bot.Solutions.Skills;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Utilities.TaskExtensions;
 
     public class Startup
     {
@@ -50,6 +52,10 @@ namespace AutomotiveSkill
 
         public void ConfigureServices(IServiceCollection services)
         {
+            // add background task queue
+            services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
+            services.AddHostedService<QueuedHostedService>();
+
             // Load the connected services from .bot file.
             var botFilePath = Configuration.GetSection("botFilePath")?.Value;
             var botFileSecret = Configuration.GetSection("botFileSecret")?.Value;
@@ -93,11 +99,22 @@ namespace AutomotiveSkill
             var dataStore = new CosmosDbStorage(cosmosOptions);
             var userState = new UserState(dataStore);
             var conversationState = new ConversationState(dataStore);
+            var proactiveState = new ProactiveState(dataStore);
 
             services.AddSingleton(dataStore);
             services.AddSingleton(userState);
             services.AddSingleton(conversationState);
+            services.AddSingleton(proactiveState);
             services.AddSingleton(new BotStateSet(userState, conversationState));
+
+            var environment = _isProduction ? "production" : "development";
+            var service = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.Endpoint && s.Name == environment);
+            if (!(service is EndpointService endpointService))
+            {
+                throw new InvalidOperationException($"The .bot file does not contain an endpoint with name '{environment}'.");
+            }
+
+            services.AddSingleton(endpointService);
 
             // Initialize service client
             services.AddSingleton<IServiceManager, ServiceManager>();
@@ -108,14 +125,6 @@ namespace AutomotiveSkill
             // Add the bot with options
             services.AddBot<AutomotiveSkill>(options =>
             {
-                // Load the connected services from .bot file.
-                var environment = _isProduction ? "production" : "development";
-                var service = botConfig.Services.FirstOrDefault(s => s.Type == ServiceTypes.Endpoint && s.Name == environment);
-                if (!(service is EndpointService endpointService))
-                {
-                    throw new InvalidOperationException($"The .bot file does not contain an endpoint with name '{environment}'.");
-                }
-
                 options.CredentialProvider = new SimpleCredentialProvider(endpointService.AppId, endpointService.AppPassword);
 
                 // Telemetry Middleware (logs activity messages in Application Insights)


### PR DESCRIPTION
## Description
Newly added dependencies are missing for skills when running in skill mode. Including endpointService, proactiveState, backgroundTaskQueue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can enable automation to close related issues, using keyword Close #ISSUENUMBER -->
<!--- See https://help.github.com/articles/closing-issues-using-keywords/ for more information -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
