### PR TITLE
[TypeScript] Fix issue with "copy-templates" script using bash

### DIFF
--- a/solutions/Virtual-Assistant/src/typescript/assistant/package.json
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/package.json
@@ -7,7 +7,7 @@
     "main": "lib/index.js",
     "scripts": {
         "clean": "rimraf ./lib",
-        "copy-templates": "copyfiles --up 1 ./src/**/*.json ./lib",
+        "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "post-install": "npm run build && node ./deploymentScripts/webConfigPrep.js",

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/package.json
@@ -7,7 +7,7 @@
     "main": "lib/index.js",
     "scripts": {
         "clean": "rimraf ./lib",
-        "copy-templates": "copyfiles --up 1 ./src/**/*.json ./lib",
+        "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",

--- a/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
+++ b/templates/Enterprise-Template/src/typescript/generator-botbuilder-enterprise/generators/app/templates/enterprise-bot/_package.json
@@ -7,7 +7,7 @@
     "main": "lib/index.js",
     "scripts": {
         "clean": "rimraf ./lib",
-        "copy-templates": "copyfiles --up 1 ./src/**/*.json ./lib",
+        "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",


### PR DESCRIPTION
## Description
### Bug Fixes
Fixes #843 
Fixes #847
Fix the `copy-templates` script that uses `copyfiles` to works with `bash`.

![image](https://user-images.githubusercontent.com/12394167/53371759-dddcec00-392f-11e9-996c-d091ff8a826f.png)

## Testing Steps
1. Use `bash`
1. `cd ./templates/Enterprise-Template/src/typescript/enterprise-bot`
1. `npm i` to install dependencies.
1. `npm run build` to build the project.
1. `cd ./lib`
1. `tree`
1. Check the `.json` files in `./locales` and `./dialogs/main/resources`.
