### PR TITLE
[Calendar] fix the exact number can't be recognized as date or time

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/DatePrompt.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/DatePrompt.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using CalendarSkill.Dialogs.CreateEvent.Resources;
+using CalendarSkill.Util;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
@@ -86,7 +87,7 @@ namespace CalendarSkill.Dialogs.CreateEvent.Prompts
 
         private List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture)
         {
-            var results = DateTimeRecognizer.RecognizeDateTime(dateTimeString, culture, options: DateTimeOptions.CalendarMode);
+            var results = DateTimeRecognizer.RecognizeDateTime(DateTimeHelper.ConvertNumberToDateTimeString(dateTimeString, true), culture, options: DateTimeOptions.CalendarMode);
             if (results.Count > 0)
             {
                 // Return list of resolutions from first match

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/TimePrompt.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/CreateEvent/Prompts/TimePrompt.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CalendarSkill.Dialogs.CreateEvent.Prompts.Options;
 using CalendarSkill.Dialogs.CreateEvent.Resources;
+using CalendarSkill.Util;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
@@ -97,7 +98,7 @@ namespace CalendarSkill.Dialogs.CreateEvent.Prompts
 
         private List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture)
         {
-            var results = DateTimeRecognizer.RecognizeDateTime(dateTimeString, culture, options: DateTimeOptions.CalendarMode);
+            var results = DateTimeRecognizer.RecognizeDateTime(DateTimeHelper.ConvertNumberToDateTimeString(dateTimeString, false), culture, options: DateTimeOptions.CalendarMode);
             if (results.Count > 0)
             {
                 // Return list of resolutions from first match

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -11,6 +11,7 @@ using CalendarSkill.Dialogs.Shared.Resources;
 using CalendarSkill.Dialogs.Shared.Resources.Strings;
 using CalendarSkill.Models;
 using CalendarSkill.ServiceClients;
+using CalendarSkill.Util;
 using Luis;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
@@ -838,9 +839,10 @@ namespace CalendarSkill.Dialogs.Shared
             }
         }
 
-        protected List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture)
+        protected List<DateTimeResolution> RecognizeDateTime(string dateTimeString, string culture, bool convertToDate = true)
         {
-            var results = DateTimeRecognizer.RecognizeDateTime(dateTimeString, culture);
+            var results = DateTimeRecognizer.RecognizeDateTime(DateTimeHelper.ConvertNumberToDateTimeString(dateTimeString, convertToDate), culture, options: DateTimeOptions.CalendarMode);
+
             if (results.Count > 0)
             {
                 // Return list of resolutions from first match
@@ -1275,7 +1277,7 @@ namespace CalendarSkill.Dialogs.Shared
         private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone, bool isStart = true)
         {
             var culture = local ?? English;
-            var results = RecognizeDateTime(date, culture);
+            var results = RecognizeDateTime(date, culture, true);
             var dateTimeResults = new List<DateTime>();
             if (results != null)
             {
@@ -1319,7 +1321,7 @@ namespace CalendarSkill.Dialogs.Shared
         private List<DateTime> GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart = true)
         {
             var culture = local ?? English;
-            var results = RecognizeDateTime(time, culture);
+            var results = RecognizeDateTime(time, culture, false);
             var dateTimeResults = new List<DateTime>();
             if (results != null)
             {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/CalendarSkillDialog.cs
@@ -475,14 +475,14 @@ namespace CalendarSkill.Dialogs.Shared
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (date != null)
                                 {
                                     state.CreateHasDetail = true;
                                     state.StartDate = date;
                                 }
 
-                                date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (date != null)
                                 {
                                     state.CreateHasDetail = true;
@@ -565,13 +565,13 @@ namespace CalendarSkill.Dialogs.Shared
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (date != null)
                                 {
                                     state.StartDate = date;
                                 }
 
-                                date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (date != null)
                                 {
                                     state.EndDate = date;
@@ -607,13 +607,13 @@ namespace CalendarSkill.Dialogs.Shared
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (date != null)
                                 {
                                     state.OriginalStartDate = date;
                                 }
 
-                                date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (date != null)
                                 {
                                     state.OriginalEndDate = date;
@@ -701,14 +701,14 @@ namespace CalendarSkill.Dialogs.Shared
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
                                 if (date != null)
                                 {
                                     state.StartDate = date;
                                     state.StartDateString = dateString;
                                 }
 
-                                date = GetTimeFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
                                 if (date != null)
                                 {
                                     state.EndDate = date;
@@ -1272,7 +1272,7 @@ namespace CalendarSkill.Dialogs.Shared
             return inputString.Substring(data.StartIndex, data.EndIndex - data.StartIndex);
         }
 
-        private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone)
+        private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone, bool isStart = true)
         {
             var culture = local ?? English;
             var results = RecognizeDateTime(date, culture);
@@ -1281,13 +1281,34 @@ namespace CalendarSkill.Dialogs.Shared
             {
                 foreach (var result in results)
                 {
-                    var dateTime = DateTime.Parse(result.Value);
-                    var dateTimeConvertType = result.Timex;
-
-                    if (dateTime != null)
+                    if (result.Value != null)
                     {
-                        var isRelativeTime = IsRelativeTime(date, result.Value, result.Timex);
-                        dateTimeResults.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime);
+                        if (!isStart)
+                        {
+                            break;
+                        }
+
+                        var dateTime = DateTime.Parse(result.Value);
+                        var dateTimeConvertType = result.Timex;
+
+                        if (dateTime != null)
+                        {
+                            var isRelativeTime = IsRelativeTime(date, result.Value, result.Timex);
+                            dateTimeResults.Add(isRelativeTime ? TimeZoneInfo.ConvertTime(dateTime, TimeZoneInfo.Local, userTimeZone) : dateTime);
+                        }
+                    }
+                    else
+                    {
+                        var startDate = DateTime.Parse(result.Start);
+                        var endDate = DateTime.Parse(result.End);
+                        if (isStart)
+                        {
+                            dateTimeResults.Add(startDate);
+                        }
+                        else
+                        {
+                            dateTimeResults.Add(endDate);
+                        }
                     }
                 }
             }

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.Designer.cs
@@ -223,6 +223,42 @@ namespace CalendarSkill.Dialogs.Shared.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}nd.
+        /// </summary>
+        public static string OrdinalSuffixNd {
+            get {
+                return ResourceManager.GetString("OrdinalSuffixNd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}rd.
+        /// </summary>
+        public static string OrdinalSuffixRd {
+            get {
+                return ResourceManager.GetString("OrdinalSuffixRd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}st.
+        /// </summary>
+        public static string OrdinalSuffixSt {
+            get {
+                return ResourceManager.GetString("OrdinalSuffixSt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}th.
+        /// </summary>
+        public static string OrdinalSuffixTh {
+            get {
+                return ResourceManager.GetString("OrdinalSuffixTh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ^(skip|no).
         /// </summary>
         public static string SkipPhrases {

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.de.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.de.resx
@@ -120,20 +120,41 @@
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} und {1} mehr</value>
   </data>
+  <data name="AdjustParticipants" xml:space="preserve">
+    <value>(Die " * (Teilnehmer)</value>
+  </data>
+  <data name="SkipPhrases" xml:space="preserve">
+    <value>^ (skip | no)</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0}th</value>
+  </data>
   <data name="AllDayLower" xml:space="preserve">
     <value>Ganztägig</value>
   </data>
   <data name="AllDay" xml:space="preserve">
     <value>Ganztägig</value>
   </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0}st</value>
+  </data>
+  <data name="AdjustSubject" xml:space="preserve">
+    <value>(Anpassung | ändern/aktualisieren)?. * (Betreff | Titel)</value>
+  </data>
+  <data name="Myself" xml:space="preserve">
+    <value>^ (me | myself) $</value>
+  </data>
   <data name="AtTime" xml:space="preserve">
     <value>at {0}</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>Keine Teilnehmer</value>
   </data>
   <data name="CancelAdjust" xml:space="preserve">
     <value>^ (no | abbrechen/nop/nicht/nicht)</value>
   </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>Keine Teilnehmer</value>
+  <data name="DefaultTitle" xml:space="preserve">
+    <value>Sitzung</value>
   </data>
   <data name="WeeklyToken" xml:space="preserve">
     <value>Wöchentliche</value>
@@ -144,13 +165,34 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>Mit einem Subjekt von {0}</value>
   </data>
+  <data name="AdjustLocation" xml:space="preserve">
+    <value>(Anpassung | ändern/aktualisieren)?. * (Lage | Ort | wo)</value>
+  </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0}nd</value>
+  </data>
   <data name="DailyToken" xml:space="preserve">
     <value>Täglich</value>
+  </data>
+  <data name="AdjustContent" xml:space="preserve">
+    <value>(Anpassung | ändern/aktualisieren)?. * (Inhalt | Körper | Details)</value>
   </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Monatliche</value>
   </data>
   <data name="Today" xml:space="preserve">
     <value>Heute</value>
+  </data>
+  <data name="ContactSeparator" xml:space="preserve">
+    <value>, | und |;</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0}rd</value>
+  </data>
+  <data name="AdjustDuration" xml:space="preserve">
+    <value>(Anpassung | ändern/aktualisieren)?. * (Dauer | Länge)</value>
+  </data>
+  <data name="AdjustTime" xml:space="preserve">
+    <value>(Anpassung | ändern/aktualisieren)?. * Zeit</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.es.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.es.resx
@@ -120,20 +120,41 @@
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} y {1} más</value>
   </data>
+  <data name="AdjustParticipants" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar | agregar | eliminar)?. * (participantes | Attendee | asistentes | personas | persona)</value>
+  </data>
+  <data name="SkipPhrases" xml:space="preserve">
+    <value>^ (SKIP | no)</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0} TH</value>
+  </data>
   <data name="AllDayLower" xml:space="preserve">
     <value>todo el día</value>
   </data>
   <data name="AllDay" xml:space="preserve">
     <value>Todo el día</value>
   </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0} St</value>
+  </data>
+  <data name="AdjustSubject" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar)?. * (tema | título)</value>
+  </data>
+  <data name="Myself" xml:space="preserve">
+    <value>^ (yo | yo) $</value>
+  </data>
   <data name="AtTime" xml:space="preserve">
     <value>en {0}</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>no asistentes</value>
   </data>
   <data name="CancelAdjust" xml:space="preserve">
     <value>^ (no | CANCEL | NOP | no | no)</value>
   </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>no asistentes</value>
+  <data name="DefaultTitle" xml:space="preserve">
+    <value>Reunión</value>
   </data>
   <data name="WeeklyToken" xml:space="preserve">
     <value>Semanal</value>
@@ -144,13 +165,34 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>con un tema de {0}</value>
   </data>
+  <data name="AdjustLocation" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar)?. * (ubicación | lugar | donde)</value>
+  </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0} ND</value>
+  </data>
   <data name="DailyToken" xml:space="preserve">
     <value>Diario</value>
+  </data>
+  <data name="AdjustContent" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar)?. * (contenido | Body | detalle | detalles)</value>
   </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensual</value>
   </data>
   <data name="Today" xml:space="preserve">
     <value>Hoy</value>
+  </data>
+  <data name="ContactSeparator" xml:space="preserve">
+    <value>, | y |;</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0} Rd</value>
+  </data>
+  <data name="AdjustDuration" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar)?. * (duración | longitud)</value>
+  </data>
+  <data name="AdjustTime" xml:space="preserve">
+    <value>(ajustar | cambiar | actualizar)?. * tiempo</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.fr.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.fr.resx
@@ -120,20 +120,41 @@
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} et {1} en savoir plus</value>
   </data>
+  <data name="AdjustParticipants" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour | ajouter | supprimer)?. * (participants | participant | participants | personnes | personne)</value>
+  </data>
+  <data name="SkipPhrases" xml:space="preserve">
+    <value>^ (SKIP | no)</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0} th</value>
+  </data>
   <data name="AllDayLower" xml:space="preserve">
     <value>toute la journée</value>
   </data>
   <data name="AllDay" xml:space="preserve">
     <value>Toute la journée</value>
   </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0} St</value>
