### PR TITLE
[BotSkill][TypeScript] Implement remote skill invocation

### DIFF
--- a/solutions/Virtual-Assistant/src/typescript/assistant/package.json
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/package.json
@@ -22,6 +22,7 @@
         "applicationinsights": "^1.0.4",
         "azure-cognitiveservices-contentmoderator": "^4.0.0",
         "bot-solution": "^1.0.0",
+        "bot-skill": "^1.0.0",
         "botbuilder": "^4.2.1",
         "botbuilder-ai": "^4.2.1",
         "botbuilder-azure": "4.2.1",

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
@@ -14,10 +14,10 @@ import {
     RouterDialog,
     SkillConfiguration,
     SkillDefinition,
-    SkillDialog,
     SkillEvent,
     SkillRouter,
     TelemetryExtensions } from 'bot-solution';
+import { SkillDialog } from "bot-skill";
 import {
     BotFrameworkAdapter,
     BotTelemetryClient,
@@ -448,10 +448,7 @@ export class MainDialog extends RouterDialog {
             this.addDialog(new SkillDialog(
                 definition,
                 this.services.skillConfigurations.get(definition.id) || new SkillConfiguration(),
-                this.proactiveState,
-                this.endpointService,
-                this.telemetryClient,
-                this.backgroundTaskQueue));
+                this.telemetryClient));
         });
 
         // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { SkillDialog } from 'bot-skill';
 import {
     IBackgroundTaskQueue,
     InterruptionAction,
@@ -17,7 +18,6 @@ import {
     SkillEvent,
     SkillRouter,
     TelemetryExtensions } from 'bot-solution';
-import { SkillDialog } from "bot-skill";
 import {
     BotFrameworkAdapter,
     BotTelemetryClient,

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SkillDialog } from 'bot-skill';
+import { SkillDialog, SkillDefinition as RemoteSkillDefinition } from 'bot-skill';
 import {
     IBackgroundTaskQueue,
     InterruptionAction,
@@ -13,7 +13,6 @@ import {
     LocaleConfiguration,
     ProactiveState,
     RouterDialog,
-    SkillConfiguration,
     SkillDefinition,
     SkillEvent,
     SkillRouter,
@@ -445,7 +444,12 @@ export class MainDialog extends RouterDialog {
 
     private registerSkills(skillDefinitions: SkillDefinition[]): void {
         skillDefinitions.forEach((definition: SkillDefinition) => {
-            this.addDialog(new SkillDialog(definition, this.telemetryClient));
+            const remoteSkillDefinition: RemoteSkillDefinition = new RemoteSkillDefinition();
+            remoteSkillDefinition.name = definition.id;
+            remoteSkillDefinition.endpoint = definition.assembly;
+            remoteSkillDefinition.dispatchIntent = definition.dispatchIntent;
+            
+            this.addDialog(new SkillDialog(remoteSkillDefinition, this.telemetryClient));
         });
 
         // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/dialogs/main/mainDialog.ts
@@ -445,10 +445,7 @@ export class MainDialog extends RouterDialog {
 
     private registerSkills(skillDefinitions: SkillDefinition[]): void {
         skillDefinitions.forEach((definition: SkillDefinition) => {
-            this.addDialog(new SkillDialog(
-                definition,
-                this.services.skillConfigurations.get(definition.id) || new SkillConfiguration(),
-                this.telemetryClient));
+            this.addDialog(new SkillDialog(definition, this.telemetryClient));
         });
 
         // Initialize skill dispatcher

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/index.ts
@@ -159,8 +159,8 @@ if (!cosmosConfig) {
 }
 
 // create conversation and user state
-const conversationState: ConversationState = new ConversationState(storage);
-const userState: UserState = new UserState(storage);
+const conversationState: ConversationState = new ConversationState(storage, 'assistant');
+const userState: UserState = new UserState(storage, 'assistant');
 const proactiveState: ProactiveState = new ProactiveState(storage);
 
 // Use the AutoSaveStateMiddleware middleware to automatically read and write conversation and user state.

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/skills.json
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/skills.json
@@ -96,7 +96,7 @@
         "type": "skill",
         "id": "sampleSkill",
         "name": "sampleSkill",
-        "assembly": "PointOfInterestSkill.PointOfInterestSkill, PointOfInterestSkill, Version=1.0.0.0, Culture=neutral",
+        "assembly": "http://localhost:3980/api/skill/messages",
         "dispatchIntent": "l_Sample",
         "luisServiceIds": [
             "sample",

--- a/solutions/Virtual-Assistant/src/typescript/assistant/src/skills.json
+++ b/solutions/Virtual-Assistant/src/typescript/assistant/src/skills.json
@@ -96,25 +96,20 @@
         "type": "skill",
         "id": "sampleSkill",
         "name": "sampleSkill",
-        "assembly": "SampleSkill, SampleSkill, Version=1.0.0.0, Culture=neutral",
+        "assembly": "PointOfInterestSkill.PointOfInterestSkill, PointOfInterestSkill, Version=1.0.0.0, Culture=neutral",
         "dispatchIntent": "l_Sample",
-        "supportedProviders": [
-
-        ],
         "luisServiceIds": [
             "sample",
             "general"
         ],
         "parameters": [
+            "IPA.Location",
+            "IPA.Timezone"
         ],
         "configuration": {
-            "googleAppName": "",
-            "googleClientId": "",
-            "googleClientSecret": "",
-            "googleScopes": "",
-            "displaySize": "3",
-            "pathToBot": "./sampleSkill/lib/sampleSkill.js",
-            "ClassName": "SampleSkill"
+            "AzureMapsKey": "",
+            "ClassName": "SampleSkill",
+            "botUrl": "http://localhost:3980/api/skill/messages"
         }
     }
 ]

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/package.json
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "bot-skill",
+    "version": "1.0.0",
+    "description": "",
+    "author": "Microsoft Bot Framework Team",
+    "license": "MIT",
+    "main": "lib/index.js",
+    "scripts": {
+        "clean": "rimraf ./lib",
+        "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
+        "prebuild": "npm run lint",
+        "build": "tsc --p tsconfig.json && npm run copy-templates",
+        "lint": "tslint -t vso ./src/**/*.ts",
+        "test": "mocha ./test/"
+    },
+    "dependencies": {
+		"bot-solution": "^1.0.0",
+        "botbuilder": "^4.2.1",
+        "botbuilder-ai": "^4.2.1",
+        "botbuilder-azure": "4.2.1",
+        "botbuilder-core": "^4.2.1",
+        "botbuilder-dialogs": "^4.2.1",
+        "botframework-config": "^4.2.1",
+        "botframework-connector": "^4.2.1",
+        "botframework-schema": "^4.2.1",
+        "i18n": "^0.8.3",
+        "p-queue": "^4.0.0",
+        "request-promise-native": "^1.0.7"
+    },
+    "devDependencies": {
+        "@types/documentdb": "1.10.5",
+        "@types/dotenv": "^6.0.0",
+        "@types/i18n": "^0.8.3",
+        "@types/node": "^10.10.1",
+        "@types/restify": "^7.2.4",
+        "copyfiles": "^2.1.0",
+        "mocha": "^5.2.0",
+        "nodemon": "^1.18.4",
+        "replace": "^1.0.0",
+        "rimraf": "^2.6.2",
+        "tslint": "^5.12.1",
+        "tslint-microsoft-contrib": "6.0.0",
+        "typescript": "^3.2.2"
+    },
+    "env": {
+        "mocha": true,
+        "node": true
+    }
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from './skillDefinition';
+export * from './skillDialogOptions';
+export * from './skillEvents';

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillDefinition.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillDefinition.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class SkillDefinition {
+
+    public name: string = '';
+    public dispatchIntent: string = '';
+    public endpoint: string = '';
+    public supportedProviders: string[] = [];
+    public scope: string = '';
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillDialogOptions.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillDialogOptions.ts
@@ -1,0 +1,12 @@
+import { SkillDefinition } from './skillDefinition';
+
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface ISkillDialogOptions {
+
+   skillDefinition: SkillDefinition | undefined;
+   parameters: Map<string, Object>;
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillEvents.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/Models/skillEvents.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export class SkillEvents {
+
+    public skillBeginEventName: string = 'skillBegin';
+    public tokenRequestEventName: string = 'tokens/request';
+    public tokenResponseEventName: string = 'tokens/response';
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @module bot-skill
+ */
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from './skillDialog';

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
@@ -8,3 +8,4 @@
 
 export * from './skillAdapter';
 export * from './skillDialog';
+export * from './models';

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/index.ts
@@ -6,4 +6,5 @@
  * Licensed under the MIT License.
  */
 
+export * from './skillAdapter';
 export * from './skillDialog';

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { ActivityExtensions } from 'bot-solution';
 import { BotFrameworkAdapter, InvokeResponse, TurnContext, WebRequest, WebResponse } from 'botbuilder';
 import { DialogContext } from 'botbuilder-dialogs';

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,6 +1,6 @@
-import { BotFrameworkAdapter, BotAdapter, TurnContext, WebRequest, WebResponse } from "botbuilder";
-import { ActivityExtensions } from '../extensions';
-import { Activity, ActivityTypes, ActivityTypesEx, ConversationReference, ResourceResponse } from "botframework-schema";
+import { BotFrameworkAdapter, TurnContext } from "botbuilder";
+import { ActivityExtensions } from 'bot-solution';
+import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from "botframework-schema";
 
 export class SkillAdapter extends BotFrameworkAdapter {
     private readonly queuedActivities: Partial<Activity>[];
@@ -15,8 +15,11 @@ export class SkillAdapter extends BotFrameworkAdapter {
         this.queuedActivities = [];
     }
 
-    public processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
-        throw new Error("Method not implemented."); 
+    public async processActivity(activity: Partial<Activity>, callback: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
+
+        const context: TurnContext = new TurnContext(this, activity);
+        await this.runMiddleware(context, callback);
+
     }
 
     public async sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
@@ -70,11 +73,11 @@ export class SkillAdapter extends BotFrameworkAdapter {
     public async continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
       
         if (!reference) {
-            throw new Error('Missing parameter.  reference is required');
+            throw new Error('Missing parameter. reference is required');
         }
 
         if (!logic) {
-            throw new Error('Missing parameter.  logic is required');
+            throw new Error('Missing parameter. logic is required');
         }
 
         const context: TurnContext = new TurnContext(this, ActivityExtensions.getContinuationActivity(reference));

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,6 +1,8 @@
 import { BotFrameworkAdapter, TurnContext, WebRequest, WebResponse, InvokeResponse } from "botbuilder";
 import { ActivityExtensions } from 'bot-solution';
-import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from "botframework-schema";
+import { BotFrameworkAdapter, InvokeResponse, TurnContext, WebRequest, WebResponse } from 'botbuilder';
+import { DialogContext } from 'botbuilder-dialogs';
+import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from 'botframework-schema';
 
 export class SkillAdapter extends BotFrameworkAdapter {
     private readonly queuedActivities: Partial<Activity>[];
@@ -8,6 +10,13 @@ export class SkillAdapter extends BotFrameworkAdapter {
 
     private get nextId(): string {
         return (this.lastId + 1).toString();
+    }
+
+    public static isSkillMode(context: TurnContext|DialogContext): boolean {
+        const ctx: TurnContext = context instanceof DialogContext ? context.context : context;
+        const mode: string = 'skillMode';
+
+        return ctx.turnState.get(mode) || false;
     }
 
     public constructor() {
@@ -40,6 +49,8 @@ export class SkillAdapter extends BotFrameworkAdapter {
 
         // Process the Activity through the Middleware and the Bot, this will generate Activities which we need to send back.
         const context: TurnContext = this.createContext(activity);
+        const mode: string = 'skillMode';
+        context.turnState.set(mode, true);
 
         await this.runMiddleware(context, callback);
 

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,31 +1,97 @@
-import { BotFrameworkAdapter, TurnContext, WebRequest, WebResponse } from "botbuilder";
-import { Activity, ConversationReference, ResourceResponse } from "botframework-schema";
+import { BotFrameworkAdapter, BotAdapter, TurnContext, WebRequest, WebResponse } from "botbuilder";
+import { ActivityExtensions } from '../extensions';
+import { Activity, ActivityTypes, ActivityTypesEx, ConversationReference, ResourceResponse } from "botframework-schema";
 
 export class SkillAdapter extends BotFrameworkAdapter {
     private readonly queuedActivities: Partial<Activity>[];
+    private lastId: number = 0;
+
+    private get nextId(): string {
+        return (this.lastId + 1).toString();
+    }
 
     constructor() {
         super();
         this.queuedActivities = [];
     }
 
-    public sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
-        throw new Error("Method not implemented.");
-    }
-
-    public continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
-        throw new Error("Method not implemented.");
-    }
-
     public processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
+        throw new Error("Method not implemented."); 
+    }
+
+    public async sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
+        const responses: ResourceResponse [] = [];
+        const proactiveActivities: Partial<Activity>[] = [];
+
+        activities.forEach(async(activity: Partial<Activity>) => {
+            if(!activity.id){
+                activity.id = this.nextId;
+            }
+
+            if(!activity.timestamp){
+                activity.timestamp = new Date();
+            }
+
+            if (activity.type === 'delay'){
+                // The BotFrameworkAdapter and Console adapter implement this
+                // hack directly in the POST method. Replicating that here
+                // to keep the behavior as close as possible to facillitate
+                // more realistic tests.
+                const delayMs: number = activity.value;
+                await this.sleep(delayMs);
+            }
+            else if(activity.type === ActivityTypes.Trace && activity.channelId !== "emulator"){
+                // if it is a Trace activity we only send to the channel if it's the emulator.
+            }
+            else if(activity.type === ActivityTypes.Typing && activity.channelId !== "test"){
+               // If it's a typing activity we omit this in test scenarios to avoid test failures
+            }
+            else{
+
+                //TODO - Post to the Parent Bot ServiceURL
+                (this.queuedActivities);
+                {
+                    this.queuedActivities.push(activity);
+                }    
+            }
+
+            responses.push( new ResourceResponse (activity.id));
+        })    
+
+        return responses;
+    }   
+
+    public getReplies(): Partial<Activity>[] {
+        return this.queuedActivities
+            .splice(0, this.queuedActivities.length)
+            .reverse();
+    }
+
+    public async continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
+      
+        if (!reference) {
+            throw new Error('Missing parameter.  reference is required');
+        }
+
+        if (!logic) {
+            throw new Error('Missing parameter.  logic is required');
+        }
+
+        const context: TurnContext = new TurnContext(this, ActivityExtensions.getContinuationActivity(reference));
+        await this.runMiddleware(context, logic);
+    }
+
+    private sleep(delay: number): Promise<void> {
+        return new Promise<void>((resolve: (value: void) => void): void => {
+            setTimeout(resolve, delay);
+        });
+    }
+
+    public deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
         throw new Error("Method not implemented.");
     }
 
     public updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
-        throw new Error("Method not implemented.");
-    }
-
-    public deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
         throw new Error("Method not implemented.");
     }
 }

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,0 +1,31 @@
+import { BotFrameworkAdapter, TurnContext, WebRequest, WebResponse } from "botbuilder";
+import { Activity, ConversationReference, ResourceResponse } from "botframework-schema";
+
+export class SkillAdapter extends BotFrameworkAdapter {
+    private readonly queuedActivities: Partial<Activity>[];
+
+    constructor() {
+        super();
+        this.queuedActivities = [];
+    }
+
+    public sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
+        throw new Error("Method not implemented.");
+    }
+
+    public continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    public processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    public updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+
+    public deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,4 +1,5 @@
 import { BotFrameworkAdapter, TurnContext, WebRequest, WebResponse, InvokeResponse } from "botbuilder";
+import { DialogContext } from "botbuilder-dialogs";
 import { ActivityExtensions } from 'bot-solution';
 import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from "botframework-schema";
 
@@ -8,6 +9,11 @@ export class SkillAdapter extends BotFrameworkAdapter {
 
     private get nextId(): string {
         return (this.lastId + 1).toString();
+    }
+
+    public static isSkillMode(context: TurnContext|DialogContext): boolean {
+        const ctx: TurnContext = context instanceof DialogContext ? context.context : context;
+        return ctx.turnState.get('skillMode') || false;
     }
 
     public constructor() {
@@ -40,6 +46,7 @@ export class SkillAdapter extends BotFrameworkAdapter {
 
         // Process the Activity through the Middleware and the Bot, this will generate Activities which we need to send back.
         const context: TurnContext = this.createContext(activity);
+        context.turnState.set('skillMode', true);
 
         await this.runMiddleware(context, callback);
 

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillAdapter.ts
@@ -1,10 +1,10 @@
-import { BotFrameworkAdapter, TurnContext, WebRequest, WebResponse, InvokeResponse } from "botbuilder";
 import { ActivityExtensions } from 'bot-solution';
-import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from "botframework-schema";
+import { BotFrameworkAdapter, InvokeResponse, TurnContext, WebRequest, WebResponse } from 'botbuilder';
+import { Activity, ActivityTypes, ConversationReference, ResourceResponse } from 'botframework-schema';
 
 export class SkillAdapter extends BotFrameworkAdapter {
     private readonly queuedActivities: Partial<Activity>[];
-    private lastId: number = 0;
+    private readonly lastId: number = 0;
 
     private get nextId(): string {
         return (this.lastId + 1).toString();
@@ -15,12 +15,15 @@ export class SkillAdapter extends BotFrameworkAdapter {
         this.queuedActivities = [];
     }
 
+    // tslint:disable-next-line:no-any
     public async processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
         // deserialize the incoming Activity
         const activity: Activity = await parseRequest(req);
 
         // grab the auth header from the inbound http request
-        const headers = req.headers;
+
+        // tslint:disable-next-line:no-any
+        const headers: any = req.headers;
 
         // process the inbound activity with the bot
         const invokeResponse: InvokeResponse = await this.processActivityInternal(headers, activity, logic);
@@ -34,7 +37,12 @@ export class SkillAdapter extends BotFrameworkAdapter {
         res.end();
     }
 
-    public async processActivityInternal(authHeader: string , activity: Partial<Activity>, callback: (revocableContext: TurnContext) => Promise<void>): Promise<InvokeResponse> {
+    public async processActivityInternal(
+        authHeader: string,
+        activity: Partial<Activity>,
+        callback: (revocableContext: TurnContext) =>
+        Promise<void>):
+        Promise<InvokeResponse> {
         // Ensure the Activity has been retrieved from the HTTP POST
         // Not performing authentication checks at this time
 
@@ -47,7 +55,7 @@ export class SkillAdapter extends BotFrameworkAdapter {
         return {
             status: 200,
             body: this.getReplies()
-        }
+        };
     }
 
     public async sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
@@ -55,39 +63,36 @@ export class SkillAdapter extends BotFrameworkAdapter {
         const proactiveActivities: Partial<Activity>[] = [];
 
         activities.forEach(async(activity: Partial<Activity>) => {
-            if(!activity.id){
+            if (activity.id !== '') {
                 activity.id = this.nextId;
             }
 
-            if(!activity.timestamp){
+            if (activity.timestamp !== undefined) {
                 activity.timestamp = new Date();
             }
 
-            if (activity.type === 'delay'){
+            if (activity.type === 'delay') {
                 // The BotFrameworkAdapter and Console adapter implement this
                 // hack directly in the POST method. Replicating that here
                 // to keep the behavior as close as possible to facillitate
                 // more realistic tests.
                 const delayMs: number = activity.value;
                 await this.sleep(delayMs);
-            }
-            else if(activity.type === ActivityTypes.Trace && activity.channelId !== "emulator"){
+            } else if (activity.type === ActivityTypes.Trace && activity.channelId !== 'emulator') {
                 // if it is a Trace activity we only send to the channel if it's the emulator.
-            }
-            else if(activity.type === ActivityTypes.Typing && activity.channelId !== "test"){
+            } else if (activity.type === ActivityTypes.Typing && activity.channelId !== 'test') {
                // If it's a typing activity we omit this in test scenarios to avoid test failures
-            }
-            else{
+            } else {
 
-                //TODO - Post to the Parent Bot ServiceURL
-                (this.queuedActivities);
-                {
+                //PENDING - Post to the Parent Bot ServiceURL
+
+               if (this.queuedActivities !== undefined) {
                     this.queuedActivities.push(activity);
                 }
             }
 
             responses.push({ id: activity.id });
-        })
+        });
 
         return responses;
     }
@@ -98,13 +103,16 @@ export class SkillAdapter extends BotFrameworkAdapter {
             .reverse();
     }
 
-    public async continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void> {
+    public async continueConversation(
+        reference: Partial<ConversationReference>,
+        logic: (revocableContext: TurnContext) =>
+        Promise<void>): Promise<void> {
 
-        if (!reference) {
+        if (reference !== undefined) {
             throw new Error('Missing parameter. reference is required');
         }
 
-        if (!logic) {
+        if (logic !== undefined) {
             throw new Error('Missing parameter. logic is required');
         }
 
@@ -112,22 +120,23 @@ export class SkillAdapter extends BotFrameworkAdapter {
         await this.runMiddleware(context, logic);
     }
 
-    private sleep(delay: number): Promise<void> {
+    private async sleep(delay: number): Promise<void> {
         return new Promise<void>((resolve: (value: void) => void): void => {
             setTimeout(resolve, delay);
         });
     }
 
-    public deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
-        throw new Error("Method not implemented.");
+    public async deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 
-    public updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
-        throw new Error("Method not implemented.");
+    public async updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
+        throw new Error('Method not implemented.');
     }
 }
 
 function parseRequest(req: WebRequest): Promise<Activity> {
+    // tslint:disable-next-line:no-any
     return new Promise((resolve: any, reject: any): void => {
         function returnActivity(activity: Activity): void {
             if (typeof activity !== 'object') { throw new Error(`BotFrameworkAdapter.parseRequest(): invalid request body.`); }

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Activity, ActivityTypes, AutoSaveStateMiddleware, BotTelemetryClient, ConversationState,
+    MemoryStorage, Storage, TurnContext, UserState } from 'botbuilder';
+import { CosmosDbStorage, CosmosDbStorageSettings } from 'botbuilder-azure';
+import { ComponentDialog, Dialog, DialogContext, DialogTurnResult, DialogTurnStatus } from 'botbuilder-dialogs';
+import { IEndpointService } from 'botframework-config';
+import { join } from 'path';
+import { IProviderTokenResponse, isProviderTokenResponse, MultiProviderAuthDialog, ActivityExtensions,
+    EventDebuggerMiddleware, SetLocaleMiddleware, TelemetryExtensions, ProactiveState, ResponseManager,
+    IBackgroundTaskQueue, InProcAdapter, SkillConfigurationBase, SkillDefinition, ISkillDialogOptions,
+    SkillResponses } from 'bot-solution';
+import { SkillAdapter } from './skillAdapter';
+import { post } from "request-promise-native";
+
+export class SkillDialog extends ComponentDialog {
+    // Fields
+    private readonly skillDefinition: SkillDefinition;
+    private readonly skillConfiguration: SkillConfigurationBase;
+
+    constructor(skillDefinition: SkillDefinition,
+                skillConfiguration: SkillConfigurationBase,
+                telemetryClient: BotTelemetryClient) {
+        super(skillDefinition.id);
+
+        this.skillDefinition = skillDefinition;
+        this.skillConfiguration = skillConfiguration;
+        this.telemetryClient = telemetryClient;
+
+        this.addDialog(new MultiProviderAuthDialog(skillConfiguration));
+    }
+
+    protected onBeginDialog(innerDC: DialogContext, options?: object): Promise<DialogTurnResult> {
+        const skillOptions: ISkillDialogOptions = <ISkillDialogOptions> options;
+
+        // Send parameters to skill in skillBegin event
+        const userData: Map<string, Object> = new Map();
+
+        if (this.skillDefinition.parameters) {
+            this.skillDefinition.parameters.forEach((parameter: string) => {
+                if (skillOptions.parameters && skillOptions.parameters.has(parameter)) {
+                    userData.set(parameter, skillOptions.parameters.get(parameter) || '');
+                }
+            });
+        }
+
+        const activity: Activity = innerDC.context.activity;
+
+        const skillBeginEvent: Partial<Activity> = {
+            type: ActivityTypes.Event,
+            channelId: activity.channelId,
+            from: activity.from,
+            recipient: activity.recipient,
+            conversation: activity.conversation,
+            name: Events.skillBeginEventName,
+            value: userData
+        };
+
+        // Send event to Skill/Bot
+        return this.forwardToSkill(innerDC, skillBeginEvent);
+    }
+
+    protected async onContinueDialog(innerDC: DialogContext): Promise<DialogTurnResult> {
+        const activity: Activity = innerDC.context.activity;
+
+        if (innerDC.activeDialog && innerDC.activeDialog.id === MultiProviderAuthDialog.name) {
+            // Handle magic code auth
+            const result: DialogTurnResult = await innerDC.continueDialog();
+
+            // forward the token response to the skill
+            if (result.status === DialogTurnStatus.complete && isProviderTokenResponse(result.result)) {
+                activity.type = ActivityTypes.Event;
+                activity.name = Events.tokenResponseEventName;
+                activity.value = <IProviderTokenResponse> result.result;
+            } else {
+                return result;
+            }
+        }
+
+        return this.forwardToSkill(innerDC, activity);
+    }
+
+    protected endComponent(outerDC: DialogContext, result: Object): Promise<DialogTurnResult> {
+        return outerDC.endDialog(result);
+    }
+
+    private async forwardToSkill(innerDc: DialogContext, activity: Partial<Activity>): Promise<DialogTurnResult> {
+        try {
+            
+            const request = post({
+                uri: <string> this.skillConfiguration.properties['botUrl'],
+                headers: { 'skill': 'true' },
+                body: activity,
+                json: true
+            });
+
+            const responses: Partial<Activity>[] = await request;
+
+            let endOfConversation: boolean = false;
+
+            const filteredResponses: Partial<Activity>[] = responses.filter(skillResponse => {
+                if (skillResponse.type === ActivityTypes.EndOfConversation) {
+                    endOfConversation = true;
+                    return false;
+                }
+
+                if (skillResponse.name === Events.tokenRequestEventName) {
+                    return false;
+                }
+
+                return true;
+            });
+
+            await innerDc.context.sendActivities(filteredResponses);
+
+            // handle ending the skill conversation
+            if (endOfConversation) {
+                const trace: Partial<Activity> = {
+                    type: ActivityTypes.Trace,
+                    text: '<--Ending the skill conversation'
+                };
+
+                await innerDc.context.sendActivity(trace);
+
+                return await innerDc.endDialog();
+            } else {
+                return Dialog.EndOfTurn;
+            }
+        } catch (error) {
+            // something went wrong forwarding to the skill, so end dialog cleanly and throw so the error is logged.
+            // NOTE: errors within the skill itself are handled by the OnTurnError handler on the adapter.
+            await innerDc.endDialog();
+            throw error;
+        }
+    }
+}
+
+namespace Events {
+    export const skillBeginEventName: string = 'skillBegin';
+    export const tokenRequestEventName: string = 'tokens/request';
+    export const tokenResponseEventName: string = 'tokens/response';
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SkillDefinition } from 'bot-solution';
+import { SkillDefinition } from './models';
 import { Activity, ActivityTypes, BotTelemetryClient } from 'botbuilder';
 import { ComponentDialog, Dialog, DialogContext, DialogTurnResult } from 'botbuilder-dialogs';
 import { post, RequestPromise } from 'request-promise-native';
@@ -13,7 +13,7 @@ export class SkillDialog extends ComponentDialog {
     private readonly skillDefinition: SkillDefinition;
 
     constructor(skillDefinition: SkillDefinition, telemetryClient: BotTelemetryClient) {
-        super(skillDefinition.id);
+        super(skillDefinition.name);
 
         this.skillDefinition = skillDefinition;
         this.telemetryClient = telemetryClient;
@@ -55,7 +55,7 @@ export class SkillDialog extends ComponentDialog {
             // PENDING - Add header to indicate a skill call
 
             const request: RequestPromise<Partial<Activity>[]> = post({
-                uri: <string> this.skillDefinition.assembly,
+                uri: <string> this.skillDefinition.endpoint,
                 body: activity,
                 json: true
             });

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/src/skillDialog.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
+import { SkillDefinition } from 'bot-solution';
 import { Activity, ActivityTypes, BotTelemetryClient } from 'botbuilder';
 import { ComponentDialog, Dialog, DialogContext, DialogTurnResult } from 'botbuilder-dialogs';
-import { SkillDefinition } from 'bot-solution';
-import { post } from "request-promise-native";
+import { post } from 'request-promise-native';
 
 export class SkillDialog extends ComponentDialog {
     // Fields
@@ -20,7 +20,7 @@ export class SkillDialog extends ComponentDialog {
     }
 
     protected async onBeginDialog(innerDC: DialogContext, options?: object): Promise<DialogTurnResult> {
-        // TODO - The SkillDialog Orchestration should try to fill slots defined in the manifest and pass through this event.
+        // PENDING - The SkillDialog Orchestration should try to fill slots defined in the manifest and pass through this event.
         const slots: object = {};
 
         const activity: Activity = innerDC.context.activity;
@@ -36,14 +36,14 @@ export class SkillDialog extends ComponentDialog {
         };
 
         // Send event to Skill/Bot
-        return await this.forwardToSkill(innerDC, skillBeginEvent);
+        return this.forwardToSkill(innerDC, skillBeginEvent);
     }
 
     protected async onContinueDialog(innerDC: DialogContext): Promise<DialogTurnResult> {
-        return await this.forwardToSkill(innerDC, innerDC.context.activity);
+        return this.forwardToSkill(innerDC, innerDC.context.activity);
     }
 
-    protected endComponent(outerDC: DialogContext, result: Object): Promise<DialogTurnResult> {
+    protected async endComponent(outerDC: DialogContext, result: Object): Promise<DialogTurnResult> {
         return outerDC.endDialog(result);
     }
 
@@ -51,10 +51,11 @@ export class SkillDialog extends ComponentDialog {
         try {
 
             // Serialize the activity and POST to the Skill endpoint
-            // TODO - Apply Authorization header
-            // TODO - Add header to indicate a skill call
-            
-            const request = post({
+            // PENDING - Apply Authorization header
+            // PENDING - Add header to indicate a skill call
+
+            // tslint:disable-next-line:no-any
+            const request: any = post({
                 uri: <string> this.skillDefinition.assembly,
                 body: activity,
                 json: true
@@ -66,7 +67,7 @@ export class SkillDialog extends ComponentDialog {
             let endOfConversation: boolean = false;
 
             skillResponses.forEach((skillResponse: Partial<Activity>) => {
-                // Once a Skill has finished it signals that it's handing back control to the parent through a 
+                // Once a Skill has finished it signals that it's handing back control to the parent through a
                 // EndOfConversation event which then causes the SkillDialog to be closed. Otherwise it remains "in control".
                 if (skillResponse.type === ActivityTypes.EndOfConversation) {
                     endOfConversation = true;

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/tsconfig.json
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/tsconfig.json
@@ -1,0 +1,59 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/solutions/Virtual-Assistant/src/typescript/bot-skill/tslint.json
+++ b/solutions/Virtual-Assistant/src/typescript/bot-skill/tslint.json
@@ -1,0 +1,27 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended",
+        "tslint-microsoft-contrib"
+    ],
+    "linterOptions":{
+      "exclude": [
+        "src/resources/*"
+      ]
+    },
+    "rules": {
+      "function-name": [ true,
+        {
+          "static-method-regex":"^[a-z][\\w\\d]+$"
+        }
+      ],
+      "linebreak-style": false,
+      "member-ordering": false,
+      "no-relative-imports": false,
+      "export-name": false,
+      "completed-docs": false
+    },
+    "rulesDirectory": [
+      "tslint-microsoft-contrib"
+    ]
+  }

--- a/solutions/Virtual-Assistant/src/typescript/bot-solution/src/skills/skillDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-solution/src/skills/skillDialog.ts
@@ -133,14 +133,16 @@ export class SkillDialog extends ComponentDialog {
 
             // Create skill instance
             try {
-                const skillDirectory: string = join(this.skillsDirectory, <string> this.skillConfiguration.properties['pathToBot']);
-                // tslint:disable-next-line:no-any
+                const key: string = 'pathToBot';
+                const skillDirectory: string = join(this.skillsDirectory, <string> this.skillConfiguration.properties[key]);
+                 // tslint:disable-next-line:no-any non-literal-require
                 const skillModule: any = require(skillDirectory);
-                const skillClassName: string = <string> this.skillConfiguration.properties['ClassName'];
+                const className: string = 'ClassName';
+                const skillClassName: string = <string> this.skillConfiguration.properties[className];
                 this.activatedSkill = new skillModule[skillClassName](
-                    this.skillConfiguration, 
-                    conversationState, 
-                    userState, 
+                    this.skillConfiguration,
+                    conversationState,
+                    userState,
                     this._telemetryClient,
                     true);
 

--- a/solutions/Virtual-Assistant/src/typescript/bot-solution/src/skills/skillDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/bot-solution/src/skills/skillDialog.ts
@@ -133,14 +133,16 @@ export class SkillDialog extends ComponentDialog {
 
             // Create skill instance
             try {
-                const skillDirectory: string = join(this.skillsDirectory, <string> this.skillConfiguration.properties['pathToBot']);
-                // tslint:disable-next-line:no-any
+                const path: string = 'pathToBot';
+                const skillDirectory: string = join(this.skillsDirectory, <string> this.skillConfiguration.properties[path]);
+               // tslint:disable-next-line:no-any non-literal-require
                 const skillModule: any = require(skillDirectory);
-                const skillClassName: string = <string> this.skillConfiguration.properties['ClassName'];
+                const key: string = 'ClassName';
+                const skillClassName: string = <string> this.skillConfiguration.properties[key];
                 this.activatedSkill = new skillModule[skillClassName](
-                    this.skillConfiguration, 
-                    conversationState, 
-                    userState, 
+                    this.skillConfiguration,
+                    conversationState,
+                    userState,
                     this._telemetryClient,
                     true);
 

--- a/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
@@ -206,6 +206,37 @@
         "typescript": "^3.2.2"
       }
     },
+    "@rush-temp/sampleSkill": {
+      "version": "file:projects/sampleSkill.tgz",
+      "integrity": "sha512-MxA5MB7Mv7Hqyp2N4Ba0sDKmQQayzFMjGlgUiPLX8E2c8j6aHFPaldgAZW/ERc2m8mvmTlPRrGy+CVjzVDhPMg==",
+      "requires": {
+        "@types/documentdb": "1.10.5",
+        "@types/dotenv": "^6.0.0",
+        "@types/i18next-node-fs-backend": "^0.0.30",
+        "@types/node": "^10.10.1",
+        "@types/restify": "^7.2.4",
+        "applicationinsights": "^1.0.4",
+        "botbuilder": "^4.2.1",
+        "botbuilder-ai": "^4.2.1",
+        "botbuilder-azure": "4.2.1",
+        "botbuilder-core": "^4.2.1",
+        "botbuilder-dialogs": "^4.2.1",
+        "botframework-config": "^4.2.1",
+        "botframework-schema": "^4.2.1",
+        "copyfiles": "^2.1.0",
+        "dotenv": "^6.0.0",
+        "i18next": "^15.0.6",
+        "i18next-node-fs-backend": "^2.1.1",
+        "mocha": "^5.2.0",
+        "ms-rest-azure": "^2.5.0",
+        "replace": "^1.0.0",
+        "restify": "^7.2.1",
+        "rimraf": "^2.6.2",
+        "tslint": "^5.12.1",
+        "tslint-microsoft-contrib": "6.0.0",
+        "typescript": "^3.2.2"
+      }
+    },
     "@types/bunyan": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",

--- a/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
@@ -114,7 +114,7 @@
     },
     "@rush-temp/assistant": {
       "version": "file:projects/assistant.tgz",
-      "integrity": "sha512-CAiWRklGQPlIajQiWP5A7GaluhqlCas0EjlTCzPNID6WzrSjUEPjv71PIIkA2ZZy/htPfZULWJXBPa8013QiaQ==",
+      "integrity": "sha512-4tSq2+D7kQqFDtd58LpTGK8PCPxnxcMwVBhnHYZ/uIgwkKbpDqEX/l5RD9v1hnaM5HMGh0JRZTgt5TTJwN9m0Q==",
       "requires": {
         "@microsoft/microsoft-graph-client": "^1.3.0",
         "@microsoft/microsoft-graph-types": "^1.5.0",
@@ -139,7 +139,6 @@
         "i18next-node-fs-backend": "^2.1.1",
         "mocha": "^5.2.0",
         "ms-rest-azure": "^2.5.0",
-        "nock": "^10.0.6",
         "nodemon": "^1.18.4",
         "replace": "^1.0.0",
         "restify": "^7.2.1",
@@ -201,37 +200,6 @@
         "nodemon": "^1.18.4",
         "p-queue": "^4.0.0",
         "replace": "^1.0.0",
-        "rimraf": "^2.6.2",
-        "tslint": "^5.12.1",
-        "tslint-microsoft-contrib": "6.0.0",
-        "typescript": "^3.2.2"
-      }
-    },
-    "@rush-temp/sampleSkill": {
-      "version": "file:projects/sampleSkill.tgz",
-      "integrity": "sha512-+Eaoj9bFIURS3X4dE1SaYYNtmkJ/bvVdOqoN+HS2W0GCZILENEzjZLGr519u6S3gATThH9t+uGVayjbNZ8S8FA==",
-      "requires": {
-        "@types/documentdb": "1.10.5",
-        "@types/dotenv": "^6.0.0",
-        "@types/i18next-node-fs-backend": "^0.0.30",
-        "@types/node": "^10.10.1",
-        "@types/restify": "^7.2.4",
-        "applicationinsights": "^1.0.4",
-        "botbuilder": "^4.2.1",
-        "botbuilder-ai": "^4.2.1",
-        "botbuilder-azure": "4.2.1",
-        "botbuilder-core": "^4.2.1",
-        "botbuilder-dialogs": "^4.2.1",
-        "botframework-config": "^4.2.1",
-        "botframework-schema": "^4.2.1",
-        "copyfiles": "^2.1.0",
-        "dotenv": "^6.0.0",
-        "i18next": "^15.0.6",
-        "i18next-node-fs-backend": "^2.1.1",
-        "mocha": "^5.2.0",
-        "ms-rest-azure": "^2.5.0",
-        "replace": "^1.0.0",
-        "restify": "^7.2.1",
         "rimraf": "^2.6.2",
         "tslint": "^5.12.1",
         "tslint-microsoft-contrib": "6.0.0",
@@ -782,9 +750,9 @@
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "binary-search-bounds": {
       "version": "2.0.3",
@@ -2584,9 +2552,9 @@
       }
     },
     "i18next": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.7.tgz",
-      "integrity": "sha512-KCSmTOE0nsku53cI0sSBY21ftXhsAfCjcNQBx54Y0AxcTxSs+v+qGFQ38ab+vi6F4NZEm8JupO36vlWoeF47cA==",
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.8.tgz",
+      "integrity": "sha512-ayzNwJ9NHtqEeAG0nQ6yKFbIpZULpDeesjVnfWQaPwbH7Anee8QwRAYPNWHtFCmDZV9FZaKiEbfo1scH8+KSDg==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }

--- a/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
@@ -149,6 +149,36 @@
         "typescript": "^3.2.2"
       }
     },
+    "@rush-temp/bot-skill": {
+      "version": "file:projects/bot-skill.tgz",
+      "integrity": "sha512-96olHL7gpU7g2zOH5frQw3Cb7rctk0siqb8nPH7uPl0b/63scl5yop+8j2ZLG7DwRC7QAMlj5Y4OfaCDjDYZRA==",
+      "requires": {
+        "@types/documentdb": "1.10.5",
+        "@types/dotenv": "^6.0.0",
+        "@types/i18n": "^0.8.3",
+        "@types/node": "^10.10.1",
+        "@types/restify": "^7.2.4",
+        "botbuilder": "^4.2.1",
+        "botbuilder-ai": "^4.2.1",
+        "botbuilder-azure": "4.2.1",
+        "botbuilder-core": "^4.2.1",
+        "botbuilder-dialogs": "^4.2.1",
+        "botframework-config": "^4.2.1",
+        "botframework-connector": "^4.2.1",
+        "botframework-schema": "^4.2.1",
+        "copyfiles": "^2.1.0",
+        "i18n": "^0.8.3",
+        "mocha": "^5.2.0",
+        "nodemon": "^1.18.4",
+        "p-queue": "^4.0.0",
+        "replace": "^1.0.0",
+        "request-promise-native": "^1.0.7",
+        "rimraf": "^2.6.2",
+        "tslint": "^5.12.1",
+        "tslint-microsoft-contrib": "6.0.0",
+        "typescript": "^3.2.2"
+      }
+    },
     "@rush-temp/bot-solution": {
       "version": "file:projects/bot-solution.tgz",
       "integrity": "sha512-QZer/RbjbHMpOtxgyATZiKvgF6i/FwDH2+wCQm9OtUhTgzqf6T93csI71QfsrZkPt8fDCqiYkd0ThQP3WvQ/Dw==",
@@ -258,6 +288,11 @@
       "resolved": "https://registry.npmjs.org/@types/html-entities/-/html-entities-1.2.16.tgz",
       "integrity": "sha512-CI6fHfFvkTtX2Nlr4JBA6yIFTfA4p9E6w9ky64X6PrfXiTALhUh/SOa+Sxvv2p87m+y5AH71lAUrx0lSYx4hKQ=="
     },
+    "@types/i18n": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@types/i18n/-/i18n-0.8.5.tgz",
+      "integrity": "sha512-8fZUrwtP8nk0JWDujsx5JdrF4RuLyAD/yb9qgnFuBZgR6rI1afLP66Vytx//Bp6sROY/+kdRjopdq+HwNlHgrQ=="
+    },
     "@types/i18next": {
       "version": "2.3.41",
       "resolved": "https://registry.npmjs.org/@types/i18next/-/i18next-2.3.41.tgz",
@@ -363,6 +398,36 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ambi": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+      "requires": {
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      },
+      "dependencies": {
+        "typechecker": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
+          "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
+          "requires": {
+            "editions": "^2.1.0"
+          },
+          "dependencies": {
+            "editions": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+              "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+              "requires": {
+                "errlop": "^1.1.1",
+                "semver": "^5.6.0"
+              }
+            }
+          }
+        }
       }
     },
     "ansi-align": {
@@ -756,6 +821,18 @@
         "request": "^2.87.0",
         "request-promise-native": "1.0.5",
         "url-parse": "^1.4.4"
+      },
+      "dependencies": {
+        "request-promise-native": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+          "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "^1.1.0",
+            "tough-cookie": ">=2.3.3"
+          }
+        }
       }
     },
     "botbuilder-azure": {
@@ -1188,6 +1265,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
+    "csextends": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz",
+      "integrity": "sha512-S/8k1bDTJIwuGgQYmsRoE+8P+ohV32WhQ0l4zqrc0XDdxOhjQQD7/wTZwCzoZX53jSX3V/qwjT+OkPTxWQcmjg=="
+    },
     "csv": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
@@ -1384,6 +1466,14 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
+    "eachr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
+      "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
+      "requires": {
+        "typechecker": "^2.0.8"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1400,6 +1490,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "emitter-listener": {
       "version": "1.1.2",
@@ -1423,6 +1518,25 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "errlop": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+      "requires": {
+        "editions": "^2.1.2"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        }
       }
     },
     "es6-promise": {
@@ -1546,6 +1660,21 @@
         }
       }
     },
+    "extendr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz",
+      "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
+      "requires": {
+        "typechecker": "~2.0.1"
+      },
+      "dependencies": {
+        "typechecker": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
+        }
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1602,6 +1731,21 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        }
+      }
+    },
+    "extract-opts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
+      "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
+      "requires": {
+        "typechecker": "~2.0.1"
+      },
+      "dependencies": {
+        "typechecker": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
         }
       }
     },
@@ -2426,6 +2570,19 @@
         "sshpk": "^1.7.0"
       }
     },
+    "i18n": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.3.tgz",
+      "integrity": "sha1-LYzxwkciYCwgQdAbpq5eqlE4jw4=",
+      "requires": {
+        "debug": "*",
+        "make-plural": "^3.0.3",
+        "math-interval-parser": "^1.1.0",
+        "messageformat": "^0.3.1",
+        "mustache": "*",
+        "sprintf-js": ">=1.0.3"
+      }
+    },
     "i18next": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.7.tgz",
@@ -2455,6 +2612,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+    },
+    "ignorefs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
+      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+      "requires": {
+        "editions": "^1.3.3",
+        "ignorepatterns": "^1.1.0"
+      }
+    },
+    "ignorepatterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
+      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -2953,6 +3124,22 @@
         "pify": "^3.0.0"
       }
     },
+    "make-plural": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
+      "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "optional": true
+        }
+      }
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -2974,6 +3161,14 @@
         "object-visit": "^1.0.0"
       }
     },
+    "math-interval-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-1.1.0.tgz",
+      "integrity": "sha1-2+2lsGsySZc8bfYXD94jhvCv2JM=",
+      "requires": {
+        "xregexp": "^2.0.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -2989,6 +3184,45 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "messageformat": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-0.3.1.tgz",
+      "integrity": "sha1-5Y//gkXps5cXmeW0PbWLPpQX9aI=",
+      "requires": {
+        "async": "~1.5.2",
+        "glob": "~6.0.4",
+        "make-plural": "~3.0.3",
+        "nopt": "~3.0.6",
+        "watchr": "~2.4.13"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1"
+          }
+        }
       }
     },
     "micromatch": {
@@ -3162,6 +3396,11 @@
         "request": "^2.88.0",
         "uuid": "^3.2.1"
       }
+    },
+    "mustache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
     },
     "mv": {
       "version": "2.1.1",
@@ -3886,13 +4125,23 @@
       }
     },
     "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
       "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "request-promise-core": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+          "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        }
       }
     },
     "require-directory": {
@@ -4000,6 +4249,14 @@
         "ret": "~0.1.10"
       }
     },
