### PR TITLE
remove default timeout for oauth

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Bot.Solutions.Authentication
                         ConnectionName = connection.Key,
                         Title = CommonStrings.Login,
                         Text = string.Format(CommonStrings.LoginDescription, connection.Key),
-                        Timeout = 30000,
                     },
                     AuthPromptValidator));
             }


### PR DESCRIPTION
## Description
OAuth card when using with magic code, sometimes inputting the magic code will not work. That's because the timeout limit has been hit. it's currently set to be 30 seconds which can be easily exceeded when user has to go through multiple hoops to get authenticated (two factor authentication and whatnot). remove the limit so it falls back to the default SDK setting which is 15 minutes.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
