### PR TITLE
Updated Action/Slot matching approach

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Utilities/ManifestUtilities.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Utilities/ManifestUtilities.cs
@@ -32,5 +32,16 @@ namespace Microsoft.Bot.Builder.Skills.Tests.Utilities
 
             return skillManifest;
         }
+
+        public static Models.Manifest.Action CreateAction(string id, List<Models.Manifest.Slot> slots = null)
+        {
+            var action = new Models.Manifest.Action();
+
+            action.Id = id;
+            action.Definition = new ActionDefinition();
+            action.Definition.Slots = slots;
+
+            return action;
+        }
     }
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/ActionDefinition.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/ActionDefinition.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Skills.Models.Manifest
         public string Description { get; set; }
 
         [JsonProperty(PropertyName = "slots")]
-        public List<Slot> Slots { get; set; }
+        public List<Slot> Slots { get; set; } = new List<Slot>();
 
         [JsonProperty(PropertyName = "triggers")]
         public Triggers Triggers { get; set; }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/SkillManifest.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/SkillManifest.cs
@@ -32,6 +32,6 @@ namespace Microsoft.Bot.Builder.Skills.Models.Manifest
         public AuthenticationConnection[] AuthenticationConnections { get; set; }
 
         [JsonProperty(PropertyName = "actions")]
-        public List<Action> Actions { get; set; }
+        public List<Action> Actions { get; set; } = new List<Action>();
     }
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SlotEqualityComparer.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SlotEqualityComparer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Bot.Builder.Skills.Models.Manifest;
+
+namespace Microsoft.Bot.Builder.Skills
+{
+    public class SlotEqualityComparer : IEqualityComparer<Slot>
+    {
+        public bool Equals(Slot x, Slot y)
+        {
+            return x.Name.Equals(y.Name);
+        }
+
+        public int GetHashCode(Slot obj)
+        {
+            return obj.Name.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
Following the recent testing of a Dispatch intent per action it's highlighted undeseriable regression and complexity for some scenarios where the caller cannot (and perhaps shouldn't) be responsible for identifying an action as that's an implementation detail on the Skill side.

Therefore this PR makes the following extensions:

- If an Action is passed on the DialogOptions parameter to SkillDialog then the behaviour is as before whereby we find the action, enumerate the Actions/Slots and try to match
- if no action is passed then we enumerate all slots across Actions, filter this to a unique list (slots are often shared across actions) and we attempt slot filling. It's then up to the remote Skill to identify action (from it's LUIS model) and use the SkillContext data
- Further unit testing to cover tests in this area

@lauren-mills the only change you should need to make to the MainDialog in VA template is to remove passing the intent. The add-skill logic needs to go back to one dispatch intent for a skill.
@enzocanoo the same for the VA TS implementation.