### PR TITLE
Multi-Locale support for Manifest generation

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -47,6 +48,8 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
             cogModelConfig.LanguageModels.Add(luisModel);
             _botSettings.CognitiveModels.Add("en", cogModelConfig);
+            _botSettings.CognitiveModels.Add("de", cogModelConfig);
+            _botSettings.CognitiveModels.Add("fr", cogModelConfig);
 
             _services = new ServiceCollection();
 
@@ -180,6 +183,15 @@ namespace Microsoft.Bot.Builder.Skills.Tests
                         Assert.IsTrue(
                             skillManifest.Actions[i].Definition.Triggers.Utterances[0].Text.Length > 0,
                             $"The {skillManifest.Actions[i].Id} action has no LUIS utterances added as part of manifest generation.");
+
+                        // Validate DE, FR has been added too.
+                        Assert.IsTrue(
+                            skillManifest.Actions[i].Definition.Triggers.Utterances.Exists(u => u.Locale.ToLower() == "de"),
+                            $"The {skillManifest.Actions[i].Id} action has no LUIS utterances added as part of manifest generation for the DE locale.");
+
+                        Assert.IsTrue(
+                            skillManifest.Actions[i].Definition.Triggers.Utterances.Exists(u => u.Locale.ToLower() == "fr"),
+                            $"The {skillManifest.Actions[i].Id} action has no LUIS utterances added as part of manifest generation for the FR locale.");
                     }
                 }
             }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/manifestTemplate.json
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/manifestTemplate.json
@@ -58,6 +58,20 @@
                 "Calendar#CreateCalendarEntry",
                 "Calendar#FindMeetingRoom"
               ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#CreateCalendarEntry",
+                "Calendar#FindMeetingRoom"
+              ]
+            },
+            {
+              "locale": "fr",
+              "source": [
+                "Calendar#CreateCalendarEntry",
+                "Calendar#FindMeetingRoom"
+              ]
             }
           ]
         }
@@ -85,6 +99,20 @@
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
               ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#AcceptEventEntry",
+                "Calendar#DeleteCalendarEntry"
+              ]
+            },
+            {
+              "locale": "fr",
+              "source": [
+                "Calendar#AcceptEventEntry",
+                "Calendar#DeleteCalendarEntry"
+              ]
             }
           ]
         }
@@ -99,6 +127,18 @@
           "utteranceSources": [
             {
               "locale": "en",
+              "source": [
+                "Calendar#ConnectToMeeting"
+              ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#ConnectToMeeting"
+              ]
+            },
+            {
+              "locale": "fr",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
@@ -133,6 +173,18 @@
               "source": [
                 "Calendar#TimeRemaining"
               ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#TimeRemaining"
+              ]
+            },
+            {
+              "locale": "fr",
+              "source": [
+                "Calendar#TimeRemaining"
+              ]
             }
           ]
         }
@@ -164,6 +216,28 @@
           "utteranceSources": [
             {
               "locale": "en",
+              "source": [
+                "Calendar#FindCalendarDetail",
+                "Calendar#FindCalendarEntry",
+                "Calendar#FindCalendarWhen",
+                "Calendar#FindCalendarWhere",
+                "Calendar#FindCalendarWho",
+                "Calendar#FindDuration"
+              ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#FindCalendarDetail",
+                "Calendar#FindCalendarEntry",
+                "Calendar#FindCalendarWhen",
+                "Calendar#FindCalendarWhere",
+                "Calendar#FindCalendarWho",
+                "Calendar#FindDuration"
+              ]
+            },
+            {
+              "locale": "fr",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -211,6 +285,18 @@
           "utteranceSources": [
             {
               "locale": "en",
+              "source": [
+                "Calendar#ChangeCalendarEntry"
+              ]
+            },
+            {
+              "locale": "de",
+              "source": [
+                "Calendar#ChangeCalendarEntry"
+              ]
+            },
+            {
+              "locale": "fr",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]


### PR DESCRIPTION
- Added the missing multi-locale support for manifest generation. If a manifest template has EN, FR, DE utterance sources provided then the generator will now use the Skill cognitivemodel configuration and enumerate through locales adding the utterances for each locale
- Previously it was hardcoded to en
- Added tests to validate and additional exception text to clarify which locale it ran into problems with