+  </data>
+  <data name="AdjustSubject" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour)?. * (sujet | titre)</value>
+  </data>
+  <data name="Myself" xml:space="preserve">
+    <value>^ (me | me) $</value>
+  </data>
   <data name="AtTime" xml:space="preserve">
     <value>à {0}</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>pas de participants</value>
   </data>
   <data name="CancelAdjust" xml:space="preserve">
     <value>^ (non | annuler | NOP | non | non)</value>
   </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>pas de participants</value>
+  <data name="DefaultTitle" xml:space="preserve">
+    <value>Réunion</value>
   </data>
   <data name="WeeklyToken" xml:space="preserve">
     <value>Hebdomadaire</value>
@@ -144,13 +165,34 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>avec un sujet de {0}</value>
   </data>
+  <data name="AdjustLocation" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour)?. * (lieu | lieu | où)</value>
+  </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0} ND</value>
+  </data>
   <data name="DailyToken" xml:space="preserve">
     <value>Quotidienne</value>
+  </data>
+  <data name="AdjustContent" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour)?. * (contenu | corps | détail | Détails)</value>
   </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensuel</value>
   </data>
   <data name="Today" xml:space="preserve">
     <value>Aujourd'hui</value>
+  </data>
+  <data name="ContactSeparator" xml:space="preserve">
+    <value>, | et |;</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0} Rd</value>
+  </data>
+  <data name="AdjustDuration" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour)?. * (durée | longueur)</value>
+  </data>
+  <data name="AdjustTime" xml:space="preserve">
+    <value>(ajuster | modifier | mettre à jour)?. * temps de</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.it.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.it.resx
@@ -120,20 +120,41 @@
   <data name="AttendeesSummary" xml:space="preserve">
     <value>{0} e {1} di più</value>
   </data>