+    "safefs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
+      "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+      "requires": {
+        "graceful-fs": "*"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4009,6 +4266,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "scandirectory": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
+      "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+      "requires": {
+        "ignorefs": "^1.0.0",
+        "safefs": "^3.1.2",
+        "taskgroup": "^4.0.5"
+      }
     },
     "select-hose": {
       "version": "2.0.0",
@@ -4021,9 +4288,9 @@
       "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -4414,6 +4681,15 @@
         "has-flag": "^3.0.0"
       }
     },
+    "taskgroup": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
+      "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+      "requires": {
+        "ambi": "^2.2.0",
+        "csextends": "^1.0.3"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -4613,6 +4889,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "typechecker": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
+      "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
     },
     "typescript": {
       "version": "3.3.4000",
@@ -4869,6 +5150,21 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "watchr": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.4.13.tgz",
+      "integrity": "sha1-10hHu01vkPYf4sdPn2hmKqDgdgE=",
+      "requires": {
+        "eachr": "^2.0.2",
+        "extendr": "^2.1.0",
+        "extract-opts": "^2.2.0",
+        "ignorefs": "^1.0.0",
+        "safefs": "^3.1.2",
+        "scandirectory": "^2.5.0",
+        "taskgroup": "^4.2.0",
+        "typechecker": "^2.0.8"
+      }
+    },
     "wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -4988,6 +5284,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
       "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.1",

