### PR TITLE
[Skill Template][TypeScript] Add Util folder into bot-solution

### DIFF
--- a/solutions/Virtual-Assistant/src/typescript/bot-solution/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-solution/src/index.ts
@@ -12,3 +12,4 @@ export * from './resources';
 export * from './skills';
 export * from './middleware';
 export * from './responses';
+export * from './util';

--- a/solutions/Virtual-Assistant/src/typescript/bot-solution/src/util/commonUtil.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-solution/src/util/commonUtil.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class CommonUtil {
+    public readonly name: string = CommonUtil.name;
+    public static readonly scoreThreshold: number = 0.5;
+    public static readonly maxReadSize : number = 3;
+    public static readonly maxDisplaySize : number = 6;
+    public static readonly dialogTurnResultCancelAllDialogs : string = 'cancelAllDialogs';
+    public static readonly deliveryModeProactive : string = 'proactive';
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-solution/src/util/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-solution/src/util/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { CommonUtil } from './commonUtil';

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/_skillDialogBase.ts
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/_skillDialogBase.ts
@@ -3,6 +3,7 @@
 
 import {
     ActivityExtensions,
+    CommonUtil,
     IProviderTokenResponse,
     ITelemetryLuisRecognizer,
     LocaleConfiguration,
@@ -106,10 +107,9 @@ export class SkillDialogBase extends ComponentDialog {
         } catch (err) {
             await this.handleDialogExceptions(sc, err);
 
-            // PENDING Need to implement Util folder in bot-solution
             return {
                 status: DialogTurnStatus.cancelled,
-                result: 'cancelAllDialogs'
+                result: CommonUtil.dialogTurnResultCancelAllDialogs
             };
         }
     }
@@ -139,10 +139,9 @@ export class SkillDialogBase extends ComponentDialog {
         } catch (err) {
             await this.handleDialogExceptions(sc, err);
 
-            // PENDING Need to implement Util folder in bot-solution
             return {
                 status: DialogTurnStatus.cancelled,
-                result: 'cancelAllDialogs'
+                result: CommonUtil.dialogTurnResultCancelAllDialogs
             };
         }
     }


### PR DESCRIPTION
## Description

- Add **util folder** in _bot-solution_
- Add `commonUtil.ts` file
- Add `index.ts` file to export the class mentioned
- Use of `CommonUtil` class in `_skillDialogBase.ts`

Related to #941 

## Testing Steps

1. Go to `AI/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/src/dialogs/shared/_skillDialogBase.ts`
2. Check the implementation of `CommonUtil` class in `_skillDialogBase.ts` with the calls instead of the hardcoded strings
