### PR TITLE
[Calendar] fix reply with email not work when ask participant for the second time in create flow

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/FindContact/FindContactDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/FindContact/FindContactDialog.cs
@@ -181,18 +181,17 @@ namespace CalendarSkill.Dialogs.FindContact
 
                 var unionList = new List<CustomizedPerson>();
                 var emailList = new List<string>();
+                foreach (var name in state.AttendeesNameList)
+                {
+                    if (IsEmail(name))
+                    {
+                        emailList.Add(name);
+                    }
+                }
 
                 if (state.FirstEnterFindContact)
                 {
                     state.FirstEnterFindContact = false;
-                    foreach (var name in state.AttendeesNameList)
-                    {
-                        if (IsEmail(name))
-                        {
-                            emailList.Add(name);
-                        }
-                    }
-
                     if (state.AttendeesNameList.Count > 1)
                     {
                         var nameString = await GetReadyToSendNameListStringAsync(sc);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->
if the user give an email as the second try in collecting participants, the bot will not take it as an email.
Move the email code out side the FirstEnterFindContact part.


### Architecture

### Bug Fixes
Bot ask for participant
user gives a name that can not be found.
Bot ask again
user gives the email
bot still reply with can not found.

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
