### PR TITLE
[Skill Template][TypeScript] Fix Placeholder replacements

### DIFF
--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/index.js
@@ -212,6 +212,30 @@ module.exports = class extends Generator {
       }
     );
 
+    // Copy bot.recipes files
+    const recipeFiles = [
+      path.join("de", "bot.recipe"),
+      path.join("en", "bot.recipe"),
+      path.join("es", "bot.recipe"),
+      path.join("fr", "bot.recipe"),
+      path.join("it", "bot.recipe"),
+      path.join("zh", "bot.recipe")
+    ];
+
+    recipeFiles.forEach(fileName =>
+      this.fs.copyTpl(
+        this.templatePath(templateName, "deploymentScripts", fileName),
+        this.destinationPath(
+          skillGenerationPath,
+          "deploymentScripts",
+          fileName
+        ),
+        {
+          name: skillName
+        }
+      )
+    );
+
     // Copy index.ts
     this.fs.copyTpl(
       this.templatePath(templateName, "src", "_index.ts"),
@@ -367,6 +391,10 @@ module.exports = class extends Generator {
       "tslint.json",
       ".env.development",
       ".env.production",
+      path.join("deploymentScripts", "bot.recipe"),
+      path.join("deploymentScripts", "deploy_bot.ps1"),
+      path.join("deploymentScripts", "generate_deployment_scripts.ps1"),
+      path.join("deploymentScripts", "update_published_models.ps1"),
       path.join("src", "dialogs", "main", "mainResponses.ts"),
       path.join("src", "dialogs", "sample", "sampleResponses.ts"),
       path.join("src", "dialogs", "shared", "sharedResponses.ts")
@@ -382,7 +410,6 @@ module.exports = class extends Generator {
     // Copy commonDirectories
     const commonDirectories = [
       "cognitiveModels",
-      "deploymentScripts",
       path.join("src", "serviceClients"),
       path.join("src", "dialogs", "main", "resources"),
       path.join("src", "dialogs", "sample", "resources"),
@@ -412,15 +439,6 @@ module.exports = class extends Generator {
       )
     );
   }
-
-  // Ainstall() {
-  //   if (this.props.finalConfirmation !== true || isAlreadyCreated) {
-  //     return;
-  //   }
-
-  //   process.chdir(skillGenerationPath);
-  //   this.installDependencies({ npm: true, bower: false });
-  // }
 
   end() {
     if (this.props.finalConfirmation === true) {

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/de/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/de/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\de\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\de\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/es/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/es/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\es\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\es\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/fr/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/fr/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\fr\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\fr\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/it/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/it/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\it\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\it\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/zh/bot.recipe
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/generators/app/templates/customSkill/deploymentScripts/zh/bot.recipe
@@ -5,13 +5,13 @@
       "type": "luis",
       "id": "general",
       "name": "General",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\general.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\zh\\general.lu"
     },
     {
       "type": "luis",
       "id": "<%= name %>",
       "name": "<%= name %>",
-      "luPath": "..\\cognitiveModels\\LUIS\\en\\<%= name %>.lu"
+      "luPath": "..\\cognitiveModels\\LUIS\\zh\\<%= name %>.lu"
     }
   ]
 }

--- a/templates/Skill-Template/src/typescript/generator-botbuilder-skill/test/generator-botbuilder-skill.test.suite.js
+++ b/templates/Skill-Template/src/typescript/generator-botbuilder-skill/test/generator-botbuilder-skill.test.suite.js
@@ -32,24 +32,31 @@ describe("The generator-botbuilder-skill tests", function() {
         ".env.development",
         ".env.production"
       ];
-    const commonDirectories = [
-        "cognitiveModels",
-        "deploymentScripts",
-    ];
-    const commonTestDirectories = [
-        "flow"
+    const deploymentFiles = [
+        path.join("de", "bot.recipe"),
+        path.join("en", "bot.recipe"),
+        path.join("es", "bot.recipe"),
+        path.join("fr", "bot.recipe"),
+        path.join("it", "bot.recipe"),
+        path.join("zh", "bot.recipe")
     ]
     const testFiles = [
         "mocha.opts",
-        "flow/mainDialogTests.js",
-        "flow/sampleDialogTests.js",
-        "flow/skillTestBase.js"
+        path.join("flow","mainDialogTests.js"),
+        path.join("flow","sampleDialogTests.js"),
+        path.join("flow","skillTestBase.js")
     ];
+    const commonDirectories = [
+        "cognitiveModels",
+    ];
+    
+    const commonTestDirectories = [
+        "flow"
+    ]
     const commonSrcDirectories = [
         path.join("serviceClients"),
         path.join("dialogs"),
     ]
-
     const commonDialogsDirectories = [
         path.join("main"),
         path.join("main", "resources"),
@@ -59,7 +66,6 @@ describe("The generator-botbuilder-skill tests", function() {
         path.join("shared", "dialogOptions"),
         path.join("shared", "resources")
     ]
-
     const commonDialogsFiles = [
         path.join("main", "mainDialog.ts"),
         path.join("main", "mainResponses.ts"),
@@ -154,7 +160,18 @@ describe("The generator-botbuilder-skill tests", function() {
                     );
                     done();
                 })
-            )
+            );
+        });
+
+        describe("in the deploymentScripts folder", function() {
+            deploymentFiles.forEach(fileName =>
+                it(fileName.concat(" file"), function(done){
+                    assert.file(
+                        path.join(skillGenerationPath, skillName, "deploymentScripts", fileName)
+                    );
+                    done();
+                })                
+            );
         });
 
         describe("in the src folder", function() {
@@ -225,6 +242,35 @@ describe("The generator-botbuilder-skill tests", function() {
                 done();
             });
         });
+
+        deploymentFiles.forEach(fileName =>
+            describe(`and have in the ${fileName} file`, function(done) {
+                it("an id key containing a value with the given name", function(done) {
+                    assert.fileContent(
+                        path.join(skillGenerationPath, skillName, "deploymentScripts", fileName),
+                        `"id": "${skillName}"`
+                    );
+                    done();
+                });
+
+                it("a name key containing a value with the given name", function(done) {
+                    assert.fileContent(
+                        path.join(skillGenerationPath, skillName, "deploymentScripts", fileName),
+                        `"name": "${skillName}"`
+                    );
+                    done();
+                });
+
+                it("a luPath key containing a value of the .lu path with the given name", function(done) {
+                    assert.fileContent(
+                        path.join(skillGenerationPath, skillName, "deploymentScripts", fileName),
+                        `"luPath": "..\\\\cognitiveModels\\\\LUIS\\\\${fileName.substring(0,2)}\\\\${skillName}.lu"`
+                    );
+                    done();
+                });
+            })
+        )
+        
 
         describe("and have in the mainDialog file", function() {
             it("an import component containing a ConversationState with the given name", function(done) {
@@ -361,7 +407,7 @@ describe("The generator-botbuilder-skill tests", function() {
         });
     });
 
-    describe("should not create", function() {
+   describe("should not create", function() {
         before(async function() {
             if(semver.gte(process.versions.node, '10.12.0')){
                 run = false;


### PR DESCRIPTION
## Description
- Update placeholder replacements for `bot.recipe` files
- Add related tests for `generator-botbuilder-skill` 
- Fix **deploymentScripts** paths

Related to #941 

## Testing Steps

1. Install Yeoman `npm install -g yo`
2. Go to `.\templates\Skill-Template\src\typescript\generator-botbuilder-skill`, run `npm i` and `npm link` to symlink the package folder
3. Open a terminal wherever you want to create a skill
4. Run `yo botbuilder-skill`
5. Follow the generator's prompts
6. Check that the skill was created successfully **without placeholders**

## Checklist
- [X] I have added or updated the appropriate unit tests
