### PR TITLE
Telemetry Recognizer fixes

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
@@ -182,7 +182,7 @@ namespace VirtualAssistant
                                         EndpointKey = qna.EndpointKey,
                                         Host = qna.Hostname,
                                     };
-                                    var qnaMaker = new TelemetryQnAMaker(qnaEndpoint);
+                                    var qnaMaker = new TelemetryQnAMaker(qnaEndpoint, logPersonalInformation: true);
                                     localeConfig.QnAServices.Add(qna.Id, qnaMaker);
                                     break;
                                 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/BotServices.cs
@@ -182,7 +182,7 @@ namespace VirtualAssistant
                                         EndpointKey = qna.EndpointKey,
                                         Host = qna.Hostname,
                                     };
-                                    var qnaMaker = new TelemetryQnAMaker(qnaEndpoint, logPersonalInformation: true);
+                                    var qnaMaker = new TelemetryQnAMaker(qnaEndpoint);
                                     localeConfig.QnAServices.Add(qna.Id, qnaMaker);
                                     break;
                                 }

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -84,7 +84,7 @@ namespace VirtualAssistant.Dialogs.Main
 
             // No dialog is currently on the stack and we haven't responded to the user
             // Check dispatch result
-            var dispatchResult = await localeConfig.DispatchRecognizer.RecognizeAsync<Dispatch>(dc, true, CancellationToken.None);
+            var dispatchResult = await localeConfig.DispatchRecognizer.RecognizeAsync<Dispatch>(dc, CancellationToken.None);
             var intent = dispatchResult.TopIntent().intent;
 
             switch (intent)
@@ -93,7 +93,7 @@ namespace VirtualAssistant.Dialogs.Main
                     {
                         // If dispatch result is general luis model
                         var luisService = localeConfig.LuisServices["general"];
-                        var luisResult = await luisService.RecognizeAsync<General>(dc, true, CancellationToken.None);
+                        var luisResult = await luisService.RecognizeAsync<General>(dc, CancellationToken.None);
                         var luisIntent = luisResult?.TopIntent().intent;
 
                         // switch on general intents

--- a/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Startup.cs
@@ -119,7 +119,7 @@ namespace VirtualAssistant
                 // Telemetry Middleware (logs activity messages in Application Insights)
                 var sp = services.BuildServiceProvider();
                 var telemetryClient = sp.GetService<IBotTelemetryClient>();
-                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true);
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient);
                 options.Middleware.Add(appInsightsLogger);
 
                 // Catches any errors that occur during a conversation turn and logs them to AppInsights.

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryLuisRecognizer.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
     {
         bool LogPersonalInformation { get; }
 
-        Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
 
-        Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryQnAMaker.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/ITelemetryQnAMaker.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
     {
         bool LogPersonalInformation { get; }
 
-        Task<QueryResult[]> GetAnswersAsync(ITurnContext context);
+        Task<QueryResult[]> GetAnswersAsync(ITurnContext context, QnAMakerOptions options = null);
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
         /// <summary>
         /// Gets a value indicating whether determines whether to log the Activity message text that came from the user.
         /// </summary>
-        /// <value>If true, will log the Activity Message text into the AppInsight Custome Event for Luis intents.</value>
+        /// <value>If true, will log the Activity Message text into the AppInsight Custom Event for Luis intents.</value>
         public bool LogPersonalInformation { get; }
 
         public async Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
             return result;
         }
 
-        public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        public new async Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             var result = new T();
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
             }
 
             // Call Luis Recognizer
-            var recognizerResult = await RecognizeAsync(context, cancellationToken);
+            var recognizerResult = await base.RecognizeAsync(context, cancellationToken);
 
             // Find the Telemetry Client
             if (context.TurnState.TryGetValue(TelemetryLoggerMiddleware.AppInsightsServiceKey, out var telemetryClient) && recognizerResult != null)

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryLuisRecognizer.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
     /// TelemetryLuisRecognizer invokes the Luis Recognizer and logs some results into Application Insights.
     /// Logs the Top Intent, Sentiment (label/score), (Optionally) Original Text
     /// Along with Conversation and ActivityID.
-    /// The Custom Event name this logs is MyLuisConstants.IntentPrefix + "." + 'found intent name'
-    /// For example, if intent name was "add_calender":
-    ///    LuisIntent.add_calendar
     /// See <seealso cref="LuisRecognizer"/> for additional information.
     /// </summary>
     public class TelemetryLuisRecognizer : LuisRecognizer, ITelemetryLuisRecognizer
