### PR TITLE
Adds quotes to the appSecret parameter to hande special characters.

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/DeploymentScripts/deploy_bot.ps1
@@ -25,7 +25,7 @@ if (!$languagesOnly)
 
 	# Deploy the common resources (Azure Bot Service, App Insights, Azure Storage, Cosmos DB, etc)
 	Write-Host "Deploying common resources..."
-	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --folder "$($PSScriptRoot)" --appId $appId --appSecret $appSecret --force --quiet 
+	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --folder "$($PSScriptRoot)" --appId $appId --appSecret """$appSecret""" --force --quiet 
 }
 
 $localeArr = $locales.Split(',')


### PR DESCRIPTION
## Description
deploy_bot.ps1 fails if the appSecret parameter is specified and the secret contains special characters like | or (. 

Here is an example of the error you will see:
![image](https://user-images.githubusercontent.com/12264946/54085984-92a4df00-431a-11e9-8fc2-e1371bc008c4.png)

This PR adds quotes to the parameter when passed to msbot so the PS parser doesn't choke on special characters.

Note that the developer will still need to pass the parameter in quotes to deploy_bot.ps1 (this fix addresses the problem that happens when deploy_bot.ps1 calls msbot).

## Testing Steps
Without this PR:

- Attempt to deploy a bot with a secret that contains a | or a ( in the string (see screenshot above) and the bot will not get created. 

Once the PR gets applied this should work.