### PR TITLE
set default locale for skill correctly

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/microsoft.bot.solutions/Skills/SkillDialog.cs
@@ -176,7 +176,16 @@ namespace Microsoft.Bot.Solutions.Skills
                 };
 
                 _inProcAdapter.Use(new EventDebuggerMiddleware());
-                _inProcAdapter.Use(new SetLocaleMiddleware(dc.Context.Activity.Locale ?? "en-us"));
+
+                // change this to use default locale from appsettings when we have dependency injection
+                var locale = "en-us";
+                if (!string.IsNullOrWhiteSpace(dc.Context.Activity.Locale))
+                {
+                    locale = dc.Context.Activity.Locale;
+                }
+
+                _inProcAdapter.Use(new SetLocaleMiddleware(locale));
+
                 _inProcAdapter.Use(new AutoSaveStateMiddleware(userState, conversationState));
                 _skillInitialized = true;
             }


### PR DESCRIPTION
## Description
When setting locale for skill's SetLocaleMiddleware we're setting it to empty if the locale is an empty string. should check for both null and empty string to give it a default value

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