+  <data name="AdjustParticipants" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento | Add | Delete)?. * (partecipanti | partecipante | partecipanti | persone | persona)</value>
+  </data>
+  <data name="SkipPhrases" xml:space="preserve">
+    <value>^ (salta | no)</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0} TH</value>
+  </data>
   <data name="AllDayLower" xml:space="preserve">
     <value>tutto il giorno</value>
   </data>
   <data name="AllDay" xml:space="preserve">
     <value>Tutto il giorno</value>
   </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0} St</value>
+  </data>
+  <data name="AdjustSubject" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento)?. * (oggetto | titolo)</value>
+  </data>
+  <data name="Myself" xml:space="preserve">
+    <value>^ (me | me) $</value>
+  </data>
   <data name="AtTime" xml:space="preserve">
     <value>alle {0}</value>
+  </data>
+  <data name="NoAttendees" xml:space="preserve">
+    <value>Nessun partecipante</value>
   </data>
   <data name="CancelAdjust" xml:space="preserve">
     <value>^ (No | Annulla | NOP | non | not)</value>
   </data>
-  <data name="NoAttendees" xml:space="preserve">
-    <value>Nessun partecipante</value>
+  <data name="DefaultTitle" xml:space="preserve">
+    <value>Riunione</value>
   </data>
   <data name="WeeklyToken" xml:space="preserve">
     <value>Settimanale</value>
