### PR TITLE
[4.4]add websocket latency

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Bot.Protocol" Version="1.0.0-55897" />
-    <PackageReference Include="Microsoft.Bot.Protocol.WebSockets" Version="1.0.0-55897" />
+    <PackageReference Include="Microsoft.Bot.Protocol" Version="1.0.0-56880" />
+    <PackageReference Include="Microsoft.Bot.Protocol.WebSockets" Version="1.0.0-56880" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Bot.Builder.Skills
 					stopWatch.Start();
                     response = await SendRequestAsync<ResourceResponse>(request).ConfigureAwait(false);
 					stopWatch.Stop();
-					_botTelemetryClient.TrackEventEx("SendActivityLatency", activity, null, null, new Dictionary<string, double>()
+					_botTelemetryClient.TrackEventEx("SkillWebSocketSendActivityLatency", activity, null, null, new Dictionary<string, double>
 					{
 						{ "Latency", stopWatch.ElapsedMilliseconds },
 					});
@@ -169,7 +169,7 @@ namespace Microsoft.Bot.Builder.Skills
 			stopWatch.Start();
 			var response = await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
 			stopWatch.Stop();
-			_botTelemetryClient.TrackEventEx("UpdateActivityLatency", activity, null, null, new Dictionary<string, double>()
+			_botTelemetryClient.TrackEventEx("SkillWebSocketUpdateActivityLatency", activity, null, null, new Dictionary<string, double>
 			{
 				{ "Latency", stopWatch.ElapsedMilliseconds },
 			});
@@ -188,7 +188,7 @@ namespace Microsoft.Bot.Builder.Skills
 			stopWatch.Start();
 			await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
 			stopWatch.Stop();
-			_botTelemetryClient.TrackEventEx("DeleteActivityLatency", null, null, null, new Dictionary<string, double>()
+			_botTelemetryClient.TrackEventEx("SkillWebSocketDeleteActivityLatency", null, null, null, new Dictionary<string, double>
 			{
 				{ "Latency", stopWatch.ElapsedMilliseconds },
 			});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

With the latest websocket package, we can attach to Disconnect event to measure E2E latency. This change adds latency events for different parts of the websocket API

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
