### PR TITLE
Update INTRO_PATH to be Mac/unix friendly

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Main/Resources/MainStrings.resx
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Main/Resources/MainStrings.resx
@@ -160,6 +160,6 @@
     <value>HELP</value>
   </data>
   <data name="INTRO_PATH" xml:space="preserve">
-    <value>.\Dialogs\Main\Resources\Intro.json</value>
+    <value>./Dialogs/Main/Resources/Intro.json</value>
   </data>
 </root>


### PR DESCRIPTION
## Description

Running the Enterprise Template project in VS Code on a Mac throws a runtime error due to the Intro.json file not being found caused by the Windows forward-slash not being interpreted into the path.

Swapping the forward-slashes for back-slashes solves this issue and continues to function on Windows w/out issue.

<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
- [ X] I have tested this in VS Code on Mac, Visual Studio 2017 on Windows 10, in Azure App Service (Windows)
