### PR TITLE
MVC refactor for skill template

### DIFF
--- a/templates/Skill-Template/src/csharp/SkillTemplate/Skills/Skill Template/Controllers/BotController.cs
+++ b/templates/Skill-Template/src/csharp/SkillTemplate/Skills/Skill Template/Controllers/BotController.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace SkillTemplate.Controllers
+{
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
+
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            _adapter = adapter;
+            _bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            await _adapter.ProcessAsync(Request, Response, _bot);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

MVC refactor for skill template

Note: there's changes needed for a few dependencies from the latest Microsoft.Bot.Builder.Solutions package which are not in this PR. Will do that after figuring out a plan as right now the package is not fully published yet.

### Architecture

### Bug Fixes

#985

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ x ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
