### PR TITLE
[Skill Template][TypeScript] Implementation of generator-botbuilder-skill

### DIFF
--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
@@ -6,35 +6,7 @@ const pkg = require("../../package.json");
 const _pick = require("lodash/pick");
 const _camelCase = require("lodash/camelCase");
 const _upperFirst = require("lodash/upperFirst");
-const _kebabCase = require("lodash/kebabCase");
 const fs = require("fs");
-
-const languages = [
-  {
-    name: "German",
-    value: "de"
-  },
-  {
-    name: "English",
-    value: "en"
-  },
-  {
-    name: "Spanish",
-    value: "es"
-  },
-  {
-    name: "French",
-    value: "fr"
-  },
-  {
-    name: "Italian",
-    value: "it"
-  },
-  {
-    name: "Chinese",
-    value: "zh"
-  }
-];
 
 const bigBot =
   "               ╭────────────────────────╮\n" +
@@ -67,24 +39,439 @@ var skillGenerationPath = process.cwd();
 var isAlreadyCreated = false;
 
 module.exports = class extends Generator {
-    constructor(args, opts) {
-        super(args, opts);
+  constructor(args, opts) {
+    super(args, opts);
 
-        this.option("skillName", {
-            description: "The name you want to give to your skill.",
-            type: String,
-            default: "customSkill",
-            alias: "n"
-        });
+    this.option("skillName", {
+      description: "The name you want to give to your skill.",
+      type: String,
+      default: "customSkill",
+      alias: "n"
+    });
 
-        this.option("skillDesc", {
-            description: "A brief bit of text used to describe what your skill does.",
-            type: String,
-            alias: "d"
-        });
+    this.option("skillDesc", {
+      description: "A brief bit of text used to describe what your skill does.",
+      type: String,
+      alias: "d"
+    });
+
+    this.option("skillGenerationPath", {
+      description: "The path where the skill will be generated.",
+      type: String,
+      default: process.cwd(),
+      alias: "p"
+    });
+
+    this.option("noPrompt", {
+      description: "Do not prompt for any information or confirmation.",
+      type: Boolean,
+      default: false
+    });
+  }
+
+  prompting() {
+    this.log(bigBot);
+    // Generate the main prompts
+    const prompts = [
+      // Name of the skill
+      {
+        type: "input",
+        name: "skillName",
+        message: "What's the name of your skill?",
+        default: this.options.skillName ? this.options.skillName : "customSkill"
+      },
+      // Description of the skill
+      {
+        type: "input",
+        name: "skillDesc",
+        message: "What will your skill do?",
+        default: this.options.skillDesc ? this.options.skillDesc : ""
+      },
+      // Path of the skill
+      {
+        type: "confirm",
+        name: "pathConfirmation",
+        message: "Do you want to change the new skill's location?",
+        default: false
+      },
+      {
+        when: function(response) {
+          return response.pathConfirmation === true;
+        },
+        type: "input",
+        name: "skillGenerationPath",
+        message: "Where do you want to generate the skill?",
+        default: this.options.skillGenerationPath
+          ? this.options.skillGenerationPath
+          : process.cwd(),
+        validate: path => {
+          if (fs.existsSync(path)) {
+            return true;
+          }
+
+          this.log(
+            chalk.red(
+              "\n",
+              "ERROR: This is not a valid path. Please try again."
+            )
+          );
+        }
+      },
+      // Final confirmation of the skill
+      {
+        type: "confirm",
+        name: "finalConfirmation",
+        message: "Looking good. Shall I go ahead and create your new skill?",
+        default: true
+      }
+    ];
+
+    // Check that if it was generated with CLI commands
+    if (this.options.noPrompt) {
+      this.props = _pick(this.options, [
+        "skillName",
+        "skillDesc",
+        "skillGenerationPath"
+      ]);
+
+      // Validate we have what we need, or we'll need to throw
+      if (!this.props.skillName) {
+        this.log.error(
+          "ERROR: Must specify a name for your skill when using --noPrompt argument. Use --skillName or -n option."
+        );
+        process.exit(1);
+      }
+
+      this.props.finalConfirmation = true;
+      return;
     }
 
-    prompting() {
-        this.log(bigBot);
+    return this.prompt(prompts).then(props => {
+      this.props = props;
+    });
+  }
+
+  writing() {
+    if (this.props.finalConfirmation !== true) {
+      return;
     }
-}
+
+    const templateName = "customSkill";
+    const conversationStateTag = "ConversationState";
+    const userStateTag = "UserState";
+    const skillDesc = this.props.skillDesc;
+    if (!this.props.skillName.replace(/\s/g, "").length) {
+      this.props.skillName = templateName;
+    }
+
+    const skillName = this.props.skillName;
+
+    // Generate vars for templates
+    const skillNamePascalCase = _upperFirst(_camelCase(this.props.skillName));
+    const skillNameCamelCase = _camelCase(this.props.skillName);
+    skillGenerationPath = path.join(skillGenerationPath, skillName);
+    if (this.props.skillGenerationPath !== undefined) {
+      skillGenerationPath = path.join(
+        this.props.skillGenerationPath,
+        skillName
+      );
+    }
+
+    const skillConversationStateNameClass = `I${skillNamePascalCase.concat(
+      conversationStateTag
+    )}`;
+    const skillConversationStateNameFile = skillNameCamelCase.concat(
+      conversationStateTag
+    );
+    const skillUserStateNameClass = `I${skillNamePascalCase.concat(
+      userStateTag
+    )}`;
+    const skillUserStateNameFile = skillNameCamelCase.concat(userStateTag);
+
+    if (fs.existsSync(skillGenerationPath)) {
+      isAlreadyCreated = true;
+      return;
+    }
+
+    // Print current values
+    this.log(chalk.magenta("\nCurrent values for the new skill:"));
+    this.log(chalk.magenta("Name: " + skillName));
+    this.log(chalk.magenta("Description: " + skillDesc));
+    this.log(chalk.magenta("Path: " + skillGenerationPath + "\n"));
+
+    // Copy package.json
+    this.fs.copyTpl(
+      this.templatePath(templateName, "_package.json"),
+      this.destinationPath(skillGenerationPath, "package.json"),
+      {
+        name: skillName,
+        description: skillDesc
+      }
+    );
+
+    // Copy index.ts
+    this.fs.copyTpl(
+      this.templatePath(templateName, "src", "_index.ts"),
+      this.destinationPath(skillGenerationPath, "src", "index.ts"),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillProjectName: skillName,
+        skillProjectNameLU: `${skillName}LU`
+      }
+    );
+
+    // Copy skillConversationState.ts
+    this.fs.copyTpl(
+      this.templatePath(templateName, "src", "_skillConversationState.ts"),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        `${skillConversationStateNameFile}.ts`
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillProjectName: skillName,
+        skillProjectNameLU: `${skillName}LU`
+      }
+    );
+
+    // Copy skillUserState.ts
+    this.fs.copyTpl(
+      this.templatePath(templateName, "src", "_skillUserState.ts"),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        `${skillUserStateNameFile}.ts`
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillProjectName: skillName,
+        skillProjectNameLU: `${skillName}LU`
+      }
+    );
+
+    // Copy skillTemplate.ts
+    this.fs.copyTpl(
+      this.templatePath(templateName, "src", "_skillTemplate.ts"),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        `${skillNameCamelCase}.ts`
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillTemplateName: skillNamePascalCase,
+        skillProjectName: skillName,
+        skillProjectNameLU: `${skillName}LU`
+      }
+    );
+
+    // Copy mainDialog.ts
+    this.fs.copyTpl(
+      this.templatePath(
+        templateName,
+        "src",
+        "dialogs",
+        "main",
+        "_mainDialog.ts"
+      ),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        "dialogs",
+        "main",
+        "mainDialog.ts"
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillProjectName: skillName
+      }
+    );
+
+    // Copy sampleDialog.ts
+    this.fs.copyTpl(
+      this.templatePath(
+        templateName,
+        "src",
+        "dialogs",
+        "sample",
+        "_sampleDialog.ts"
+      ),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        "dialogs",
+        "sample",
+        "sampleDialog.ts"
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile
+      }
+    );
+
+    // Copy skillDialogBase.ts
+    this.fs.copyTpl(
+      this.templatePath(
+        templateName,
+        "src",
+        "dialogs",
+        "shared",
+        "_skillDialogBase.ts"
+      ),
+      this.destinationPath(
+        skillGenerationPath,
+        "src",
+        "dialogs",
+        "shared",
+        "skillDialogBase.ts"
+      ),
+      {
+        skillConversationStateNameClass: skillConversationStateNameClass,
+        skillConversationStateNameFile: skillConversationStateNameFile,
+        skillUserStateNameClass: skillUserStateNameClass,
+        skillUserStateNameFile: skillUserStateNameFile,
+        skillProjectName: skillName
+      }
+    );
+
+    // Copy gitignore
+    this.fs.copy(
+      this.templatePath(templateName, "_.gitignore"),
+      this.destinationPath(skillGenerationPath, ".gitignore")
+    );
+
+    // Copy commonFiles
+    const commonFiles = [
+      "tsconfig.json",
+      "tslint.json",
+      ".env.development",
+      ".env.production",
+      path.join("src", "dialogs", "main", "mainResponses.ts"),
+      path.join("src", "dialogs", "sample", "sampleResponses.ts"),
+      path.join("src", "dialogs", "shared", "sharedResponses.ts")
+    ];
+
+    commonFiles.forEach(fileName =>
+      this.fs.copy(
+        this.templatePath(templateName, fileName),
+        this.destinationPath(skillGenerationPath, fileName)
+      )
+    );
+
+    // Copy commonDirectories
+    const commonDirectories = [
+      "cognitiveModels",
+      "deploymentScripts",
+      path.join("src", "serviceClients"),
+      path.join("src", "dialogs", "main", "resources"),
+      path.join("src", "dialogs", "sample", "resources"),
+      path.join("src", "dialogs", "shared", "resources"),
+      path.join("src", "dialogs", "shared", "dialogOptions")
+    ];
+
+    commonDirectories.forEach(directory =>
+      this.fs.copy(
+        this.templatePath(templateName, directory, "**", "*"),
+        this.destinationPath(skillGenerationPath, directory)
+      )
+    );
+
+    // Copy commonFlowFiles
+    const commonTestFiles = [
+      path.join("flow", "mainDialogTests.js"),
+      path.join("flow", "sampleDialogTests.js"),
+      path.join("flow", "skillTestBase.js"),
+      "mocha.opts"
+    ];
+
+    commonTestFiles.forEach(testFlowFileName =>
+      this.fs.copy(
+        this.templatePath(templateName, "test", testFlowFileName),
+        this.destinationPath(skillGenerationPath, "test", testFlowFileName)
+      )
+    );
+  }
+
+  // Ainstall() {
+  //   if (this.props.finalConfirmation !== true || isAlreadyCreated) {
+  //     return;
+  //   }
+
+  //   process.chdir(skillGenerationPath);
+  //   this.installDependencies({ npm: true, bower: false });
+  // }
+
+  end() {
+    if (this.props.finalConfirmation === true) {
+      if (isAlreadyCreated) {
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " ERROR: It's seems like you already have a skill with the same name in the destination path. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            " Try again changing the name or the destination path or deleting the previous skill. "
+          )
+        );
+        this.log(
+          chalk.red.bold(
+            "-------------------------------------------------------------------------------------------- "
+          )
+        );
+      } else {
+        this.log(
+          chalk.green(
+            "---------------------------------------------------------- "
+          )
+        );
+        this.log(chalk.green(" Your new skill is ready!  "));
+        this.log(
+          chalk.green(
+            " Now you are able to install the dependencies and build it!"
+          )
+        );
+        this.log(
+          chalk.green(
+            "---------------------------------------------------------- "
+          )
+        );
+        this.log(
+          "Open the " +
+            chalk.green.bold("README.md") +
+            " to learn how to run your skill. "
+        );
+      }
+    } else {
+      this.log(chalk.red.bold("-------------------------------- "));
+      this.log(chalk.red.bold(" New skill creation was canceled. "));
+      this.log(chalk.red.bold("-------------------------------- "));
+    }
+
+    this.log("Thank you for using the Microsoft Bot Framework. ");
+    this.log("\n" + tinyBot + "The Bot Framework Team");
+  }
+};

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/test/generator-botbuilder-skill.test.suite.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/test/generator-botbuilder-skill.test.suite.js
@@ -1,1 +1,403 @@
 "use strict";
