### PR TITLE
SkillDialog - don't pass dispatch intent

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.json
@@ -44,7 +44,7 @@
       "data": {
         "action": "startOnboarding"
       }
-    },
+    },   
     {
       "type": "Action.OpenUrl",
       "title": "Documentation",
@@ -52,13 +52,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Linked Accounts",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -74,8 +74,7 @@ namespace VirtualAssistantSample.Dialogs
             if (identifiedSkill != null)
             {
                 // We have identiifed a skill so initialize the skill connection with the target skill 
-                // the dispatch intent is the Action ID of the Skill enabling us to resolve the specific action and identify slots
-                await dc.BeginDialogAsync(identifiedSkill.Id, intent.ToString());
+                await dc.BeginDialogAsync(identifiedSkill.Id);
 
                 // Pass the activity we have
                 var result = await dc.ContinueDialogAsync();

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.json
@@ -49,16 +49,11 @@
       "type": "Action.OpenUrl",
       "title": "Documentation",
       "url": "https://aka.ms/virtualassistantdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
-      "title": "Linked Accounts",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
+    },   
     {
       "type": "Action.OpenUrl",
       "title": "Skills",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Dialogs/MainDialog.cs
@@ -73,8 +73,7 @@ namespace $safeprojectname$.Dialogs
         if (identifiedSkill != null)
         {
             // We have identiifed a skill so initialize the skill connection with the target skill 
-            // the dispatch intent is the Action ID of the Skill enabling us to resolve the specific action and identify slots
-            await dc.BeginDialogAsync(identifiedSkill.Id, intent.ToString());
+            await dc.BeginDialogAsync(identifiedSkill.Id);
 
             // Pass the activity we have
             var result = await dc.ContinueDialogAsync();


### PR DESCRIPTION
- VA MainDialog currently passes the dispatchIntent as the action, this isn't the action and not passing this parameter indicates to the SkilLDialog to aggregate slots and pass globally so removing the dispatchIntent being passed which was throwing an exception
- Remove linkedaccounts from intro card