### PR TITLE
[Skill Template][TypeScript] Update properties of Responses classes

### DIFF
--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 "use strict";
 const Generator = require("yeoman-generator");
 const chalk = require("chalk");

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/_skillTemplate.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/_skillTemplate.ts
@@ -10,7 +10,7 @@ import { MainResponses } from './dialogs/main/mainResponses';
 import { SampleResponses } from './dialogs/sample/sampleResponses';
 import { SharedResponses } from './dialogs/shared/sharedResponses';
 import { IServiceManager } from './serviceClients/IServiceManager';
-
+import { ServiceManager } from './serviceClients/serviceManager';
 /**
  * Here is the documentation of the <%=skillTemplateName%> class
  */

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/main/_mainDialog.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/main/_mainDialog.ts
@@ -77,7 +77,7 @@ export class MainDialog extends RouterDialog {
     protected async onStart(dc: DialogContext): Promise<void> {
         if (!this.skillMode) {
             // send a greeting if we're in local mode
-            await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.responseIds.welcomeMessage));
+            await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.welcomeMessage));
         }
     }
 
@@ -106,7 +106,7 @@ export class MainDialog extends RouterDialog {
                     }
                     case 'None': {
                         // No intent was identified, send confused message
-                        await dc.context.sendActivity(this.responseManager.getResponse(SharedResponses.responseIds.didntUnderstandMessage));
+                        await dc.context.sendActivity(this.responseManager.getResponse(SharedResponses.didntUnderstandMessage));
                         if (this.skillMode) {
                             turnResult = {
                                 status: DialogTurnStatus.complete
@@ -117,7 +117,7 @@ export class MainDialog extends RouterDialog {
                     }
                     default: {
                         // intent was identified but not yet implemented
-                        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.responseIds.featureNotAvailable));
+                        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.featureNotAvailable));
                         if (this.skillMode) {
                             turnResult = {
                                 status: DialogTurnStatus.complete
@@ -218,7 +218,7 @@ export class MainDialog extends RouterDialog {
     }
 
     private async onCancel(dc: DialogContext): Promise<InterruptionAction> {
-        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.responseIds.cancelMessage));
+        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.cancelMessage));
         await this.complete(dc);
         await dc.cancelAllDialogs();
 
@@ -226,7 +226,7 @@ export class MainDialog extends RouterDialog {
     }
 
     private async onHelp(dc: DialogContext): Promise<InterruptionAction> {
-        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.responseIds.helpMessage));
+        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.helpMessage));
 
         return InterruptionAction.MessageSentToUser;
     }
@@ -251,7 +251,7 @@ export class MainDialog extends RouterDialog {
             }
         });
 
-        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.responseIds.logOut));
+        await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.logOut));
 
         return InterruptionAction.StartedDialog;
     }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/main/mainResponses.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/main/mainResponses.ts
