### PR TITLE
Add SpeechUtility class to Microsoft.Bot.Builder.Solutions

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Bot.Schema;
+using Microsoft.Bot.Builder.Solutions.Responses;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AdaptiveCards;
+using System.Collections.Generic;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Solutions.Resources;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+
+namespace Microsoft.Bot.Builder.Solutions.Tests
+{
+    [TestClass]
+    public class SpeechUtilityTests
+    {
+        private Activity _activity;
+
+        private PromptOptions _promptOptions;
+
+        private string parentSpeakProperty = "Parent speak property";
+
+        private string listItemSpeakProperty = "List item speak property";
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _activity = new Activity() { Speak = parentSpeakProperty };
+            _promptOptions = new PromptOptions() { Prompt = new Activity() { Text = parentSpeakProperty, Speak = parentSpeakProperty } };
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromOnePromptOption()
+        {
+            _promptOptions.Choices = new List<Choice>()
+            {
+                new Choice(listItemSpeakProperty)
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_promptOptions);
+
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{listItemSpeakProperty}"));
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromTwoPromptOptionsChronological()
+        {
+            _promptOptions.Choices = new List<Choice>()
+            {
+                new Choice(listItemSpeakProperty),
+                new Choice(listItemSpeakProperty)
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_promptOptions, ReadPreference.Chronological);
+
+            var item1 = string.Format(CommonStrings.LatestItem, listItemSpeakProperty);
+            var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1} {CommonStrings.And} {item2}"));
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromActivityWithOneAttachment()
+        {
+            _activity.Attachments = new List<Attachment>
+            {
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName })
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_activity);
+
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{listItemSpeakProperty}"));
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromActivityWithTwoAttachments()
+        {
+            _activity.Attachments = new List<Attachment>
+            {
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName })
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_activity);
+
+            var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
+            var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1} {CommonStrings.And} {item2}"));
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromActivityWithThreeAttachments()
+        {
+            _activity.Attachments = new List<Attachment>
+            {
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName })
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_activity);
+
+            var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
+            var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
+            var item3 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1}, {item2} {CommonStrings.And} {item3}"));
+        }
+
+        [TestMethod]
+        public void GetSpeechReadyStringFromActivityWithFourAttachments()
+        {
+            _activity.Attachments = new List<Attachment>
+            {
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName }),
+                new Attachment(contentType: AdaptiveCard.ContentType, content: new AdaptiveCard() { Speak = listItemSpeakProperty, Type = AdaptiveCard.TypeName })
+            };
+
+            var response = SpeechUtility.ListToSpeechReadyString(_activity);
+
+            var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
+            var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
+            var item3 = string.Format(CommonStrings.ThirdItem, listItemSpeakProperty);
+            var item4 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1}, {item2}, {item3} {CommonStrings.And} {item4}"));
+        }
+    }
+}

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.Designer.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.Designer.cs
@@ -151,11 +151,38 @@ namespace Microsoft.Bot.Builder.Solutions.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The latest email is {0}.
+        ///   Looks up a localized string similar to The first is {0}.
         /// </summary>
         public static string FirstItem {
             get {
                 return ResourceManager.GetString("FirstItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to the fourth is {0}.
+        /// </summary>
+        public static string FourthItem {
+            get {
+                return ResourceManager.GetString("FourthItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to the last is {0}..
+        /// </summary>
+        public static string LastItem {
+            get {
+                return ResourceManager.GetString("LastItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The latest is {0}.
+        /// </summary>
+        public static string LatestItem {
+            get {
+                return ResourceManager.GetString("LatestItem", resourceCulture);
             }
         }
         

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.de.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.de.resx
@@ -222,4 +222,13 @@
   <data name="LoginDescription" xml:space="preserve">
     <value>Bitte melden Sie sich mit Ihrem {0} Konto an</value>
   </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>der vierte ist {0};</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>das späteste ist {0};</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>das jüngste ist {0};</value>
+  </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.es.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.es.resx
@@ -222,4 +222,13 @@
   <data name="LoginDescription" xml:space="preserve">
     <value>Por favor ingrese con su cuenta {0}</value>
   </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>el cuarto es {0};</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>el ultimo es {0};</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>el reciente es {0};</value>
+  </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.fr.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.fr.resx
@@ -225,4 +225,13 @@
   <data name="LoginDescription" xml:space="preserve">
     <value>Veuillez vous connecter avec votre compte {0}</value>
   </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>le quatrième est {0};</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>le dernier est {0};</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>le dernier est {0};</value>
+  </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.it.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.it.resx
@@ -222,4 +222,13 @@
   <data name="LoginDescription" xml:space="preserve">
     <value>Effettua il login con il tuo account {0}</value>
   </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>il quarto è {0};</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>l'ultimo è {0};</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>Il recente è {0};</value>
+  </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.resx
@@ -123,8 +123,14 @@
   <data name="At" xml:space="preserve">
     <value>at</value>
   </data>
+  <data name="AttendeesSummary" xml:space="preserve">
+    <value>+ {0} others</value>
+  </data>
   <data name="AtTimeDetailsFormat" xml:space="preserve">
     <value>{0} at {1}</value>
+  </data>
+  <data name="DateWithAllDay" xml:space="preserve">
+    <value>{0} all day</value>
   </data>
   <data name="DaysFormat" xml:space="preserve">
     <value>{0} days ago</value>
@@ -135,8 +141,32 @@
   <data name="DisplayDateFormat_CurrentYear" xml:space="preserve">
     <value>MMM d</value>
   </data>
+  <data name="DisplayFullDateFormat" xml:space="preserve">
+    <value>dd-MM-yyyy</value>
+  </data>
   <data name="DisplayTime" xml:space="preserve">
     <value>h:mm tt</value>
+  </data>
+  <data name="FirstItem" xml:space="preserve">
+    <value>The first is {0}</value>
+  </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>the fourth is {0}</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>the last is {0}.</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>The latest is {0}</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="LoginDescription" xml:space="preserve">
+    <value>Please login with your {0} account</value>
+  </data>
+  <data name="More" xml:space="preserve">
+    <value>more</value>
   </data>
   <data name="NotAvailable" xml:space="preserve">
     <value>Not available</value>
@@ -149,6 +179,9 @@
   </data>
   <data name="RecipientsSummary" xml:space="preserve">
     <value> + {0} more</value>
+  </data>
+  <data name="SecondItem" xml:space="preserve">
+    <value>the second is {0}</value>
   </data>
   <data name="SeparatorFormat" xml:space="preserve">
     <value> {0} </value>
@@ -165,20 +198,8 @@
   <data name="SpokenTimePrefix_One" xml:space="preserve">
     <value>at</value>
   </data>
-  <data name="Today" xml:space="preserve">
-    <value>Today</value>
-  </data>
-  <data name="Tomorrow" xml:space="preserve">
-    <value>Tomorrow</value>
-  </data>
-  <data name="Yesterday" xml:space="preserve">
-    <value>Yesterday</value>
-  </data>
-  <data name="AttendeesSummary" xml:space="preserve">
-    <value>+ {0} others</value>
-  </data>
-  <data name="DateWithAllDay" xml:space="preserve">
-    <value>{0} all day</value>
+  <data name="ThirdItem" xml:space="preserve">
+    <value>the third is {0}</value>
   </data>
   <data name="TimeFormatDay" xml:space="preserve">
     <value>{0} day</value>
@@ -201,25 +222,13 @@
   <data name="TimeFormatMinutes" xml:space="preserve">
     <value>{0} minutes</value>
   </data>
-  <data name="DisplayFullDateFormat" xml:space="preserve">
-    <value>dd-MM-yyyy</value>
+  <data name="Today" xml:space="preserve">
+    <value>Today</value>
   </data>
-  <data name="FirstItem" xml:space="preserve">
-    <value>The latest email is {0}</value>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>Tomorrow</value>
   </data>
-  <data name="More" xml:space="preserve">
-    <value>more</value>
-  </data>
-  <data name="SecondItem" xml:space="preserve">
-    <value>the second is {0}</value>
-  </data>
-  <data name="ThirdItem" xml:space="preserve">
-    <value>the third is {0}</value>
-  </data>
-  <data name="Login" xml:space="preserve">
-    <value>Login</value>
-  </data>
-  <data name="LoginDescription" xml:space="preserve">
-    <value>Please login with your {0} account</value>
+  <data name="Yesterday" xml:space="preserve">
+    <value>Yesterday</value>
   </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.zh.resx
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Resources/CommonStrings.zh.resx
@@ -222,4 +222,13 @@
   <data name="LoginDescription" xml:space="preserve">
     <value>请登陆您的{0}账户</value>
   </data>
+  <data name="FourthItem" xml:space="preserve">
+    <value>第四是{0};</value>
+  </data>
+  <data name="LastItem" xml:space="preserve">
+    <value>最后是{0};</value>
+  </data>
+  <data name="LatestItem" xml:space="preserve">
+    <value>最新的是{0};</value>
+  </data>
 </root>

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Solutions.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using AdaptiveCards;
+    using Microsoft.Bot.Builder.Dialogs;
+    using Microsoft.Bot.Builder.Solutions.Extensions;
+    using Microsoft.Bot.Builder.Solutions.Resources;
+    using Microsoft.Bot.Schema;
+
+    /// <summary>
+    /// Read order of list items.
+    /// </summary>
+    public enum ReadPreference
+    {
+        /// <summary>First item, second item, third item, etc.</summary>
+        Enumeration,
+
+        /// <summary>Latest item, second item, third item, etc.</summary>
+        Chronological
+    }
+
+    public class SpeechUtility
+    {
+        public const string BreakString = "<break/>";
+
+        /// <summary>
+        /// Concatenate PromptOption string properties into a formatted speech-ready string.
+        /// </summary>
+        /// <param name="selectOption">Prompt options.</param>
+        /// <param name="readOrder">Read order of list items.</param>
+        /// <param name="maxSize">The max read size, default is 4.</param>
+        /// <returns>Formatted speech-ready string.</returns>
+        public static string ListToSpeechReadyString(PromptOptions selectOption, ReadPreference readOrder = ReadPreference.Enumeration, int maxSize = 4)
+        {
+            List<string> selectOptionSpeakStrings = new List<string>();
+
+            for (int i = 0; i < selectOption.Choices.Count; ++i)
+            {
+                selectOptionSpeakStrings.Add(selectOption.Choices[i].Value);
+            }
+
+            return ListToSpeechReadyString(selectOption.Prompt.Text, selectOptionSpeakStrings, readOrder, maxSize);
+        }
+
+        /// <summary>
+        /// Concatenate Activity string properties into a formatted speech-ready string.
+        /// </summary>
+        /// <param name="activityToProcess">Activity.</param>
+        /// <param name="readOrder">Read order of list items.</param>
+        /// <param name="maxSize">The max read size, default is 4.</param>
+        /// <returns>Formatted speech-ready string.</returns>
+        public static string ListToSpeechReadyString(Activity activityToProcess, ReadPreference readOrder = ReadPreference.Enumeration, int maxSize = 4)
+        {
+            List<string> selectOptionSpeakStrings = new List<string>();
+
+            for (int i = 0; i < activityToProcess.Attachments.Count; ++i)
+            {
+                // Card attachments may be formatted as card or generic objects
+                if (activityToProcess.Attachments[i].Content is AdaptiveCard)
+                {
+                    dynamic cardContent = activityToProcess.Attachments[i].Content;
+                    if (!string.IsNullOrEmpty(cardContent?.Speak))
+                    {
+                        selectOptionSpeakStrings.Add(cardContent.Speak);
+                    }
+                }
+                else
+                {
+                    dynamic cardContent = activityToProcess.Attachments[i].Content;
+                    if (cardContent?.speak != null)
+                    {
+                        selectOptionSpeakStrings.Add(cardContent.speak.ToString());
+                    }
+                }
+            }
+
+            return ListToSpeechReadyString(activityToProcess.Speak, selectOptionSpeakStrings, readOrder, maxSize);
+        }
+
+        /// <summary>
+        /// Concatenate strings into a formatted speech-ready string.
+        /// </summary>
+        /// <param name="parentString">Itroduction string.</param>
+        /// <param name="selectionStrings">List item strings.</param>
+        /// <param name="readOrder">Read order of list items.</param>
+        /// <param name="maxSize">The max read size.</param>
+        /// <returns>Formatted speech-ready string.</returns>
+        private static string ListToSpeechReadyString(string parentString, List<string> selectionStrings, ReadPreference readOrder, int maxSize)
+        {
+            var result = string.Empty;
+            if (!string.IsNullOrEmpty(parentString))
+            {
+                result += parentString + BreakString;
+            }
+
+            List<string> itemDetails = new List<string>();
+
+            int readSize = Math.Min(selectionStrings.Count, maxSize);
+            if (readSize == 1)
+            {
+                itemDetails.Add(selectionStrings[0]);
+            }
+            else
+            {
+                for (var i = 0; i < readSize; i++)
+                {
+                    var readFormat = string.Empty;
+
+                    if (i == 0)
+                    {
+                        if (readOrder.Equals(ReadPreference.Chronological))
+                        {
+                            readFormat = CommonStrings.LatestItem;
+                        }
+                        else
+                        {
+                            readFormat = CommonStrings.FirstItem;
+                        }
+                    }
+                    else
+                    {
+                        if (i == readSize - 1)
+                        {
+                            readFormat = CommonStrings.LastItem;
+                        }
+                        else
+                        {
+                            if (i == 1)
+                            {
+                                readFormat = CommonStrings.SecondItem;
+                            }
+                            else if (i == 2)
+                            {
+                                readFormat = CommonStrings.ThirdItem;
+                            }
+                            else if (i == 3)
+                            {
+                                readFormat = CommonStrings.FourthItem;
+                            }
+                        }
+                    }
+
+                    var selectionDetail = string.Format(readFormat, selectionStrings[i]);
+                    itemDetails.Add(selectionDetail);
+                }
+            }
+
+            result += itemDetails.ToSpeechString(CommonStrings.And);
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Maintenance
#1013 added `SpeechUtility` class that accounts for speech helper variants used by individual skills. This takes in an input of `PromptOptions` or `Activity` and splits the strings to concatenate a parent text property with the childrens appended to it. Users may pass in optional parameters:
* ReadPreference
    * Chronological: latest, second, third, last
    * Numerical: first. second, third, last
* ReadSize
    * Integer of how many items should be read out loud.
    * Default is 4 max.

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the appropriate unit tests
- [X] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly.
<!--- If you have updated responses or `.lu` files:-->
- [X] All languages have been updated
