### PR TITLE
only add telemetryClient into state when not exist

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskill/AutomotiveSkill.cs
@@ -106,7 +106,7 @@ namespace AutomotiveSkill
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            turnContext.TurnState.Add(TelemetryLoggerMiddleware.AppInsightsServiceKey, _telemetryClient);
+            turnContext.TurnState.TryAdd(TelemetryLoggerMiddleware.AppInsightsServiceKey, _telemetryClient);
 
             var dc = await _dialogs.CreateContextAsync(turnContext);
 


### PR DESCRIPTION
## Description
In Automotive skill, when trying to add TelemetryClient into state, only add when it doesn't exist

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can enable automation to close related issues, using keyword Close #ISSUENUMBER -->
<!--- See https://help.github.com/articles/closing-issues-using-keywords/ for more information -->
<!--- Please link to the issue here: -->

## Testing Steps
<!--- Include any instructions for testing your Pull Request-->
<!--- Include sample utterances, steps, etc-->

## Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
- [ ] A duplicate issue is filed to track future  work.

If you have updated responses or `.lu` files:
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
