### PR TITLE
[Solutions] Enable neutral culture resource to persist when looping through localized responses

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/ResponseManager.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/ResponseManager.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Bot.Builder.Solutions.Responses
                 {
                     try
                     {
-                        resourceAssembly = resourceAssembly.GetSatelliteAssembly(new CultureInfo(locale));
-                        LoadResponses(resourceName, resourceAssembly, locale);
+                        var localizedResourceAssembly = resourceAssembly.GetSatelliteAssembly(new CultureInfo(locale));
+                        LoadResponses(resourceName, localizedResourceAssembly, locale);
                     }
                     catch
                     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Bug Fix
#1060: When looping through a VA's locales, it will pick the first satellite assembly available.
Previously, this overwrite the assembly where `culture=neutral` and thus all future references defaulted to English. This caused the `de-de` resource to load correctly, but lookups for additional locales were based off of `de-de` rather than `neutral`.
Now it will only look at the localized resource off of `culture=neutral` and find the correct responses per locale.

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->
Test the VA introduction with locales `de-de`, `fr-fr`, `it-it`, `zh-cn`, `en-us` and validate the correct card is displayed.