### PR TITLE
Implement dependency injection for Dialogs in Enterprise Bot Template

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Bot.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Bot.cs
@@ -18,8 +18,6 @@ namespace $safeprojectname$
     {
         private readonly BotServices _services;
         private readonly ConversationState _conversationState;
-        private readonly UserState _userState;
-        private readonly IBotTelemetryClient _telemetryClient;
         private DialogSet _dialogs;
 
         /// <summary>
@@ -28,15 +26,14 @@ namespace $safeprojectname$
         /// <param name="botServices">Bot services.</param>
         /// <param name="conversationState">Bot conversation state.</param>
         /// <param name="userState">Bot user state.</param>
-        public Bot(BotServices botServices, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient)
+        public Bot(BotServices botServices, ConversationState conversationState, IBotTelemetryClient telemetryClient
+            , MainDialog mainDialog)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
-            _userState = userState ?? throw new ArgumentNullException(nameof(userState));
             _services = botServices ?? throw new ArgumentNullException(nameof(botServices));
-            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
             _dialogs = new DialogSet(_conversationState.CreateProperty<DialogState>(nameof($safeprojectname$)));
-            _dialogs.Add(new MainDialog(_services, _conversationState, _userState, _telemetryClient));
+            _dialogs.Add(mainDialog);
         }
 
         /// <summary>

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Main/MainDialog.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Main/MainDialog.cs
@@ -17,20 +17,17 @@ namespace $safeprojectname$.Dialogs.Main
     public class MainDialog : RouterDialog
     {
         private BotServices _services;
-        private UserState _userState;
-        private ConversationState _conversationState;
         private MainResponses _responder = new MainResponses();
 
-        public MainDialog(BotServices services, ConversationState conversationState, UserState userState, IBotTelemetryClient telemetryClient)
+        public MainDialog(BotServices services, IBotTelemetryClient telemetryClient,
+            OnboardingDialog onboardingDialog, EscalateDialog escalateDialog)
             : base(nameof(MainDialog))
         {
             _services = services ?? throw new ArgumentNullException(nameof(services));
-            _conversationState = conversationState;
-            _userState = userState;
             TelemetryClient = telemetryClient;
 
-            AddDialog(new OnboardingDialog(_services, _userState.CreateProperty<OnboardingState>(nameof(OnboardingState)), telemetryClient));
-            AddDialog(new EscalateDialog(_services));
+            AddDialog(onboardingDialog);
+            AddDialog(escalateDialog);
         }
 
         protected override async Task OnStartAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Onboarding/OnboardingDialog.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Dialogs/Onboarding/OnboardingDialog.cs
@@ -16,10 +16,10 @@ namespace $safeprojectname$.Dialogs.Onboarding
         private IStatePropertyAccessor<OnboardingState> _accessor;
         private OnboardingState _state;
 
-        public OnboardingDialog(BotServices botServices, IStatePropertyAccessor<OnboardingState> accessor, IBotTelemetryClient telemetryClient)
+        public OnboardingDialog(BotServices botServices, UserState userState, IBotTelemetryClient telemetryClient)
             : base(botServices, nameof(OnboardingDialog))
         {
-            _accessor = accessor;
+            _accessor = userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
             InitialDialogId = nameof(OnboardingDialog);
 
             var onboarding = new WaterfallStep[]

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Startup.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Startup.cs
@@ -78,6 +78,8 @@ namespace $safeprojectname$
             services.AddSingleton(conversationState);
             services.AddSingleton(new BotStateSet(userState, conversationState));
 
+            RegisterDialogs(services);
+
             // Add the bot with options
             services.AddBot<Bot>(options =>
             {
@@ -139,6 +141,17 @@ namespace $safeprojectname$
                 .UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
+        }
+
+        /// <summary>
+        /// Register dialogs with Dependency Injection
+        /// </summary>
+        /// <param name="services"></param>
+        private void RegisterDialogs(IServiceCollection services)
+        {
+            services.AddTransient<Dialogs.Main.MainDialog>();
+            services.AddTransient<Dialogs.Escalate.EscalateDialog>();
+            services.AddTransient<Dialogs.Onboarding.OnboardingDialog>();
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
There has been a lot of talk and wishes for improvement around dependency injection of Dialogs.
- https://github.com/Microsoft/botbuilder-dotnet/issues/860
- https://github.com/Microsoft/botbuilder-dotnet/issues/357
- https://github.com/Microsoft/botbuilder-dotnet/issues/1188
- https://stackoverflow.com/questions/52549850/how-do-you-do-dependency-injection-in-a-class-that-inherits-dialogcontainer-bot

I believe Enterprise Bot Template should set a good example. I'm trying to do that with this PR without changes to the bot framework.

### Architecture
This PR builds the existing ASP.Net Core DI code and follows the approach from https://github.com/Microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/42.scaleout/Startup.cs

- Dialogs are registered in a separate method `RegisterDialogs` in `Startup.cs`
- The `MainDialog` is injected in `Bot`
- Redundant constructor parameters are removed:
  - Some dialogs do not need `UserState` or `ConversationState` anymore
  - UserState and ConversationState can be injected directly because they are registered
  - `OnboardingDialog` generate its own state accessor based on the injected `UserState`

## Testing Steps
Run the bot as before

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.
