### PR TITLE
Updated linked accounts docs to reflect AZ portal changes and fix Change UserId bug

### DIFF
--- a/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
@@ -23,19 +23,22 @@ The Linked Accounts feature of the Virtual Assistant provides a reference sample
 
 ## Authentication Configuration
 
-In order to perform Account Linking, the Linked Accounts web app will need a user to login using the same account as they'll use to authenticate as a user of your Virtual Assistant, for example `darren@contosoassistant.com`. 
-The ``appsettings.json`` file in the sample project has the following OAuth configuration entry for you to complete, the default example is for a microsoft.online.com scenario.
+In order to perform Account Linking, the Linked Accounts web app will need the end user to login using the same account as they'll use to authenticate as a user of your Virtual Assistant, for example `darren@contosoassistant.com`. This is required to retrieve the unique identifier of the user which is used as the **key** to retrieving any linked token in the future.
+
+The ``appsettings.json`` file in the LinkedAccounts sample project has the following OAuth configuration entry for you to complete, the default example is for a microsoftonline.com based scenario. You can replace this with any custom authentication solution you have, what is key is ensuring the Linked Accounts feature is authenticating the user in some way and retrieving the same unique identifier which is passed to the assistant in future conversations.
 
 ### Integrating Azure AD
 
 1. Sign in to the [Azure Portal](https://portal.azure.com/).
 2. On the left sidebar, select  **Azure Active Directory**.
 3. From the sidedbar within, select **App Registrations (Preview)**.
-4. Select **New application registration**
+4. Select **New registration**
    *  **Name**: *Provide a friendly name*
-   *  **Application Type**: Web app / API
-   *  **Sign-on URL**: `http://localhost:XXXX/signin-oidc` *(update with the local port of your project)*
-5. On the **Overview** page of your new app, copy the following values into your `appsettings.json`
+   *  **Redirect URI**: `https://localhost:XXXX/signin-oidc` *(update with the local port of your project or replace with the address of your deployed website*
+   *  Click Register
+5. Select the Authentication section of your newly created application
+   *  Select `ID tokens` under the Implicit grant section
+6. On the **Overview** page of your new app, copy the following values into your `appsettings.json`
    * `Directory (tenant) ID` maps to `TenantId`
    * `Application (client) ID` maps to `ClientId`
 
@@ -71,9 +74,9 @@ Exchanging a Direct Line secret for a Token and providing a Trusted Origin enabl
 ## Testing Linked Accounts
 
 If you run the project within Visual Studio you will be navigated to the Linked Accounts web app. 
-You'll be prompted to login, use the same credentials that your Virtual Assistant will be using when performing operations on your behalf. 
+You'll be prompted to login, use the same credentials that your Virtual Assistant will be using when performing operations on your behalf thus ensuring the underlying unique identifier matches.
 
-> If different accounts are used then the VA Bot will not have access to your linked tokens and may prompt for authentication.
+> If different accounts are used then your assistant Bot will not have access to your linked tokens and may prompt for authentication. Also ensure that you use HTTPS when testing linked accounts.
 
 Once logged in you, click Linked Accounts in the top navigation page and you should see a list of the Authentication connections configured for the Bot 
 (whose MicrosoftAppId you specified in the earlier configuration step).

--- a/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
@@ -54,16 +54,15 @@ The ``appsettings.json`` file in the LinkedAccounts sample project has the follo
 
 > **Note** This should enable MSA accounts to be linked as well, but your provider may prevent that as a default. You can go to **Users** > **New guest user** to add additional accounts.
 
-This sample uses the AD Object Identifier claim (``AadObjectidentifierClaim``) as the unique user identifier when performing token operations. This needs to be the same claim used by the Virtual Assistant when requesting tokens. 
+This sample uses the AD Object Identifier claim (``AadObjectidentifierClaim``) as the unique user identifier when performing token operations. This needs to be the same user identifier used by the Virtual Assistant when requesting tokens. 
 
-In order to manage account linking and securely store authentication tokens, the web app requires access to your bot's ApplicationId and Secret.
+In order to manage account linking and securely store authentication tokens, the web app requires access to your bot's ApplicationId and Secret which you provide through the following configuration settings.
 ```
 "MicrosoftAppId": "YOUR_BOT_APPLICATIONID",
 "MicrosoftAppPassword": "YOUR_BOT_APPLICATION_SECRET" 
 ```
   
-The final configuration is the Direct Line secret for your Virtual Assistant bot.
-This is required to avoid prompts for magic codes, otherwise required to protect against man-in-the-middle attacks. 
+The final configuration is the Direct Line secret for your Virtual Assistant bot. This is required to avoid prompts for magic codes, otherwise required to protect against man-in-the-middle attacks. 
 Exchanging a Direct Line secret for a Token and providing a Trusted Origin enables removal of the magic code step.
 
 > Your VA Bot will need to be deployed and have a Direct Line channel configured within the Azure portal
@@ -91,3 +90,11 @@ Now that you've linked your account and stored tokens you can move back to your 
 > Equally, the principal name (upn) could be used if preferred.
 
 Asking a question that triggers a user flow which requires the specified token should now not prompt for authentication.
+
+The Bot Framework Emulator currently generates a unique UserId which can be changed to a new unique ID by clicking the down arrow next to the Restart Conversation button and choosing 'Restart with new UserId'. Unfortunately there is no current way to specify a UserId and therefore match the `AadObjectidentifierClaim` associated with your user account for use which blocks Emulator testing. At this time we have provided the ability in Linked Accounts to override the UserId enabling you to pass in the UserId currently in use by the Emulator. You can view the User identified being used by the emulator by sending a message and clicking on the entry in the log window and retrieving the from.id value.
+```
+  "from": {
+    "id": "USERID_IN_USE_HERE",
+    "role": "user"
+  },
+```

--- a/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
+++ b/solutions/Virtual-Assistant/docs/virtualassistant-linkedaccounts.md
@@ -34,7 +34,7 @@ The ``appsettings.json`` file in the LinkedAccounts sample project has the follo
 3. From the sidedbar within, select **App Registrations (Preview)**.
 4. Select **New registration**
    *  **Name**: *Provide a friendly name*
-   *  **Redirect URI**: `https://localhost:XXXX/signin-oidc` *(update with the local port of your project or replace with the address of your deployed website*
+   *  **Redirect URI**: `http://localhost:XXXX/signin-oidc` *(update with the local port of your project or replace with the address of your deployed website*
    *  Click Register
 5. Select the Authentication section of your newly created application
    *  Select `ID tokens` under the Implicit grant section
@@ -76,8 +76,7 @@ Exchanging a Direct Line secret for a Token and providing a Trusted Origin enabl
 If you run the project within Visual Studio you will be navigated to the Linked Accounts web app. 
 You'll be prompted to login, use the same credentials that your Virtual Assistant will be using when performing operations on your behalf thus ensuring the underlying unique identifier matches.
 
-> If different accounts are used then your assistant Bot will not have access to your linked tokens and may prompt for authentication. Also ensure that you use HTTPS when testing linked accounts.
-
+> If different accounts are used then your assistant Bot will not have access to your linked tokens and may prompt for authentication.
 Once logged in you, click Linked Accounts in the top navigation page and you should see a list of the Authentication connections configured for the Bot 
 (whose MicrosoftAppId you specified in the earlier configuration step).
 

--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/SessionController.cs
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Controllers/SessionController.cs
@@ -8,6 +8,7 @@ namespace LinkedAccounts.Web.Controllers
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using LinkedAccounts.Web.Helpers;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
@@ -23,28 +24,8 @@ namespace LinkedAccounts.Web.Controllers
         public void Post([FromQuery]string id)
         {
             // Passed the SessionID from the View which we store against the UserId for later use.
-            var userId = GetUserId();
+            var userId = UserId.GetUserId(HttpContext, this.User);
             Sessions[userId] = id;
-        }
-
-        private string GetUserId()
-        {
-            var claimsIdentity = this.User?.Identity as System.Security.Claims.ClaimsIdentity;
-
-            if (claimsIdentity == null)
-            {
-                throw new InvalidOperationException("User is not logged in and needs to be.");
-            }
-
-            // Update as appropriate for your scenario to the unique identifier claim
-            var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == HomeController.AadObjectidentifierClaim)?.Value;
-
-            if (objectId == null)
-            {
-                throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
-            }
-
-            return objectId;
         }
     }
 }

--- a/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Helpers/UserId.cs
+++ b/solutions/Virtual-Assistant/src/csharp/linkedaccounts/linkedaccounts.web/Helpers/UserId.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace LinkedAccounts.Web.Helpers
+{
+    public class UserId
+    {
+        public const string AadObjectidentifierClaim = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+
+        public static string GetUserId(HttpContext httpContext, ClaimsPrincipal user)
+        {
+            // If the user has overriden (to work around emulator blocker) then we use a provided UserId inside of the logged in user.            
+            if (!string.IsNullOrEmpty(httpContext.Session.GetString("ChangedUserId")))
+            {
+                return httpContext.Session.GetString("ChangedUserId");
+            }
+            else
+            {
+                var claimsIdentity = user?.Identity as System.Security.Claims.ClaimsIdentity;
+
+                if (claimsIdentity == null)
+                {
+                    throw new InvalidOperationException("User is not logged in and needs to be.");
+                }
+
+                var objectId = claimsIdentity.Claims?.SingleOrDefault(c => c.Type == AadObjectidentifierClaim)?.Value;
+
+                if (objectId == null)
+                {
+                    throw new InvalidOperationException("User does not have a valid AAD ObjectId claim.");
+                }
+
+                return objectId;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Azure Portal Active Directory application creation experience has changed meaning the default settings and steps have changed causing problems when people try to deploy Linked Accounts.

- Updated to reflect new changes and tested
- Fixed a bug with Change UserId whereby the change was being made but a new Session token was not being stored causing a magic code prompt