--- a/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
@@ -18,9 +18,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -114,7 +114,7 @@
     },
     "@rush-temp/assistant": {
       "version": "file:projects/assistant.tgz",
-      "integrity": "sha512-4tSq2+D7kQqFDtd58LpTGK8PCPxnxcMwVBhnHYZ/uIgwkKbpDqEX/l5RD9v1hnaM5HMGh0JRZTgt5TTJwN9m0Q==",
+      "integrity": "sha512-g7yuI3rqzjP+XjYxecszyPhvmaRvp2dloURhJVU/QYg+x428P21uL4Bt9JsmlBd7xvsBXMu3zWzMNcfJIlAYaw==",
       "requires": {
         "@microsoft/microsoft-graph-client": "^1.3.0",
         "@microsoft/microsoft-graph-types": "^1.5.0",
@@ -139,6 +139,7 @@
         "i18next-node-fs-backend": "^2.1.1",
         "mocha": "^5.2.0",
         "ms-rest-azure": "^2.5.0",
+        "nock": "^10.0.6",
         "nodemon": "^1.18.4",
         "replace": "^1.0.0",
         "restify": "^7.2.1",
@@ -470,9 +471,9 @@
       }
     },
     "applicationinsights": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.2.0.tgz",
-      "integrity": "sha512-zb2id/cGdapn7sSH9rotgzic7Cje9k9zb+e9RrrQxG2GuOPPN0kD03FqO8qIAd3HvdtefQY3tTZXbQKo0qtmKw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.3.0.tgz",
+      "integrity": "sha512-rZbdSAZ88SQLquS3TQCBFfbGXVA1a/Yzce2A4kqjZNCqA4wxuOnOqg7EDvdU11iJYFj/FgOY91ni9/OJ9HE4IA==",
       "requires": {
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
@@ -2583,9 +2584,9 @@
       }
     },
     "i18next": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.8.tgz",