+const path = require("path");
+const assert = require("yeoman-assert");
+const helpers = require("yeoman-test");
+const rimraf = require("rimraf");
+const _camelCase = require("lodash/camelCase");
+const _upperFirst = require("lodash/upperFirst");
+const semver = require('semver');
+
+describe("The generator-botbuilder-skill tests", function() {
+    var skillName;
+    var skillDesc;
+    var skillNamePascalCase;
+    var skillNameCamelCase;
+    var skillConversationStateNameClass;
+    var skillConversationStateNameFile;
+    var skillUserStateNameClass;
+    var skillUserStateNameFile;
+    var pathConfirmation;
+    var skillGenerationPath;
+    var finalConfirmation;
+    var run = true;
+    var srcFiles;
+    const conversationStateTag = "ConversationState";
+    const userStateTag = "UserState";
+    const cognitiveDirectories = ["LUIS"];
+    const rootFiles = [
+        ".gitignore",
+        "tsconfig.json",
+        "package.json",
+        "tslint.json",
+        ".env.development",
+        ".env.production"
+      ];
+    const commonDirectories = [
+        "cognitiveModels",
+        "deploymentScripts",
+    ];
+    const commonTestDirectories = [
+        "flow"
+    ]
+    const testFiles = [
+        "mocha.opts",
+        "flow/mainDialogTests.js",
+        "flow/sampleDialogTests.js",
+        "flow/skillTestBase.js"
+    ];
+    const commonSrcDirectories = [
+        path.join("serviceClients"),
+        path.join("dialogs"),
+    ]
+
+    const commonDialogsDirectories = [
+        path.join("main"),
+        path.join("main", "resources"),
+        path.join("sample"),
+        path.join("sample", "resources"),
+        path.join("shared"),
+        path.join("shared", "dialogOptions"),
+        path.join("shared", "resources")
+    ]
+
+    const commonDialogsFiles = [
+        path.join("main", "mainDialog.ts"),
+        path.join("main", "mainResponses.ts"),
+        path.join("sample", "sampleDialog.ts"),
+        path.join("sample", "sampleResponses.ts"),
+        path.join("shared", "skillDialogBase.ts"),
+        path.join("shared", "sharedResponses.ts")
+    ]
+
+    describe("should create", function() {
+        skillName = "mySkill";
+        skillDesc = "A description for mySkill";
+        skillNamePascalCase = _upperFirst(_camelCase(skillName));
+        skillNameCamelCase = _camelCase(skillName);
+        skillGenerationPath = path.join(__dirname, "tmp");
+        
+        skillConversationStateNameClass = `I${skillNamePascalCase.concat(
+          conversationStateTag
+        )}`;
+        skillConversationStateNameFile = skillNameCamelCase.concat(
+          conversationStateTag
+        );
+        skillUserStateNameClass = `I${skillNamePascalCase.concat(userStateTag)}`;
+        skillUserStateNameFile = skillNameCamelCase.concat(
+          userStateTag
+        );
+        pathConfirmation = true;
+        finalConfirmation = true;
+        srcFiles = ["index.ts", `${skillUserStateNameFile}.ts`, `${skillConversationStateNameFile}.ts`, `${skillNameCamelCase}.ts`];
+        before(async function(){
+            await helpers
+            .run(path.join(__dirname, "..", "generators", "app"))
+            .inDir(skillGenerationPath)
+            .withArguments([
+              "-n",
+              skillName,
+              "-d",
+              skillDesc,
+              "-p",
+              skillGenerationPath,
+              "--noPrompt"
+            ])
+        });
+
+        after(function() {
+            rimraf.sync(path.join(__dirname, "tmp", "*"));
+        });
+
+        describe("the base", function() {
+            it(skillName.concat(" folder"), function(done) {
+                assert.file(
+                    path.join(skillGenerationPath, skillName)
+                );
+                done();
+            });
+        });
+
+        describe("the folders", function() {
+            commonDirectories.forEach(directoryName => {
+                it(directoryName.concat(" folder"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, directoryName)
+                    );
+                    done();
+                });
+            });
+
+            cognitiveDirectories.forEach(directoryName =>
+                it(directoryName.concat(" folder"), function(done) {
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "cognitiveModels", directoryName)
+                    );
+                    done();
+                })
+            );
+
+            commonTestDirectories.forEach(testDirectoryName => 
+                it(testDirectoryName.concat(" folder"), function(done) {
+                    assert.file(
+                      path.join(skillGenerationPath, skillName, "test", testDirectoryName)  
+                    );
+                    done();
+                })
+            );
+        });
+
+        describe("in the root folder", function() {
+            rootFiles.forEach(fileName =>
+                it(fileName.concat(" file"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, fileName)
+                    );
+                    done();
+                })
+            )
+        });
+
+        describe("in the src folder", function() {
+            srcFiles.forEach(fileName => 
+                it(fileName.concat(" file"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "src", fileName)
+                    );
+                    done();
+                })
+            );
+
+            commonSrcDirectories.forEach(directoryName => 
+                it(directoryName.concat(" folder"), function(done) {
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "src", directoryName)
+                    )
+                    done();
+                })
+            );
+        });
+
+        describe("in the dialogs folder", function() {
+            commonDialogsDirectories.forEach(directoryName => 
+                it(directoryName.concat(" folder"), function(done) {
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "src", "dialogs", directoryName)
+                    )
+                    done();
+                })
+            );
+
+            commonDialogsFiles.forEach(fileName => 
+                it(fileName.concat(" file"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "src", "dialogs", fileName)
+                    );
+                    done();
+                })
+            );
+        });
+
+        describe("in the test folder", function() {
+            testFiles.forEach(fileName =>
+                it(fileName.concat(" file"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "test", fileName)
+                    );
+                    done();
+                })
+            );
+        });
+
+        describe("and have in the package.json", function() {
+            it("a name property with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "package.json"),
+                    `"name": "${skillName}"`
+                );
+                done();
+            });
+
+            it("a description property with given description", function(done) {
+                assert.fileContent(
+                  path.join(skillGenerationPath, skillName, "package.json"),
+                  `"description": "${skillDesc}"`
+                );
+                done();
+            });
+        });
+
+        describe("and have in the mainDialog file", function() {
+            it("an import component containing a ConversationState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `import { ${skillConversationStateNameClass} } from '../../${skillConversationStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an import component containing an UserState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `import { ${skillUserStateNameClass} } from '../../${skillUserStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an accessor containing a ConversationState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `StatePropertyAccessor<${skillConversationStateNameClass}>`
+                );
+                done();
+            });
+
+            it("an accessor containing an UserState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `StatePropertyAccessor<${skillUserStateNameClass}>`
+                );
+                done();
+            });
+
+            it("a creation of a property containing a ConversationState with the given name" , function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `.createProperty('${skillConversationStateNameClass}')`
+                );
+                done();
+            });
+
+            it("a creation of a property containing an UserState with the given name" , function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `.createProperty('${skillUserStateNameClass}')`
+                );
+                done();
+            });
+
+            it("a property with the name of the project", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `private projectName: string = '${skillName}'`
+                );
+                done()
+            });
+        });
+
+        describe("and have in the sampleDialog file", function() {
+            it("an import component containing a ConversationState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "sample", "sampleDialog.ts"),
+                    `import { ${skillConversationStateNameClass} } from '../../${skillConversationStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an import component containing an UserState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "sample", "sampleDialog.ts"),
+                    `import { ${skillUserStateNameClass} } from '../../${skillUserStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an accessor containing a ConversationState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "sample", "sampleDialog.ts"),
+                    `StatePropertyAccessor<${skillConversationStateNameClass}>`
+                );
+                done();
+            });
+
+            it("an accessor containing an UserState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "sample", "sampleDialog.ts"),
+                    `StatePropertyAccessor<${skillUserStateNameClass}>`
+                );
+                done();
+            });
+        });
+
+        describe("and have in the skillDialogBase file", function() {
+            it("an import component containing a ConversationState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "shared", "skillDialogBase.ts"),
+                    `import { ${skillConversationStateNameClass} } from '../../${skillConversationStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an import component containing an UserState with the given name", function(done) {
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "shared", "skillDialogBase.ts"),
+                    `import { ${skillUserStateNameClass} } from '../../${skillUserStateNameFile}';`
+                );
+                done();
+            });
+
+            it("an accessor containing a ConversationState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "shared", "skillDialogBase.ts"),
+                    `StatePropertyAccessor<${skillConversationStateNameClass}>`
+                );
+                done();
+            });
+
+            it("an accessor containing an UserState with the given name", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "shared", "skillDialogBase.ts"),
+                    `StatePropertyAccessor<${skillUserStateNameClass}>`
+                );
+                done();
+            });
+
+            it("a property with the name of the project", function(done){
+                assert.fileContent(
+                    path.join(skillGenerationPath, skillName, "src", "dialogs", "main", "mainDialog.ts"),
+                    `private projectName: string = '${skillName}'`
+                );
+                done()
+            });
+        });
+    });
+
+    describe("should not create", function() {
+        before(async function() {
+            if(semver.gte(process.versions.node, '10.12.0')){
+                run = false;
+            }
+            else {
+                finalConfirmation = false;
+                await helpers
+                    .run(path.join(
+                        __dirname,
+                        "..",
+                        "generators",
+                        "app"
+                    ))
+                    .inDir(skillGenerationPath)
+                    .withPrompts({
+                        skillName: skillName,
+                        skillDesc: skillDesc,
+                        pathConfirmation: pathConfirmation,
+                        skillGenerationPath: skillGenerationPath,
+                        finalConfirmation: finalConfirmation
+                    });
+            }
+        });
+
+        after(function() {
+            rimraf.sync(path.join(__dirname, "tmp", "*"));
+        });
+
+        describe("the base", function() {
+            it(skillName + " folder when the final confirmation is deny", function(done) {
+              if(!run){
+                this.skip()          
+              }
+              assert.noFile(skillGenerationPath, skillName);
+              done();
+            });
+        });
+    })
+});


### PR DESCRIPTION
**Depends on** #968

## Description

- Implementation of `generator-botbuilder-skill`
- Add test for `generator-botbuilder-skill`

Related to #941 

## Testing Steps

1. Install Yeoman `npm install -g yo`
2. Go to `.\templates\Skill-Template\src\typescript\generator-botbuilder-skill` and run `npm i` and `npm link` to symlink the package folder
3. Open a terminal wherever you want to create a skill
4. Run `yo botbuilder-skill`
5. Follow the generator's prompts
6. Check that the skill was created successfully

## Checklist
- [x] I have added or updated the appropriate unit tests

