### PR TITLE
Add productivity skill project references back

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
+++ b/solutions/Virtual-Assistant/src/csharp/assistant/VirtualAssistant.csproj
@@ -58,6 +58,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\skills\calendarskill\calendarskill\CalendarSkill.csproj" />
+    <ProjectReference Include="..\skills\emailskill\emailskill\EmailSkill.csproj" />
+    <ProjectReference Include="..\skills\pointofinterestskill\pointofinterestskill\PointOfInterestSkill.csproj" />
+    <ProjectReference Include="..\skills\todoskill\todoskill\ToDoSkill.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Dialogs\Main\Resources\MainDialogResponses.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
- Productivity and PoI Skills were removed from the csproj previously? Project bulds but at runtime it fails to activate the Skill as it cannot find the endpoint. Adding them back in