-      "integrity": "sha512-ayzNwJ9NHtqEeAG0nQ6yKFbIpZULpDeesjVnfWQaPwbH7Anee8QwRAYPNWHtFCmDZV9FZaKiEbfo1scH8+KSDg==",
+      "version": "15.0.9",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-15.0.9.tgz",
+      "integrity": "sha512-IdVj7DqErUuMbGuj2dFT431T7zKlmDci63eae6pNA/bMwgBZKT74/KnwHXE0WH7ivo2EV/LNme4pP4Yw6vB79w==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -3944,9 +3945,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
-          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -4821,9 +4822,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
-      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
+      "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -4831,7 +4832,7 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.0",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",

--- a/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/solutions/Virtual-Assistant/src/typescript/common/config/rush/npm-shrinkwrap.json
@@ -259,9 +259,9 @@
       }
     },
     "@types/dotenv": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.0.tgz",
-      "integrity": "sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
+      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
       "requires": {
         "@types/node": "*"
       }
@@ -2755,9 +2755,9 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -3944,9 +3944,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -4013,9 +4013,9 @@
           }
         },
         "mem": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-          "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^2.0.0",
@@ -4023,9 +4023,9 @@
           }
         },
         "mimic-fn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "os-locale": {
           "version": "3.1.0",
