### PR TITLE
[Calendar] fix exception when logout in calendar skill

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/Dialogs/Main/MainDialog.cs
@@ -74,24 +74,27 @@ namespace VirtualAssistant.Dialogs.Main
 
         protected override async Task<InterruptionAction> OnInterruptDialogAsync(DialogContext dc, CancellationToken cancellationToken)
         {
-            // get current activity locale
-            var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            var localeConfig = _services.LocaleConfigurations[locale];
-
-            // check luis intent
-            var luisService = localeConfig.LuisServices["general"];
-            var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
-            var intent = luisResult.TopIntent().intent;
-
-            // TODO - Evolve this pattern
-            if (luisResult.TopIntent().score > 0.5)
+            if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
-                switch (intent)
+                // get current activity locale
+                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+                var localeConfig = _services.LocaleConfigurations[locale];
+
+                // check luis intent
+                var luisService = localeConfig.LuisServices["general"];
+                var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
+                var intent = luisResult.TopIntent().intent;
+
+                // TODO - Evolve this pattern
+                if (luisResult.TopIntent().score > 0.5)
                 {
-                    case General.Intent.Logout:
-                        {
-                            return await LogoutAsync(dc);
-                        }
+                    switch (intent)
+                    {
+                        case General.Intent.Logout:
+                            {
+                                return await LogoutAsync(dc);
+                            }
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Architecture

### Bug Fixes
fixes #738
The exception occurs due to the adapter is not BotFrameworkAdapter when logout. The logout intent should be handled in VA. But VA didn't implement the OnInterruptDialogAsync function. Added the function to handle logout intent.

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
