### PR TITLE
Fixed bug with Locale Middleware

### DIFF
--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/EnterpriseBotSample/Middleware/SetLocaleMiddleware.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/EnterpriseBotSample/Middleware/SetLocaleMiddleware.cs
@@ -16,7 +16,7 @@ namespace EnterpriseBotSample.Middleware
 
         public async Task OnTurnAsync(ITurnContext context, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var cultureInfo = context.Activity.Locale != null ? new CultureInfo(context.Activity.Locale) : new CultureInfo(defaultLocale);
+            var cultureInfo = !string.IsNullOrWhiteSpace(context.Activity.Locale) ? new CultureInfo(context.Activity.Locale) : new CultureInfo(defaultLocale);
 
             CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture = cultureInfo;
 

--- a/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Middleware/SetLocaleMiddleware.cs
+++ b/templates/Enterprise-Template/src/csharp/EnterpriseBotTemplate/EnterpriseTemplate/Middleware/SetLocaleMiddleware.cs
@@ -19,7 +19,7 @@ namespace $safeprojectname$.Middleware
 
         public async Task OnTurnAsync(ITurnContext context, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var cultureInfo = context.Activity.Locale != null ? new CultureInfo(context.Activity.Locale) : new CultureInfo(defaultLocale);
+            var cultureInfo = !string.IsNullOrWhiteSpace(context.Activity.Locale) ? new CultureInfo(context.Activity.Locale) : new CultureInfo(defaultLocale);
 
             CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture = cultureInfo;
 


### PR DESCRIPTION
## Description

Even if you didn't define the locale middleware, the condition would always be true since the context.Activity.Locale returned string.empty and not null.
This PR fixes the issue.

### Bug Fixes
Locale not getting caught correctly. Should I open an issue before?

## Testing Steps
Define a defaultLocale in appsettings and define some utterances for that locale and run the bot.

## Checklist
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.