@@ -4054,9 +4054,9 @@
           }
         },
         "p-try": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "yargs": {
           "version": "12.0.5",
@@ -4895,9 +4895,9 @@
       "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
     },
     "typescript": {
-      "version": "3.3.4000",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q=="
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/solutions/Virtual-Assistant/src/typescript/rush.json
+++ b/solutions/Virtual-Assistant/src/typescript/rush.json
@@ -14,6 +14,7 @@
       "projectFolder": "bot-solution"
     },
     {
+      "packageName": "bot-skill",
       "projectFolder": "bot-skill"
     },
     {

--- a/solutions/Virtual-Assistant/src/typescript/rush.json
+++ b/solutions/Virtual-Assistant/src/typescript/rush.json
@@ -14,6 +14,9 @@
       "projectFolder": "bot-solution"
     },
     {
+      "projectFolder": "bot-skill"
+    },
+    {
       "packageName": "sampleSkill",
       "projectFolder": "skills/sampleSkill"
     }

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/.env.development
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/.env.development
@@ -1,5 +1,5 @@
-# Environment variables for devs
-ENDPOINT=development
+# Environment variables for deployment
+ENDPOINT=production
 
 BOT_FILE_NAME=<your-bot-file-name>
 BOT_FILE_SECRET=<your-bot-secret>

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/.env.development
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/.env.development
@@ -1,5 +1,5 @@
-# Environment variables for deployment
-ENDPOINT=production
+# Environment variables for devs
+ENDPOINT=development
 
 BOT_FILE_NAME=<your-bot-file-name>
 BOT_FILE_SECRET=<your-bot-secret>

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/package.json
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "clean": "rimraf ./lib",
         "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