@@ -144,13 +165,34 @@
   <data name="WithTheSubject" xml:space="preserve">
     <value>con un oggetto di {0}</value>
   </data>
+  <data name="AdjustLocation" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento)?. * (posizione | luogo | dove)</value>
+  </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0} ND</value>
+  </data>
   <data name="DailyToken" xml:space="preserve">
     <value>Quotidiana</value>
+  </data>
+  <data name="AdjustContent" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento)?. * (contenuto | Body | dettaglio | dettagli)</value>
   </data>
   <data name="MonthlyToken" xml:space="preserve">
     <value>Mensile</value>
   </data>
   <data name="Today" xml:space="preserve">
     <value>Oggi</value>
+  </data>
+  <data name="ContactSeparator" xml:space="preserve">
+    <value>, | e |;</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0} Rd</value>
+  </data>
+  <data name="AdjustDuration" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento)?. * (durata | lunghezza)</value>
+  </data>
+  <data name="AdjustTime" xml:space="preserve">
+    <value>(regola | modifica | aggiornamento)?. * tempo di</value>
   </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.resx
@@ -183,4 +183,16 @@
   <data name="SkipPhrases" xml:space="preserve">
     <value>^(skip|no)</value>
   </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0}nd</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0}rd</value>
+  </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0}st</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0}th</value>
+  </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Shared/Resources/Strings/CalendarCommonStrings.zh.resx
@@ -183,4 +183,16 @@
   <data name="SkipPhrases" xml:space="preserve">
     <value>(跳过|不要|空着|没有)</value>
   </data>