@@ -47,19 +44,19 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
         /// <value>If true, will log the Activity Message text into the AppInsight Custome Event for Luis intents.</value>
         public bool LogPersonalInformation { get; }
 
-        public async Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             var result = new T();
-            result.Convert(await RecognizeAsync(dialogContext, logPersonalInformation, cancellationToken).ConfigureAwait(false));
+            result.Convert(await RecognizeAsync(dialogContext, cancellationToken).ConfigureAwait(false));
             return result;
         }
 
-        public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             var result = new T();
-            result.Convert(await RecognizeAsync(turnContext, logPersonalInformation, cancellationToken).ConfigureAwait(false));
+            result.Convert(await RecognizeAsync(turnContext, cancellationToken).ConfigureAwait(false));
             return result;
         }
 
@@ -67,39 +64,36 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
         /// Return results of the analysis (Suggested actions and intents), passing the dialog id from dialog context to the TelemetryClient.
         /// </summary>
         /// <param name="dialogContext">Dialog context object containing information for the dialog being executed.</param>
-        /// <param name="logPersonalInformation">TRUE to include personally indentifiable information.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
-        public async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (dialogContext == null)
             {
                 throw new ArgumentNullException(nameof(dialogContext));
             }
 
-            return await RecognizeInternalAsync(dialogContext.Context, logPersonalInformation, dialogContext.ActiveDialog?.Id, cancellationToken);
+            return await RecognizeInternalAsync(dialogContext.Context, dialogContext.ActiveDialog?.Id, cancellationToken);
         }
 
         /// <summary>
         /// Return results of the analysis (Suggested actions and intents), using the turn context. This is missing a dialog id used for telemetry..
         /// </summary>
         /// <param name="context">Context object containing information for a single turn of conversation with a user.</param>
