### PR TITLE
Fix phrasing of Send Email response text

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.json
+++ b/solutions/Virtual-Assistant/src/csharp/skills/emailskill/emailskill/Dialogs/Shared/Resources/EmailSharedResponses.json
@@ -179,8 +179,8 @@
   "SentSuccessfully": {
     "replies": [
       {
-        "text": "I have send the email with subject {Subject}.",
-        "speak": "I have send the email with subject {Subject}."
+        "text": "I have sent the email with subject {Subject}.",
+        "speak": "I have sent the email with subject {Subject}."
       }
     ],
     "inputHint": "acceptingInput"


### PR DESCRIPTION
## Description
Fixes #862. There is a typo in the bot response text

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
1. Send an email

## Checklist
N/A