@@ -7,24 +7,14 @@ import { join } from 'path';
  * Contains bot responses.
  */
 export class MainResponses implements IResponseIdCollection {
-    public name: string = MainResponses.name;
-    public pathToResource: string = join(__dirname, 'resources');
     // Generated accessors
-    public static responseIds: {
-        welcomeMessage: string;
-        helpMessage: string;
-        greetingMessage: string;
-        goodbyeMessage: string;
-        logOut: string;
-        featureNotAvailable: string;
-        cancelMessage: string;
-    } = {
-        welcomeMessage: 'WelcomeMessage',
-        helpMessage: 'HelpMessage',
-        greetingMessage: 'GreetingMessage',
-        goodbyeMessage: 'GoodbyeMessage',
-        logOut: 'LogOut',
-        featureNotAvailable: 'FeatureNotAvailable',
-        cancelMessage: 'CancelMessage'
-    };
+    public readonly name: string = MainResponses.name;
+    public pathToResource: string = join(__dirname, 'resources');
+    public static readonly welcomeMessage: string = 'WelcomeMessage';
+    public static readonly helpMessage: string = 'HelpMessage';
+    public static readonly greetingMessage: string = 'GreetingMessage';
+    public static readonly goodbyeMessage: string = 'GoodbyeMessage';
+    public static readonly logOut: string = 'LogOut';
+    public static readonly featureNotAvailable: string = 'FeatureNotAvailable';
+    public static readonly cancelMessage: string = 'CancelMessage';
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/sample/_sampleDialog.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/sample/_sampleDialog.ts
@@ -66,7 +66,7 @@ export class SampleDialog extends SkillDialogBase {
         // let entities = state.luisResult.entities;
 
         // tslint:disable-next-line:no-any
-        const prompt: any = this.responseManager.getResponse(SampleResponses.responseIds.namePrompt);
+        const prompt: any = this.responseManager.getResponse(SampleResponses.namePrompt);
 
         return stepContext.prompt(dialogIds.namePrompt, { prompt: prompt });
     }
@@ -77,7 +77,7 @@ export class SampleDialog extends SkillDialogBase {
         tokens.set(this.tokenKey, <string>stepContext.result);
 
         // tslint:disable-next-line:no-any
-        const response: any = this.responseManager.getResponse(SampleResponses.responseIds.namePrompt, tokens);
+        const response: any = this.responseManager.getResponse(SampleResponses.namePrompt, tokens);
         await stepContext.context.sendActivity(response);
 
         return stepContext.next();

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/sample/sampleResponses.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/sample/sampleResponses.ts
@@ -1,4 +1,3 @@
-// https://docs.microsoft.com/en-us/visualstudio/modeling/t4-include-directive?view=vs-2017
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -8,14 +7,9 @@ import { join } from 'path';
  * Contains bot responses.
  */
 export class SampleResponses implements IResponseIdCollection {
-    public name: string = SampleResponses.name;
-    public pathToResource: string = join(__dirname, 'resources');
     // Generated accessors
-    public static responseIds: {
-        namePrompt: string;
-        haveNameMessage: string;
-    } = {
-        namePrompt: 'NamePrompt',
-        haveNameMessage: 'HaveNameMessage'
-    };
+    public readonly name: string = SampleResponses.name;
+    public pathToResource: string = join(__dirname, 'resources');
+    public static readonly namePrompt: string = 'NamePrompt';
+    public static readonly haveNameMessage: string = 'HaveNameMessage';
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/_skillDialogBase.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/_skillDialogBase.ts
@@ -100,7 +100,7 @@ export class SkillDialogBase extends ComponentDialog {
                 return await sc.prompt(DialogIds.skillModeAuth, {});
             } else {
                 return await sc.prompt(MultiProviderAuthDialog.name, {
-                    retryPrompt: this.responseManager.getResponse(SharedResponses.responseIds.noAuth)
+                    retryPrompt: this.responseManager.getResponse(SharedResponses.noAuth)
                 });
             }
         } catch (err) {
@@ -201,7 +201,7 @@ export class SkillDialogBase extends ComponentDialog {
         });
 
         // send error message to bot user
-        await sc.context.sendActivity(this.responseManager.getResponse(SharedResponses.responseIds.errorMessage));
+        await sc.context.sendActivity(this.responseManager.getResponse(SharedResponses.errorMessage));
 
         // clear state
         // tslint:disable-next-line:no-any

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/sharedResponses.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/sharedResponses.ts
@@ -7,22 +7,13 @@ import { join } from 'path';
  * Contains bot responses.
  */
 export class SharedResponses implements IResponseIdCollection {
-    public name: string = SharedResponses.name;
-    public pathToResource: string = join(__dirname, 'resources');
     // Generated accessors
-    public static responseIds: {
-        didntUnderstandMessage : string;
-        cancellingMessage : string;
-        noAuth : string;
-        authFailed : string;
-        actionEnded : string;
-        errorMessage : string;
-    } = {
-        didntUnderstandMessage : 'DidntUnderstandMessage',
-        cancellingMessage : 'CancellingMessage',
-        noAuth : 'NoAuth',
-        authFailed : 'AuthFailed',
-        actionEnded : 'ActionEnded',
-        errorMessage : 'ErrorMessage'
-    };
+    public readonly name: string = SharedResponses.name;
+    public pathToResource: string = join(__dirname, 'resources');
+    public static readonly didntUnderstandMessage: string = 'DidntUnderstandMessage';
+    public static readonly cancellingMessage: string = 'CancellingMessage';
+    public static readonly noAuth: string = 'NoAuth';
+    public static readonly authFailed: string = 'AuthFailed';
+    public static readonly actionEnded: string = 'ActionEnded';
+    public static readonly errorMessage: string = 'ErrorMessage';
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/mainDialogTests.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/mainDialogTests.js
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/sampleDialogTests.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/sampleDialogTests.js
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/skillTestBase.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/test/flow/skillTestBase.js
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.


### PR DESCRIPTION
## Description

- Change the structure of the properties for **Responses** classes and each calls
- Add an import of ServiceManager into `_skillTemplate.ts`
- Add **Microsoft Copyrights**

Related to #941 

## Testing Steps
1. Go to `AI/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs`
2. Check the structure of the properties for Responses files in each dialog folder

