### PR TITLE
change adjust time to not change duration

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkillState.cs
@@ -273,7 +273,7 @@ namespace CalendarSkill
             OriginalEndDate = new List<DateTime>();
             OriginalEndTime = new List<DateTime>();
             NewStartDateTime = null;
-            Duration = 0;
+            //Duration = 0;
             MoveTimeSpan = 0;
             CreateHasDetail = true;
             RecreateState = RecreateEventState.Time;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkillState.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/CalendarSkillState.cs
@@ -273,7 +273,6 @@ namespace CalendarSkill
             OriginalEndDate = new List<DateTime>();
             OriginalEndTime = new List<DateTime>();
             NewStartDateTime = null;
-            //Duration = 0;
             MoveTimeSpan = 0;
             CreateHasDetail = true;
             RecreateState = RecreateEventState.Time;

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
@@ -92,8 +92,6 @@ namespace CalendarSkillTest.Flow
                 .Send(Strings.Strings.DefaultStartDate)
                 .AssertReplyOneOf(this.AskForStartTimePrompt())
                 .Send(Strings.Strings.DefaultStartTime)
-                .AssertReplyOneOf(this.AskForDurationPrompt())
-                .Send(Strings.Strings.DefaultDuration)
                 .AssertReply(this.ShowCalendarList())
                 .Send(Strings.Strings.ConfirmYes)
                 .AssertReply(this.ShowCalendarList())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->
when user choose to adjust time when confirm no on creation, the bot will only ask for new date and time. It won't ask for duration.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
