### PR TITLE
[Skill Template][TypeScript] Adapt PowerShell Deployment Scripts

### DIFF
--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/de/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/de/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/deploy_bot.ps1
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/deploy_bot.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 6
+
 # all msbot clone parameters and locales
 Param(
 	[string] [Parameter(Mandatory=$true)]$name,
@@ -9,23 +11,33 @@ Param(
 	[string] $luisPublishRegion,
 	[string] $subscriptionId,
 	[string] $insightsRegion,
-	[string] $groupName,
+	[string] $groupName = $name,
 	[string] $sdkLanguage,
 	[string] $sdkVersion,
 	[string] $prefix,
 	[string] $appId,        
-	[string] $appSecret
+    [string] $appSecret,
+    [switch] $showLogs
 )
 
 if (!$languagesOnly)
 {
 	# Change to project directory for .bot file
-	Write-Host "Changing to project directory ..."
-	cd "$($PSScriptRoot)\..\"
+    Write-Host "Changing to project directory ..."
+    Set-Location "$(Join-Path $PSScriptRoot ..)"
 
-	# Deploy the common resources (Azure Bot Service, App Insights, Azure Storage, Cosmos DB, etc)
+    # Deploy the common resources (Azure Bot Service, App Insights, Azure Storage, Cosmos DB, etc)
 	Write-Host "Deploying common resources..."
-	msbot clone services -n $name -l $location --luisAuthoringKey $luisAuthoringKey --folder "$($PSScriptRoot)" --appId $appId --appSecret $appSecret --force --quiet
+    $msbotScript = "msbot clone services -n " + $name + " -l " + $location + " --luisAuthoringKey " + $luisAuthoringKey + " --groupName " + $groupName + " --folder $($PSScriptRoot) --appId " + $appId + " --appSecret " + $appSecret + " --force  " 
+    if($showLogs)
+    {
+        $msbotScript += "--verbose"
+    }
+    else
+    {
+        $msbotScript += "--quiet"
+    }
+	Invoke-Expression $msbotScript
 }
 
 $localeArr = $locales.Split(',')
@@ -33,18 +45,18 @@ $localeArr = $locales.Split(',')
 foreach ($locale in $localeArr)
 {	
 	# Update deployment scripts for the locale
-	Invoke-Expression "$($PSScriptRoot)\generate_deployment_scripts.ps1 -locale $($locale)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 
 	# Get language code from locale (first two characters, i.e. "en")
 	$langCode = ($locale -split "-")[0]
 
 	# Create LocaleConfigurations folder and change directory
-	mkdir -Force "$($PSScriptRoot)\..\LocaleConfigurations" > $null
-	Set-Location "$($PSScriptRoot)\..\LocaleConfigurations" > $null
+	New-Item -ItemType directory -Force -Path "$(Join-Path $PSScriptRoot .. LocaleConfigurations)" > $null
+	cd "$(Join-Path $PSScriptRoot .. LocaleConfigurations)" > $null
 
 	# Deploy Dispatch, LUIS (calendar, email, todo, and general), and QnA Maker for the locale
     Write-Host "Deploying $($locale) resources..."
-    msbot clone services -n "$($name)$($langCode)" -l $location --luisAuthoringKey $luisAuthoringKey --groupName $name --force --quiet --folder "$($PSScriptRoot)\$($langCode)" | Out-Null
+    msbot clone services -n "$($name)$($langCode)" -l $location --luisAuthoringKey $luisAuthoringKey --groupName $groupName --force --quiet --folder "$(Join-Path $PSScriptRoot $langCode)" | Out-Null
 }
 
 Write-Host "Done."

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/en/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/en/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/es/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/es/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/fr/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/fr/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/generate_deployment_scripts.ps1
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/generate_deployment_scripts.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 6
+
 param (
     [string] [Parameter(Mandatory=$true)]$locale
 )
@@ -13,14 +15,18 @@ function CheckForDuplicates($lu) {
 
 $locale = $locale.ToLower()
 $langCode = ($locale -split "-")[0]
-$outputPath = "$($PSScriptRoot)\..\DeploymentScripts\$($langCode)"
-$recipePath = "$($PSScriptRoot)\..\DeploymentScripts\$($langCode)\bot.recipe"
+$basePath = Join-Path $PSScriptRoot ".."
+$outputPath = Join-Path $basePath "DeploymentScripts" $langCode
+$recipePath = Join-Path $basePath "DeploymentScripts" $langCode "bot.recipe"
 $recipe = Get-Content -Raw -Path $recipePath | ConvertFrom-Json
+
+Write-Host $basePath
+
 
 foreach ($service in $recipe.resources)
 {
 	Write-Host "Generating $($locale) $($service.name) script ..."
-	$path = "$($PSScriptRoot)\$($service.luPath)"
+	$path = Join-Path $basePath $service.luPath
 
 	if ($service.type -eq "luis")
 	{

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/it/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/it/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/update_published_models.ps1
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/update_published_models.ps1
@@ -1,14 +1,18 @@
+#Requires -Version 6
+
 param (
 	[string] $locales = "de-de,en-us,es-es,fr-fr,it-it,zh-cn",
 	[string] $serviceIds
 )
 
-$basePath = "$($PSScriptRoot)\..\LocaleConfigurations\"
-$botFiles = get-childitem $basePath -recurse | Where-Object {$_.extension -eq ".bot"} 
-$localeArr = $locales.Split(",")
+$basePath = Join-Path $PSScriptRoot ".." "LocaleConfigurations"
+$botFiles = get-childitem $basePath -recurse | where {$_.extension -eq ".bot"} 
+$localeArr = $locales.split(',')
+
+Write-Host $localeArr
 
 if ($PSBoundParameters.ContainsKey('serviceIds')) {
-	$serviceIdArr = $serviceIds.Split(",")
+	$serviceIdArr = $serviceIds.split(',')
 }
 else {
 	$serviceIdArr = @()
@@ -17,53 +21,150 @@ else {
 function UpdateLUIS ($botFilePath, $langCode, $id) {
 	$versions = msbot get $id --bot $botFilePath | luis list versions --stdin | ConvertFrom-Json
 
-	if ($versions | Where-Object {$_.version -eq "backup"})
+	if ($versions | where {$_.version -eq "backup"})
 	{
 		msbot get $id --bot $botFilePath | luis delete version --stdin --versionId backup --force --wait
 	}
-		
+	
 	msbot get $id --bot $botFilePath | luis rename version --newVersionId backup --stdin --wait
-	msbot get $id --bot $botFilePath | luis import version --stdin --in "$($PSScriptRoot)\$($langCode)\$($id).luis" --wait
+	msbot get $id --bot $botFilePath | luis import version --stdin --in "$(Join-Path $PSScriptRoot $langCode $id).luis" --wait
 	msbot get $id --bot $botFilePath | luis train version --wait --stdin 
 	msbot get $id --bot $botFilePath | luis publish version --stdin
 }
 
-function UpdateQnA ($botFilePath, $langCode, $id) {
-	msbot get $id --bot $botFilePath | qnamaker replace kb --in "$($PSScriptRoot)\$($langCode)\$($id).qna" --stdin
+function UpdateKB ($botFilePath, $langCode, $id) {
+	Write-Host "Updating $($langCode) knowledge base $($id)..."
+
+	msbot get $id --bot $botFilePath | qnamaker replace kb --in "$(Join-Path $PSScriptRoot $langCode $id).qna" --stdin
+	msbot get $id --bot $botFilePath | qnamaker publish kb --stdin
+}
+
+function ImportLUIS ($botFileName, $botFilePath, $langCode, $id, $sampleService) {
+	$luisService = luis import application --appName "$($botFileName)_$($id)" --authoringKey $sampleService.authoringKey --subscriptionKey $sampleService.authoringKey --region $sampleService.region --in "$(Join-Path $recipeBasePath $id).luis" --wait --msbot | ConvertFrom-Json
+	Add-Member -InputObject $luisService -MemberType NoteProperty -Name id -Value $id -Force
+
+	$botServices = Get-Content -Raw -Path $botFilePath | ConvertFrom-Json
+	$botServices.services += $luisService
+	$botFileJson = $botServices | ConvertTo-Json -Depth 10
+	Set-Content -Path $botFilePath -Value $botFileJson
+
+	msbot get $id --bot $botFilePath | luis train version --wait --stdin 
+	msbot get $id --bot $botFilePath | luis publish version --stdin
+}
+
+function ImportKB ($botFilePath, $langCode, $id, $sampleService){
+	Write-Host "Importing $($langCode) knowledge base $($id)..."
+	$qnaService = qnamaker create kb --in "$(Join-Path $recipeBasePath $id).qna" --name $id --subscriptionKey $sampleService.subscriptionKey --msbot | ConvertFrom-Json
+	Add-Member -InputObject $qnaService -MemberType NoteProperty -Name id -Value $id -Force
+
+	$botServices = Get-Content -Raw -Path $botFilePath | ConvertFrom-Json
+	$botServices.services += $qnaService
+	$botFileJson = $botServices | ConvertTo-Json -Depth 10
+	Set-Content -Path $botFilePath -Value $botFileJson
+
 	msbot get $id --bot $botFilePath | qnamaker publish kb --stdin
 }
 
 foreach ($locale in $localeArr) {
-	Invoke-Expression "$($PSScriptRoot)\generate_deployment_scripts.ps1 -locale $($locale)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot generate_deployment_scripts.ps1) -locale $($locale)"
 }
 
 foreach ($botFile in $botFiles) {
-	$botFileName = $botFile | ForEach-Object {$_.BaseName}
-	$botFilePath = "$($basePath)$($botFile)"
+	$botFileName = $botFile | % {$_.BaseName}
+	$botFilePath = $botFile.FullName
 	$langCode = $botFileName.Substring($botFileName.Length - 2, 2)
+	$recipeBasePath = Join-Path $PSScriptRoot $langCode
+	$recipePath = Join-Path $recipeBasePath "bot.recipe"
 
-	if ($localeArr | Where-Object {$_ -like "*$($langCode)*"}) {
+	# if locale of bot file is in the list
+	if ($localeArr | where {$_ -like "*$($langCode)*"}) {
+		
+		# get the services from the bot file
 		$botServices = Get-Content -Raw -Path $botFilePath | ConvertFrom-Json
+		$recipeServices = Get-Content -Raw -Path $recipePath | ConvertFrom-Json
 
+		# if there are any service ids supplied as parameters
 		if ($serviceIdArr.Count -gt 0) {
-			foreach ($serviceId in $serviceIdArr) {
-				$service = $botServices.services | Where-Object { $_.id -eq $serviceId }
 
-				if (($service.type -eq "luis") -or ($service.type -eq "dispatch")) {
-					UpdateLUIS $botFilePath $langCode $service.id
+			# foreach supplied service
+			foreach ($serviceId in $serviceIdArr) {
+
+				# get the service from .bot and .recipe
+				$service = $botServices.services | where { $_.id -eq $serviceId }
+				$recipeService = $recipeServices.resources | where { $_.id -eq $serviceId}
+
+				# if service exists in .bot file
+				if ($service) {
+					# if LUIS or dispatch call UpdateLUIS, else call UpdateKB
+					if (($service.type -eq "luis") -or ($service.type -eq "dispatch")) {
+						UpdateLUIS $botFilePath $langCode $service.id
+
+						if ($service.id -eq "dispatch") {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode dispatch.luis)" -ts dispatch -o "$(Join-Path $basePath .. src dialogs shared resources)"
+						}
+						else {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode $service.id).luis" -ts "$($recipeService.Name)LU" -o "$(Join-Path $basePath .. $recipeService.luPath .. .. .. .. src dialogs shared resources)"
+						}
+					}
+					elseif ($service.type -eq "qna") {
+						UpdateKB $botFilePath $langCode $service.id
+					}
 				}
-				elseif ($service.type -eq "faq") {
-					UpdateQnA $botFilePath $langCode $service.id
+				elseif ($recipeService) {
+					if ($recipeService.type -eq "luis") {
+						$sampleService = $botServices.services | where { $_.type -eq "luis" } | Select-Object -First 1
+						ImportLUIS $botFileName $botFilePath $langCode $service.id $sampleService
+					}
+					elseif ($recipeService.type -eq "dispatch") {
+						$sampleService = $botServices.services | where { $_.type -eq "luis" } | Select-Object -First 1
+						ImportLUIS $botFileName $botFilePath $langCode $service.id $sampleService
+					}
+					elseif($recipeService.type -eq "qna"){
+						$sampleService = $botServices.services | where { $_.type -eq "qna" } | Select-Object -First 1
+						ImportKB $botFilePath $langCode $service.id $sampleService
+					}
 				}
 			}
 		}
+
+		# if no service ids were supplied, update everything
 		else {
-			foreach ($service in $botServices.services) {
-				if (($service.type -eq "luis") -or ($service.type -eq "dispatch")) {
-					UpdateLUIS $botFilePath $langCode $service.id
+			foreach ($recipeService in $recipeServices.resources) {
+
+				# if service exists in bot file
+				$service = $botServices.services | where { $_.id -eq $recipeService.id }
+
+				if ($service) {
+					if (($service.type -eq "luis") -or ($service.type -eq "dispatch")) {
+						UpdateLUIS $botFilePath $langCode $service.id
+
+						if ($service.id -eq "dispatch") {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode dispatch.luis)" -ts dispatch -o "$(Join-Path $basePath .. src dialogs shared resources)"
+						}
+						else {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode $service.id).luis" -ts "$($recipeService.Name)LU" -o "$(Join-Path $basePath .. $recipeService.luPath .. .. .. .. src dialogs shared resources)"
+						}
+					}
+					elseif ($service.type -eq "qna") {
+						UpdateKB $botFilePath $langCode $service.id
+					}
 				}
-				elseif ($service.type -eq "faq") {
-					UpdateQnA $botFilePath $langCode $service.id
+				else {
+					if ($recipeService.type -eq "luis") {
+						$sampleService = $botServices.services | where { $_.type -eq "luis" } | Select-Object -First 1
+						ImportLUIS $botFileName $botFilePath $langCode $recipeService.id $sampleService
+
+						if ($service.id -eq "dispatch") {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode dispatch.luis)" -ts dispatch -o "$(Join-Path $basePath .. src dialogs shared resources)"
+						}
+						else {
+							luisgen "$(Join-Path $basePath .. deploymentScripts $langCode $service.id).luis" -ts "$($recipeService.Name)LU" -o "$(Join-Path $basePath .. $recipeService.luPath .. .. .. .. src dialogs shared resources)"
+						}
+					}
+					elseif ($recipeService.type -eq "qna") {
+						$sampleService = $botServices.services | where { $_.type -eq "qna" } | Select-Object -First 1
+						ImportKB $botFilePath $langCode $recipeService.id $sampleService
+					}
 				}
 			}
 		}

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/zh/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/zh/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\CognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
     }
   ]
 }


### PR DESCRIPTION
## Description
- Update PowerShell deployment scripts (adapting to TypeScript)
- Update `bot.recipe` **cognitiveModel** reference

Related to #941

## Testing Steps

1. Go to `AI/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts`
2. Check that the PowerShell files are adapted to TypeScript running the **Step 7** of this [document](https://github.com/southworkscom/AI/blob/master/docs/skills/create.md#create-a-new-skill-using-the-skill-template)

