### PR TITLE
[Virtual Assistant Template][TypeScript] Fix ESLint errors

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
@@ -19,31 +19,38 @@ let assistantGenerationPath = process.cwd();
 let isAlreadyCreated = false;
 let copier;
 
-const languagesChoice = [{
-    name: 'Chinese',
-    value: 'zh',
+const languagesChoice = [
+  {
+    name: "Chinese",
+    value: "zh",
     checked: true
-    },{
-    name: 'Deutsch',
-    value: 'de',
+  },
+  {
+    name: "Deutsch",
+    value: "de",
     checked: true
-  },{
-    name: 'English',
-    value: 'en',
+  },
+  {
+    name: "English",
+    value: "en",
     checked: true
-  },{
-    name: 'French',
-    value: 'fr',
+  },
+  {
+    name: "French",
+    value: "fr",
     checked: true
-  },{
-    name: 'Italian',
-    value: 'it',
+  },
+  {
+    name: "Italian",
+    value: "it",
     checked: true
-  },{
-    name: 'Spanish',
-    value: 'es',
+  },
+  {
+    name: "Spanish",
+    value: "es",
     checked: true
-  }];
+  }
+];
 
 const bigBot =
   `               ╭─────────────────────────────────╮\n` +
@@ -117,14 +124,19 @@ module.exports = class extends Generator {
     this.log(bigBot);
     // Validate language option
     if (this.options.assistantLang) {
-        this.options.assistantLang = this.options.assistantLang.replace(/\s/g, "").split(','); 
-        if(!this.options.assistantLang.every(language => {
+      this.options.assistantLang = this.options.assistantLang
+        .replace(/\s/g, "")
+        .split(",");
+      if (
+        !this.options.assistantLang.every(language => {
           return languages.includes(language);
-        })){
-          this.log.error(
-            "ERROR: One of the languages is not recognized, please check your language value\n\t");
-          process.exit(1);      
-        }
+        })
+      ) {
+        this.log.error(
+          "ERROR: One of the languages is not recognized, please check your language value\n\t"
+        );
+        process.exit(1);
+      }
     } else {
       this.log.error(
         "ERROR: Language must be selected from the list:\n\t" +
@@ -154,9 +166,9 @@ module.exports = class extends Generator {
       },
       // Language of the assistant
       {
-        type: 'checkbox',
-        name: 'assistantLang',
-        message: 'Which languages will your assistant use?',
+        type: "checkbox",
+        name: "assistantLang",
+        message: "Which languages will your assistant use?",
         choices: languagesChoice
       },
       // Path of the assistant

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
@@ -6,7 +6,6 @@
 const path = require(`path`);
 const templateFiles = new Map();
 const allLanguages = [`zh`, `de`, `en`, `fr`, `it`, `es`];
-let selectedLanguages = [];
 let ignoredLanguages = [];
 
 class Copier {
@@ -42,25 +41,27 @@ class Copier {
 
   selectLanguages(languages) {
     // Take all the languages that will be ignored
-    ignoredLanguages = allLanguages.filter(language => {
-      return !languages.includes(language)
-    }).map(language => {
-      return this.pathToLUFolder(language);
-    });
+    ignoredLanguages = allLanguages
+      .filter(language => {
+        return !languages.includes(language);
+      })
+      .map(language => {
+        return this.pathToLUFolder(language);
+      });
 
     // Add the paths of the deployment languages
     languages.forEach(language => {
       templateFiles.set(
-        path.join(`deployment`,`resources`,`LU`, language),
-        path.join(`deployment`,`resources`,`LU`, language)
+        path.join(`deployment`, `resources`, `LU`, language),
+        path.join(`deployment`, `resources`, `LU`, language)
       );
       templateFiles.set(
-        path.join(`deployment`,`resources`,`QnA`, language),
-        path.join(`deployment`,`resources`,`QnA`, language)
+        path.join(`deployment`, `resources`, `QnA`, language),
+        path.join(`deployment`, `resources`, `QnA`, language)
       );
       templateFiles.set(
-        path.join(`deployment`,`resources`,`QnA`, language),
-        path.join(`deployment`,`resources`,`QnA`, language)
+        path.join(`deployment`, `resources`, `QnA`, language),
+        path.join(`deployment`, `resources`, `QnA`, language)
       );
     });
   }
@@ -70,11 +71,14 @@ class Copier {
     templateFiles.set(`_package.json`, `package.json`);
     templateFiles.set(`_.gitignore`, `.gitignore`);
     templateFiles.set(`_.npmrc`, `.npmrc`);
-    templateFiles.set(path.join(`src`, `bots`, `_dialogBot.ts`), path.join(`src`, `bots`, `dialogBot.ts`))
+    templateFiles.set(
+      path.join(`src`, `bots`, `_dialogBot.ts`),
+      path.join(`src`, `bots`, `dialogBot.ts`)
+    );
   }
 
-  pathToLUFolder(language){
-    // return path.join(`**`,`LU`, language, `*`);
+  pathToLUFolder(language) {
+    // Return path.join(`**`,`LU`, language, `*`);
     return path.join(`**`, language, `*.*`);
   }
 }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/flow/botTestBase.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/flow/botTestBase.js
@@ -18,14 +18,8 @@ const TEST_MODE = require('../testBase').testMode;
 const setupEnvironment = function (testMode) {
     switch (testMode) {
         case 'record':
-            config({ path: path.join(__dirname, '..', '..', '.env.development') });
-            languageModelsRaw = require('../../../assistant/src/languageModels.json'); 
-            skillsRaw = require('../../../assistant/src/skills.json');
             break;
         case 'lockdown':
-            config({ path: path.join(__dirname, '..', '.env.test') });
-            languageModelsRaw = require('../mockResources/languageModels.json');
-            skillsRaw = require('../mockResources/skills.json');
             break;
     }
 }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
@@ -9,6 +9,7 @@ const helpers = require(`yeoman-test`);
 const rimraf = require(`rimraf`);
 const _kebabCase = require(`lodash/kebabCase`);
 const semver = require('semver');
+const languages = [`zh`, `de`, `en`, `fr`, `it`, `es`];
 
 describe(`The generator-botbuilder-assistant tests`, function() {
     var assistantName;
@@ -38,8 +39,6 @@ describe(`The generator-botbuilder-assistant tests`, function() {
         path.join(`src`, `services`),
         `test`,
         path.join(`test`, `flow`),
-        path.join(`test`, `mockResources`),
-        path.join(`test`, `mockResources`, `LocaleConfigurations`)
     ];
 
     describe(`should create`, function() {
@@ -135,6 +134,7 @@ describe(`The generator-botbuilder-assistant tests`, function() {
                     .withPrompts({
                         assistantName: assistantName,
                         assistantDesc: assistantDesc,
+                        assistantLang: languages,
                         pathConfirmation: pathConfirmation,
                         assistantGenerationPath: assistantGenerationPath,
                         finalConfirmation: finalConfirmation


### PR DESCRIPTION
## Description
- Fix ESLint errors
- Fix generator tests

Related to: #1058 

## Testing Steps
1. Go to `AI\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant`
2. Run `npm install`
3. Run `npm run test`
4. Check that there is no **ESLint** errors
5. Check that all the **tests passed** successfully

## Checklist
- [X] I have added or updated the appropriate unit tests
