### PR TITLE
[4.4]fix token response issue where it's not getting to the skill properly

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/ISkillTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/ISkillTransport.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Bot.Builder.Skills
 {
     public interface ISkillTransport
     {
-        Task<bool> ForwardToSkillAsync(ITurnContext dialogContext, Activity activity, Func<Activity, Activity> tokenRequestHandler = null);
+        Task<bool> ForwardToSkillAsync(ITurnContext dialogContext, Activity activity, Action<Activity> tokenRequestHandler = null);
 
         Task CancelRemoteDialogsAsync(ITurnContext turnContext);
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillHttpTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillHttpTransport.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Skills
             // doesn't have to do any disconnect for http
         }
 
-        public async Task<bool> ForwardToSkillAsync(ITurnContext dialogContext, Activity activity, Func<Activity, Activity> tokenRequestHandler = null)
+        public async Task<bool> ForwardToSkillAsync(ITurnContext dialogContext, Activity activity, Action<Activity> tokenRequestHandler = null)
         {
             // Serialize the activity and POST to the Skill endpoint
             var httpRequest = new HttpRequestMessage();
@@ -83,11 +83,7 @@ namespace Microsoft.Bot.Builder.Skills
                     {
                         if (tokenRequestHandler != null)
                         {
-                            var tokenResponseActivity = tokenRequestHandler(skillResponse);
-                            if (tokenResponseActivity != null)
-                            {
-                                return await ForwardToSkillAsync(dialogContext, tokenResponseActivity);
-                            }
+                            tokenRequestHandler(skillResponse);
                         }
                     }
                     else

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Skills
             _microsoftAppCredentialsEx = microsoftAppCredentialsEx ?? throw new ArgumentNullException(nameof(microsoftAppCredentialsEx));
         }
 
-        public async Task<bool> ForwardToSkillAsync(ITurnContext turnContext, Activity activity, Func<Activity, Activity> tokenRequestHandler = null)
+        public async Task<bool> ForwardToSkillAsync(ITurnContext turnContext, Activity activity, Action<Activity> tokenRequestHandler = null)
         {
             if (_webSocketClient == null)
             {
@@ -77,18 +77,13 @@ namespace Microsoft.Bot.Builder.Skills
             }
         }
 
-        private Action<Activity> GetTokenCallback(ITurnContext turnContext, Func<Activity, Activity> tokenRequestHandler)
+        private Action<Activity> GetTokenCallback(ITurnContext turnContext, Action<Activity> tokenRequestHandler)
         {
-            return async (activity) =>
+            return (activity) =>
             {
                 if (tokenRequestHandler != null)
                 {
-                    var tokenResponseActivity = tokenRequestHandler(activity);
-
-                    if (tokenResponseActivity != null)
-                    {
-                        await ForwardToSkillAsync(turnContext, tokenResponseActivity);
-                    }
+                    tokenRequestHandler(activity);
                 }
             };
         }


### PR DESCRIPTION
… if no auth dialog needed

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

For the case when token service can return user's token immediately instead of having to launch a dialog, it's not being sent to the skill properly so that the skill will terminate the dialog when it gets the token response. This PR fixes that issue by queuing the responses and send them again after all responses are processed, to start a new turn.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
