### PR TITLE
fix path issues in update_published_models.ps1

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/update_published_models.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/update_published_models.ps1
@@ -23,9 +23,9 @@ function UpdateLUIS ($botFilePath, $langCode, $id) {
 	{
 		msbot get $id --bot $botFilePath | luis delete version --stdin --versionId backup --force --wait
 	}
-		
+	
 	msbot get $id --bot $botFilePath | luis rename version --newVersionId backup --stdin --wait
-	msbot get $id --bot $botFilePath | luis import version --stdin --in "($(Join-Path $PSScriptRoot $langCode $id).luis" --wait
+	msbot get $id --bot $botFilePath | luis import version --stdin --in "$(Join-Path $PSScriptRoot $langCode $id).luis" --wait
 	msbot get $id --bot $botFilePath | luis train version --wait --stdin 
 	msbot get $id --bot $botFilePath | luis publish version --stdin
 }
@@ -66,7 +66,7 @@ foreach ($locale in $localeArr) {
 
 foreach ($botFile in $botFiles) {
 	$botFileName = $botFile | % {$_.BaseName}
-	$botFilePath = Join-Path $basePath $botFile
+	$botFilePath = $botFile.FullName
 	$langCode = $botFileName.Substring($botFileName.Length - 2, 2)
 	$recipeBasePath = Join-Path $PSScriptRoot $langCode
 	$recipePath = Join-Path $recipeBasePath "bot.recipe"


### PR DESCRIPTION
## Description
This PR addresses two path concatenation issues. One is a typo and the other is a byproduct of switching to `Join-Path`

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
- Run `update_published_models.ps1` with all supported parameter sets, on Windows and Mac, using only PowerShell 6+
- Script should complete without errors

## Checklist
N/A
