### PR TITLE
[To Do]Remove duplicated logic of identifying 'ContainsAll' entity

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/Dialogs/Shared/ToDoSkillDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/skills/todoskill/todoskill/Dialogs/Shared/ToDoSkillDialog.cs
@@ -391,18 +391,6 @@ namespace ToDoSkill.Dialogs.Shared
                 {
                     state.TaskContentML = entities.TaskContentML[0];
                 }
-
-                if (dc.Context.Activity.Text != null)
-                {
-                    var words = dc.Context.Activity.Text.Split(' ');
-                    foreach (var word in words)
-                    {
-                        if (word.Equals("all", StringComparison.OrdinalIgnoreCase))
-                        {
-                            state.MarkOrDeleteAllTasksFlag = true;
-                        }
-                    }
-                }
             }
             catch
             {


### PR DESCRIPTION
Remove duplicated logic of identifying 'ContainsAll' entity
## Description
Remove duplicated logic of identifying 'ContainsAll' entity which was ever uesd when LU model is not good enough. Since LU models from Carina team are officailly applied, this temporary logic should be removed.
