### PR TITLE
Fixed the issue of project not loading as it was referencing a wrong project

### DIFF
--- a/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/NewsSkill.sln
+++ b/solutions/Virtual-Assistant/src/csharp/experimental/skills/newsskill/NewsSkill.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 15.0.28010.2046
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewsSkill", "NewsSkill.csproj", "{F73951D9-24AA-48D5-875F-BFB141747E06}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Solutions", "..\..\..\microsoft.bot.solutions\Microsoft.Bot.Solutions.csproj", "{9422C616-34FA-4BE2-9C08-1203AB05B36A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
NewsSkill project was referencing another project of Bot Builder which I have removed from the Solution to load a NewsSkill project without any errors. 