-        /// <param name="logPersonalInformation">TRUE to include personally indentifiable information.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
-        public async Task<RecognizerResult> RecognizeAsync(ITurnContext context, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<RecognizerResult> RecognizeAsync(ITurnContext context, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await RecognizeInternalAsync(context, logPersonalInformation, null, cancellationToken);
+            return await RecognizeInternalAsync(context, null, cancellationToken);
         }
 
         /// <summary>
         /// Analyze the current message text and return results of the analysis (Suggested actions and intents).
         /// </summary>
         /// <param name="context">Context object containing information for a single turn of conversation with a user.</param>
-        /// <param name="logPersonalInformation">TRUE to include personally indentifiable information.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
-        private async Task<RecognizerResult> RecognizeInternalAsync(ITurnContext context, bool logPersonalInformation, string dialogId = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<RecognizerResult> RecognizeInternalAsync(ITurnContext context, string dialogId = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (context == null)
             {
@@ -146,7 +140,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
                 telemetryProperties.Add(LuisTelemetryConstants.EntitiesProperty, entities);
 
                 // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
-                if (logPersonalInformation && !string.IsNullOrEmpty(context.Activity.Text))
+                if (LogPersonalInformation && !string.IsNullOrEmpty(context.Activity.Text))
                 {
                     telemetryProperties.Add(LuisTelemetryConstants.QuestionProperty, context.Activity.Text);
                 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
 
         public bool LogPersonalInformation { get; }
 
-        public async Task<QueryResult[]> GetAnswersAsync(ITurnContext context)
+        public new async Task<QueryResult[]> GetAnswersAsync(ITurnContext context, QnAMakerOptions options = null)
         {
-            // Call Qna Maker
-            var queryResults = await base.GetAnswersAsync(context);
+            // Call QnA Maker
+            var queryResults = await base.GetAnswersAsync(context, options);
 
             // Find the Application Insights Telemetry Client
             if (queryResults != null && context.TurnState.TryGetValue(TelemetryLoggerMiddleware.AppInsightsServiceKey, out var telemetryClient))

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Middleware/Telemetry/TelemetryQnAMaker.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
                 {
                     var queryResult = queryResults[0];
                     telemetryProperties.Add(QnATelemetryConstants.QuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
-                    telemetryMetrics.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id);
+                    telemetryProperties.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id.ToString());
                     telemetryProperties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
                     telemetryMetrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);
                     telemetryProperties.Add(QnATelemetryConstants.ArticleFoundProperty, "true");
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Solutions.Middleware.Telemetry
                 else
                 {
                     telemetryProperties.Add(QnATelemetryConstants.QuestionProperty, "No Qna Question matched");
-                    telemetryMetrics.Add(QnATelemetryConstants.QuestionIdProperty, -1);
+                    telemetryProperties.Add(QnATelemetryConstants.QuestionIdProperty, "No QnA Question Id matched");
                     telemetryProperties.Add(QnATelemetryConstants.AnswerProperty, "No Qna Answer matched");
                     telemetryProperties.Add(QnATelemetryConstants.ArticleFoundProperty, "false");
                 }

--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Testing/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Testing/Fakes/MockLuisRecognizer.cs
@@ -35,19 +35,10 @@ namespace Microsoft.Bot.Solutions.Testing.Fakes
             throw new NotImplementedException();
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             var text = dialogContext.Context.Activity.Text;
-
-            var mockResult = TestUtterances.GetValueOrDefault(text, DefaultIntent);
-            return Task.FromResult((T)mockResult);
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            var text = turnContext.Activity.Text;
 
             var mockResult = TestUtterances.GetValueOrDefault(text, DefaultIntent);
             return Task.FromResult((T)mockResult);

--- a/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/automotiveskill/automotiveskilltest/Flow/Fakes/MockLuisRecognizer.cs
@@ -60,13 +60,7 @@ namespace AutomotiveSkillTest.Flow.Fakes
             return Task.FromResult(mockResult);
         }    
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             throw new NotImplementedException();

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/Fakes/MockLuisRecognizer.cs
@@ -57,13 +57,7 @@ namespace CalendarSkillTest.Flow.Fakes
             return await Task.FromResult(mockResult);
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             throw new NotImplementedException();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/Fakes/MockEmailLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/Fakes/MockEmailLuisRecognizer.cs
@@ -48,13 +48,7 @@ namespace EmailSkillTest.Flow.Fakes
             return Task.FromResult(mockResult);
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             throw new NotImplementedException();

--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/Fakes/MockGeneralLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskilltest/Flow/Fakes/MockGeneralLuisRecognizer.cs
@@ -39,13 +39,7 @@ namespace EmailSkillTest.Flow.Fakes
             return Task.FromResult(mockResult);
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             throw new NotImplementedException();

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskill/Dialogs/Main/MainDialog.cs
@@ -92,7 +92,7 @@ namespace PointOfInterestSkill.Dialogs.Main
             else
             {
                 var turnResult = EndOfTurn;
-                var result = await luisService.RecognizeAsync<PointOfInterestLU>(dc, true, CancellationToken.None);
+                var result = await luisService.RecognizeAsync<PointOfInterestLU>(dc, CancellationToken.None);
                 var intent = result?.TopIntent().intent;
 
                 var skillOptions = new PointOfInterestSkillDialogOptions

--- a/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskilltests/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/pointofinterestskill/pointofinterestskilltests/Flow/Fakes/MockLuisRecognizer.cs
@@ -48,38 +48,13 @@ namespace PointOfInterestSkillTests.Flow.Fakes
             return Task.FromResult(mockResult);
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             var mockResult = new T();
 
             var t = typeof(T);
             var text = dialogContext.Context.Activity.Text;
-            if (t.Name.Equals(typeof(PointOfInterestLU).Name))
-            {
-                var mockPointOfInterest = new MockPointOfInterestIntent(text);
-
-                var test = mockPointOfInterest as object;
-                mockResult = (T)test;
-            }
-            else if (t.Name.Equals(typeof(General).Name))
-            {
-                var mockGeneralIntent = new MockGeneralIntent(text);
-
-                var test = mockGeneralIntent as object;
-                mockResult = (T)test;
-            }
-
-            return Task.FromResult(mockResult);
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logOriginalMessage, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            var mockResult = new T();
-
-            var t = typeof(T);
-            var text = turnContext.Activity.Text;
             if (t.Name.Equals(typeof(PointOfInterestLU).Name))
             {
                 var mockPointOfInterest = new MockPointOfInterestIntent(text);

--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskilltest/Flow/Fakes/MockLuisRecognizer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskilltest/Flow/Fakes/MockLuisRecognizer.cs
@@ -57,13 +57,7 @@ namespace ToDoSkillTest.Flow.Fakes
             return Task.FromResult(mockResult);
         }
 
-        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
-            where T : IRecognizerConvert, new()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, bool logPersonalInformation, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<T> RecognizeAsync<T>(DialogContext dialogContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new()
         {
             throw new NotImplementedException();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Bug Fixes 
* Close #851 where individual invokes of telemetry luis recognizer required passing the logPersonalInformation boolean, this is now picked up in the initializer.
* Fixed bug where the question id was inappropriately logged as a metric rather than a property.

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->
Validate that QnATelemetry is logging question ID under `customDimensions` rather than `customMetrics` and that PII is enabled by default.