+  <data name="OrdinalSuffixNd" xml:space="preserve">
+    <value>{0}号</value>
+  </data>
+  <data name="OrdinalSuffixRd" xml:space="preserve">
+    <value>{0}号</value>
+  </data>
+  <data name="OrdinalSuffixSt" xml:space="preserve">
+    <value>{0}号</value>
+  </data>
+  <data name="OrdinalSuffixTh" xml:space="preserve">
+    <value>{0}号</value>
+  </data>
 </root>

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Dialogs/Summary/SummaryDialog.cs
@@ -323,7 +323,7 @@ namespace CalendarSkill.Dialogs.Summary
                     }
 
                     // filter meetings with start time
-                    var timeResult = RecognizeDateTime(userInput, sc.Context.Activity.Locale ?? English);
+                    var timeResult = RecognizeDateTime(userInput, sc.Context.Activity.Locale ?? English, false);
                     if (filteredMeetingList.Count <= 0 && timeResult != null)
                     {
                         foreach (var result in timeResult)

--- a/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Util/DateTimeHelper.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/calendarskill/calendarskill/Util/DateTimeHelper.cs
@@ -1,0 +1,48 @@
+﻿using CalendarSkill.Dialogs.Shared.Resources.Strings;
+
+namespace CalendarSkill.Util
+{
+    public class DateTimeHelper
+    {
+        public static string ConvertNumberToDateTimeString(string numberString, bool convertToDate)
+        {
+            // convert exact number to date or time
+            // if need convert to date, add "st", "rd", or "th" after the number
+            // if need convert to time, add ":00" after the number
+            if (int.TryParse(numberString, out var number))
+            {
+                if (convertToDate)
+                {
+                    if (number > 0 && number <= 31)
+                    {
+                        if (number % 10 == 1 && number != 11)
+                        {
+                            return string.Format(CalendarCommonStrings.OrdinalSuffixSt, numberString);
+                        }
+                        else if (number % 10 == 2 && number != 12)
+                        {
+                            return string.Format(CalendarCommonStrings.OrdinalSuffixNd, numberString);
+                        }
+                        else if (number % 10 == 3 && number != 13)
+                        {
+                            return string.Format(CalendarCommonStrings.OrdinalSuffixRd, numberString);
+                        }
+                        else
+                        {
+                            return string.Format(CalendarCommonStrings.OrdinalSuffixTh, numberString);
+                        }
+                    }
+                }
+                else
+                {
+                    if (number >= 0 && number <= 24)
+                    {
+                        return numberString + ":00";
+                    }
+                }
+            }
+
+            return numberString;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Architecture

### Bug Fixes
when bot asked for "For what date" then the user said "19", the DateTimeRecognizer can't handle it. To resolve this issue, do a workaroud that add "th" after the "19". For the scenario of ask for time, add ":00" after the number.
issue: https://github.com/Microsoft/AI/issues/725
https://fuselabs.visualstudio.com/Solutions/_workitems/edit/27011/

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->
Try utterance:
create a meeting at 14
or answer a number when bot asked "For what date" and "For what time" in create meeting flow

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
