### PR TITLE
[Calendar] merge next meeting intent when show next

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -256,6 +256,38 @@ namespace CalendarSkill.Dialogs.Shared
             return false;
         }
 
+        protected General.Intent? MergeShowIntent(General.Intent? generalIntent, CalendarLU.Intent? calendarIntent, CalendarLU calendarLuisResult)
+        {
+            if (generalIntent == General.Intent.Next || generalIntent == General.Intent.Previous)
+            {
+                return generalIntent;
+            }
+
+            if (calendarIntent == CalendarLU.Intent.ShowNextCalendar)
+            {
+                return General.Intent.Next;
+            }
+
+            if (calendarIntent == CalendarLU.Intent.ShowPreviousCalendar)
+            {
+                return General.Intent.Previous;
+            }
+
+            if (calendarIntent == CalendarLU.Intent.FindCalendarEntry)
+            {
+                if (calendarLuisResult.Entities.OrderReference != null)
+                {
+                    var orderReference = GetOrderReferenceFromEntity(calendarLuisResult.Entities);
+                    if (orderReference == "next")
+                    {
+                        return General.Intent.Next;
+                    }
+                }
+            }
+
+            return generalIntent;
+        }
+
         protected Task<bool> DateTimePromptValidator(PromptValidatorContext<IList<DateTimeResolution>> promptContext, CancellationToken cancellationToken)
         {
             return Task.FromResult(true);

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -242,6 +242,7 @@ namespace CalendarSkill.Dialogs.Summary
 
                 var generalLuisResult = state.GeneralLuisResult;
                 var generalTopIntent = generalLuisResult?.TopIntent().intent;
+                generalTopIntent = MergeShowIntent(generalTopIntent, topIntent, luisResult);
 
                 if (topIntent == null)
                 {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Models/EventModel.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Models/EventModel.cs
@@ -747,6 +747,11 @@ namespace CalendarSkill.Models
                         }
 
                     case EventSource.Google:
+                        if (gmailEventData.Attendees == null)
+                        {
+                            return EventStatus.None;
+                        }
+
                         foreach (var attendee in gmailEventData.Attendees)
                         {
                             if (attendee.Self.HasValue && attendee.Self.Value)
@@ -796,6 +801,11 @@ namespace CalendarSkill.Models
 
                         break;
                     case EventSource.Google:
+                        if (gmailEventData.Attendees == null)
+                        {
+                            return;
+                        }
+
                         foreach (var attendee in gmailEventData.Attendees)
                         {
                             if (attendee.Self.HasValue && attendee.Self.Value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->
what's my next meeting 
can be FindMeetingEntry and ShowNextCalendar at the same time.
Merge them in Summary Flow

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