-        "prebuild": "npm run lint",
+        "pre-build": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "postinstall": "npm run build",
         "lint": "tslint -t vso ./src/**/*.ts",
@@ -19,6 +19,7 @@
     "dependencies": {
         "applicationinsights": "^1.0.4",
         "bot-solution": "^1.0.0",
+        "bot-skill": "^1.0.0",
         "botbuilder": "^4.2.1",
         "botbuilder-ai": "^4.2.1",
         "botbuilder-azure": "4.2.1",

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/dialogs/main/mainDialog.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
+import { SkillAdapter } from 'bot-skill';
 import {
     ActivityExtensions,
     InterruptionAction,
@@ -9,7 +10,6 @@ import {
     ResponseManager,
     RouterDialog,
     SkillConfigurationBase } from 'bot-solution';
-import { SkillAdapter } from 'bot-skill';
 import {
     Activity,
     ActivityTypes,

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/dialogs/main/mainDialog.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/dialogs/main/mainDialog.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
+import { SkillAdapter } from 'bot-skill';
 import {
     ActivityExtensions,
     InterruptionAction,
@@ -41,26 +42,23 @@ import { ISampleSkillUserState } from '../../sampleSkillUserState';
  * Here is the description of the MainDialog's functionality
  */
 export class MainDialog extends RouterDialog {
-    private skillMode: boolean;
-    private services: SkillConfigurationBase;
-    private responseManager: ResponseManager;
-    private userState: UserState;
-    private conversationState: ConversationState;
-    private serviceManager: IServiceManager;
-    private conversationStateAccessor: StatePropertyAccessor<ISampleSkillConversationState>;
-    private userStateAccessor: StatePropertyAccessor<ISampleSkillUserState>;
-    private generalLUISName: string = 'general';
-    private projectName: string = 'sample';
+    private readonly services: SkillConfigurationBase;
+    private readonly responseManager: ResponseManager;
+    private readonly userState: UserState;
+    private readonly conversationState: ConversationState;
+    private readonly serviceManager: IServiceManager;
+    private readonly conversationStateAccessor: StatePropertyAccessor<ISampleSkillConversationState>;
+    private readonly userStateAccessor: StatePropertyAccessor<ISampleSkillUserState>;
+    private readonly generalLUISName: string = 'general';
+    private readonly projectName: string = 'sample';
     constructor(
         services: SkillConfigurationBase,
         responseManager: ResponseManager,
         conversationState: ConversationState,
         userState: UserState,
         telemetryClient: BotTelemetryClient,
-        serviceManager: IServiceManager,
-        skillMode: boolean) {
+        serviceManager: IServiceManager) {
             super(MainDialog.name, telemetryClient);
-            this.skillMode = skillMode;
             this.services = services;
             this.responseManager = responseManager;
             this.conversationState = conversationState;
@@ -76,7 +74,7 @@ export class MainDialog extends RouterDialog {
     }
 
     protected async onStart(dc: DialogContext): Promise<void> {
-        if (!this.skillMode) {
+        if (!SkillAdapter.isSkillMode(dc)){
             // send a greeting if we're in local mode
             await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.welcomeMessage));
         }
@@ -108,7 +106,7 @@ export class MainDialog extends RouterDialog {
                     case 'None': {
                         // No intent was identified, send confused message
                         await dc.context.sendActivity(this.responseManager.getResponse(SharedResponses.didntUnderstandMessage));
-                        if (this.skillMode) {
+                        if (!SkillAdapter.isSkillMode(dc)) {
                             turnResult = {
                                 status: DialogTurnStatus.complete
                             };
@@ -119,7 +117,7 @@ export class MainDialog extends RouterDialog {
                     default: {
                         // intent was identified but not yet implemented
                         await dc.context.sendActivity(this.responseManager.getResponse(MainResponses.featureNotAvailable));
-                        if (this.skillMode) {
+                        if (!SkillAdapter.isSkillMode(dc)) {
                             turnResult = {
                                 status: DialogTurnStatus.complete
                             };
@@ -135,7 +133,7 @@ export class MainDialog extends RouterDialog {
     }
 
     protected async complete(dc: DialogContext, result?: DialogTurnResult): Promise<void> {
-        if (this.skillMode) {
+        if (!SkillAdapter.isSkillMode(dc)) {
             const response: Activity = ActivityExtensions.createReply(dc.context.activity);
             response.type = ActivityTypes.EndOfConversation;
 

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
@@ -241,7 +241,6 @@ try {
         conversationState,
         userState,
         telemetryClient,
-        true,
         responseManager,
         new ServiceManager());
 } catch (err) {

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { TelemetryClient } from 'applicationinsights';
+import * as botSkill from 'bot-skill';
 import {
     ActivityExtensions,
     EventDebuggerMiddleware,
@@ -16,7 +17,6 @@ import {
     SkillDefinition,
     TelemetryExtensions
 } from 'bot-solution';
-import { SkillAdapter } from "bot-skill";
 import {
     AutoSaveStateMiddleware,
     BotFrameworkAdapter,

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
@@ -166,8 +166,8 @@ if (!cosmosConfig) {
 }
 
 // create conversation and user state
-const conversationState: ConversationState = new ConversationState(storage);
-const userState: UserState = new UserState(storage);
+const conversationState: ConversationState = new ConversationState(storage, 'sampleSkill');
+const userState: UserState = new UserState(storage, 'sampleSkill');
 const proactiveState: ProactiveState = new ProactiveState(storage);
 
 // Use the AutoSaveStateMiddleware middleware to automatically read and write conversation and user state.
@@ -241,7 +241,7 @@ try {
         conversationState,
         userState,
         telemetryClient,
-        false,
+        true,
         responseManager,
         new ServiceManager());
 } catch (err) {
@@ -269,10 +269,11 @@ server.post('/api/messages', (req: restify.Request, res: restify.Response) => {
 });
 
 // Listen for incoming requests as a skill
-server.post('/api/skill/messages', (req: restify.Request, res: restify.Response) => {
+server.post('/api/skill/messages', async (req: restify.Request, res: restify.Response, next: restify.Next) => {
     // Route received a request to adapter for processing
-    skillAdapter.processActivity(req, res, async (turnContext: TurnContext) => {
+    await skillAdapter.processActivity(req, res, async (turnContext: TurnContext) => {
         // route to bot activity handler.
         await bot.onTurn(turnContext);
     });
+    await next();
 });

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { TelemetryClient } from 'applicationinsights';
+import { SkillAdapter } from 'bot-skill';
 import {
     ActivityExtensions,
     EventDebuggerMiddleware,
@@ -16,7 +17,6 @@ import {
     SkillDefinition,
     TelemetryExtensions
 } from 'bot-solution';
-import { SkillAdapter } from "bot-skill";
 import {
     AutoSaveStateMiddleware,
     BotFrameworkAdapter,

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/sampleSkill.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/sampleSkill.ts
@@ -23,18 +23,15 @@ export class SampleSkill {
     private readonly telemetryClient: BotTelemetryClient;
     private readonly serviceManager: IServiceManager;
     private dialogs: DialogSet;
-    private skillMode: boolean = false;
 
     constructor (
         services: SkillConfigurationBase,
         conversationState: ConversationState,
         userState: UserState,
         telemetryClient: BotTelemetryClient,
-        skillMode: boolean = false,
         responseManager: ResponseManager | undefined,
         serviceManager: IServiceManager | undefined) {
 
-        this.skillMode = skillMode;
         if (services === undefined) {
             throw new Error('services parameter is null');
         }
@@ -72,8 +69,7 @@ export class SampleSkill {
             this.conversationState,
             this.userState,
             this.telemetryClient,
-            this.serviceManager,
-            this.skillMode
+            this.serviceManager
              ));
         }
         /**

--- a/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/sampleSkill.ts
+++ b/solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/sampleSkill.ts
@@ -23,7 +23,6 @@ export class SampleSkill {
     private readonly telemetryClient: BotTelemetryClient;
     private readonly serviceManager: IServiceManager;
     private dialogs: DialogSet;
-    private skillMode: boolean = false;
 
     constructor (
         services: SkillConfigurationBase,
@@ -34,7 +33,6 @@ export class SampleSkill {
         responseManager: ResponseManager | undefined,
         serviceManager: IServiceManager | undefined) {
 
-        this.skillMode = skillMode;
         if (services === undefined) {
             throw new Error('services parameter is null');
         }
@@ -72,9 +70,8 @@ export class SampleSkill {
             this.conversationState,
             this.userState,
             this.telemetryClient,
-            this.serviceManager,
-            this.skillMode
-             ));
+            this.serviceManager
+            ));
         }
         /**
          * Run every turn of the conversation. Handles orchestration of messages.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
We implemented the first version of remote skill invocation and adapted the sampleSkill to be used remotely.

## Testing Steps
> Prerequisites: `.bot` file and `LocaleConfigurations/*.bot` files with the services needed for the assistant bot and the sampleSkill bot.

### Skill remote invocation
1. `npm install -g @microsoft/rush` to install the build tool.
1. Add `.bot` file path and secret to `./solutions/Virtual-Assistant/src/typescript/assistant/.env.development`.
1. Add `.bot` file path and secret to `./solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/.env.development`.
1. Add `LocaleConfigurations/*.bot` paths to `./solutions/Virtual-Assistant/src/typescript/assistant/src/languageModels.json`.
1. Add `LocaleConfigurations/*.bot` paths to `./solutions/Virtual-Assistant/src/typescript/skills/sampleSkill/src/languageModels.json`.
1. Open a terminal in `./solutions/Virtual-Assistant/src/typescript/`.
1. `rush update` to install dependencies and symlink packages.
1. `rush rebuild` to build the solution.
1. `rush start` to run the bot.
1. Open a second terminal in `./solutions/Virtual-Assistant/src/typescript/skills/sampleSkill`.
1. Run `npm run start` to run the sampleSkill bot.
1. Open the Bot Framework Emulator with the assistant `.bot` file.
1. Send `sample dialog` to trigger the `sample` intent and get redirected to the SampleSkill.

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [x] I have commented my code, particularly in hard-to-understand areas