### PR TITLE
Fixed bug #954 with path concatenation in deployment scripts

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
@@ -33,14 +33,16 @@ $localeArr = $locales.Split(',')
 foreach ($locale in $localeArr)
 {	
 	# Update deployment scripts for the locale
+	Write-Host "Invoke-Expression $(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 	Invoke-Expression "$(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 
 	# Get language code from locale (first two characters, i.e. "en")
 	$langCode = ($locale -split "-")[0]
 
+	Write-Host "Creating directory"
 	# Create LocaleConfigurations folder and change directory
-	New-Item -ItemType directory -Force -Path "$(Join-Path $PSScriptRoot .. LocaleConfigurations)" > $null
-	cd "$(Join-Path $PSScriptRoot .. LocaleConfigurations)" > $null
+	New-Item -ItemType directory -Force -Path "$(Join-Path $PSScriptRoot .. | Join-Path -ChildPath LocaleConfigurations)" > $null
+	cd "$(Join-Path $PSScriptRoot .. | Join-Path -ChildPath LocaleConfigurations)" > $null
 
 	# Deploy Dispatch, LUIS (calendar, email, todo, and general), and QnA Maker for the locale
     Write-Host "Deploying $($locale) resources..."

--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
@@ -33,13 +33,11 @@ $localeArr = $locales.Split(',')
 foreach ($locale in $localeArr)
 {	
 	# Update deployment scripts for the locale
-	Write-Host "Invoke-Expression $(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 	Invoke-Expression "$(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 
 	# Get language code from locale (first two characters, i.e. "en")
 	$langCode = ($locale -split "-")[0]
 
-	Write-Host "Creating directory"
 	# Create LocaleConfigurations folder and change directory
 	New-Item -ItemType directory -Force -Path "$(Join-Path $PSScriptRoot .. | Join-Path -ChildPath LocaleConfigurations)" > $null
 	cd "$(Join-Path $PSScriptRoot .. | Join-Path -ChildPath LocaleConfigurations)" > $null

--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/generate_deployment_scripts.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/generate_deployment_scripts.ps1
@@ -14,8 +14,8 @@ function CheckForDuplicates($lu) {
 $locale = $locale.ToLower()
 $langCode = ($locale -split "-")[0]
 $basePath = Join-Path $PSScriptRoot ".."
-$outputPath = Join-Path $basePath "DeploymentScripts" $langCode
-$recipePath = Join-Path $basePath "DeploymentScripts" $langCode "bot.recipe"
+$outputPath = Join-Path $basePath "DeploymentScripts" | Join-Path -ChildPath $langCode
+$recipePath = Join-Path $basePath "DeploymentScripts" | Join-Path -ChildPath $langCode | Join-Path -ChildPath "bot.recipe"
 $recipe = Get-Content -Raw -Path $recipePath | ConvertFrom-Json
 
 Write-Host $basePath


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Close #954: Fixed a couple of Join-Paths in the deployment script that had more than two parameters.  
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Bug Fixes
#954 Join-Path problematic in generate_deployment_scripts.ps1

- [x ] You have tested deployment with your new models
