### PR TITLE
MainDialog and SkillRouter Fix

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
@@ -96,6 +96,23 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             }
         }
 
+        [TestMethod()]
+        public async Task TestIsSkillHelper()
+        {
+            using (StreamReader sr = new StreamReader(@".\manifestTemplate.json"))
+            {
+                string manifestBody = await sr.ReadToEndAsync();
+                var skillManifest = JsonConvert.DeserializeObject<SkillManifest>(manifestBody);
+
+                List<SkillManifest> skillManifests = new List<SkillManifest>();
+                skillManifests.Add(skillManifest);
+
+                Assert.IsNotNull(SkillRouter.IsSkill(skillManifests, "calendarSkill/createEvent"));
+                Assert.IsNotNull(SkillRouter.IsSkill(skillManifests, "calendarSkill/updateEvent"));
+                Assert.IsNull(SkillRouter.IsSkill(skillManifests, "calendarSkill/MISSINGEVENT"));
+            }
+        }
+
         /// <summary>
         /// Test that a manifest is generated and the basic dynamic properties are changed.
         /// </summary>

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillRouter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillRouter.cs
@@ -4,32 +4,20 @@ using Microsoft.Bot.Builder.Skills.Models.Manifest;
 
 namespace Microsoft.Bot.Builder.Skills
 {
-    public class SkillRouter
+    /// <summary>
+    /// Skill Router class that helps Bots identify if a registered Skill matches the identified dispatch intent.
+    /// </summary>
+    public static class SkillRouter
     {
-        private List<SkillManifest> _registeredSkills;
-
-        public SkillRouter(List<SkillManifest> registeredSkills)
+        /// <summary>
+        /// Helper method to go through a SkillManifeste and match the passed dispatch intent to a registered action.
+        /// </summary>
+        /// <param name="skillConfiguration">The Skill Configuration for the current Bot.</param>
+        /// <param name="dispatchIntent">The Dispatch intent to try and match to a skill.</param>
+        /// <returns>Whether the intent matches a Skill.</returns>
+        public static SkillManifest IsSkill(List<SkillManifest> skillConfiguration, string dispatchIntent)
         {
-            // Retrieve any Skills that have been registered with the Bot
-            _registeredSkills = registeredSkills;
-        }
-
-        public SkillManifest IdentifyRegisteredSkill(string skillName)
-        {
-            SkillManifest matchedSkill = null;
-
-            // Did we find any skills?
-            if (_registeredSkills != null)
-            {
-                // Identify a skill by taking the LUIS model name identified by the dispatcher and matching to the skill luis model name
-                // Bug raised on dispatcher to move towards LuisModelId instead perhaps?
-                matchedSkill = _registeredSkills.FirstOrDefault(s => s.Name == skillName);
-                return matchedSkill;
-            }
-            else
-            {
-                return null;
-            }
+            return skillConfiguration.SingleOrDefault(s => s.Actions.Any(a => a.Id == dispatchIntent.ToString()));
         }
     }
 }

--- a/templates/Virtual-Assistant-Template/src/csharp/VirtualAssistantTemplate/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/src/csharp/VirtualAssistantTemplate/Dialogs/MainDialog.cs
@@ -109,12 +109,14 @@ namespace VirtualAssistantTemplate.Dialogs
             var dispatchResult = await cognitiveModels.DispatchService.RecognizeAsync<DispatchLuis>(dc.Context, CancellationToken.None);
             var intent = dispatchResult.TopIntent().intent;
 
-            if (_settings.Skills.Any(s => s.Id == intent.ToString()))
-            {
-                var skill = _settings.Skills.Where(s => s.Id == intent.ToString()).First();
+            // Identify if the dispatch intent matches any Action within a Skill if so, we pass to the appropriate SkillDialog to hand-off
+            var identifiedSkill = SkillRouter.IsSkill(_settings.Skills, intent.ToString());
 
-                // Initialize the skill connection, the dispatch intent is the Action ID of the Skill enabling us to resolve the specific action and identify slots
-                await dc.BeginDialogAsync(skill.Id, intent);
+            if(identifiedSkill != null)
+            {
+                // We have identiifed a skill so initialize the skill connection with the target skill 
+                // the dispatch intent is the Action ID of the Skill enabling us to resolve the specific action and identify slots
+                await dc.BeginDialogAsync(identifiedSkill.Id, intent);
 
                 // Pass the activity we have
                 var result = await dc.ContinueDialogAsync();


### PR DESCRIPTION

- Spotted issue with MainDialog not being able to match dispatchIntent to Skill after recent changes
- Moved logic out of MainDialog to SkillRouter in Skills library
- MainDialog passes Skills configuration and dispatch intent to above method and is told which skill if any it matches, MainDialog then calls BeginDialog
- Manifest tests updated to test above
- Updated MainDialog 
