### PR TITLE
Add .env files to .gitignore file generated with generator

### DIFF
--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_.gitignore
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Generated folder by build process
 lib/
 
+# Environment variables
+.env.*
+
 # Bot Files
 *.bot
 !test/mockedConfiguration.bot


### PR DESCRIPTION
## Description
### Bug Fixes
Resolves #850: Now the bot created with the template will exclude the `.env` files from source control (The sample still has the .env files)

## Testing Steps
1. `yo botbuilder-enterprise --noPrompt`
2. The `.gitignore` file has the `.env` files ignored.

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have added or updated the appropriate unit tests~
- ~[ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.~
- ~[ ] I have updated related documentation~

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- ~[ ] A duplicate issue is filed to track future  work.~

<!--- If you have updated responses or `.lu` files:-->
- ~[ ] All languages have been updated~
- ~[ ] You have tested deployment with your new models~
