### PR TITLE
[build] Use different versions for CLI tool and botbuilder-* libraries

### DIFF
--- a/build.ts.ps1
+++ b/build.ts.ps1
@@ -1,9 +1,15 @@
 ﻿Param(
-	[string] $version
+	[string] $pkgversion,
+	[string] $cliversion
 )
 
-if (-not $version) {
-    Write-Host "Version required!.  Please use the param -version" -ForegroundColor DarkRed
+if (-not $pkgversion) {
+    Write-Host "Version for botbuilder-* required!.  Please use the param -pkgversion" -ForegroundColor DarkRed
+	Break
+}
+
+if (-not $cliversion) {
+    Write-Host "Version for botskills CLI required!.  Please use the param -cliversion" -ForegroundColor DarkRed
 	Break
 }
 
@@ -13,21 +19,21 @@ rush update
 
 pushd .\botskills
 
-npm version $($version) --allow-same-version
+npm version $($cliversion) --allow-same-version
 npm run build
 
 popd
 
 pushd .\botbuilder-solutions
 
-npm version $($version) --allow-same-version
+npm version $($pkgversion) --allow-same-version
 npm run build
 
 popd
 
 pushd .\botbuilder-skills
 
-npm version $($version) --allow-same-version
+npm version $($pkgversion) --allow-same-version
 npm run build
 
 popd
@@ -36,7 +42,7 @@ popd
 
 pushd .\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant
 
-npm version $($version) --allow-same-version
+npm version $($pkgversion) --allow-same-version
 npm install
 
 popd

--- a/build.ts.ps1
+++ b/build.ts.ps1
@@ -42,7 +42,7 @@ popd
 
 pushd .\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant
 
-npm version $($pkgversion) --allow-same-version
+npm version $($cliversion) --allow-same-version
 npm install
 
 popd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add new params to use separate versions for the `CLI tool` and `botbuilder-*` packages. The `template` uses the same version of the `botbuilder-*` because it depends on them.

New params
`-cliversion` for the CLI tool
`-pkgversion` for the other projects

## Testing Steps
> NOTE: Run `npm install -g @microsoft/rush` to install the build tool globally.
1. Open powershell in the root directory of the project.
1. Run `./build.ts.ps1 -cliversion 4.4.0 -pkgversion 1.0.0`
1. You will see the packages in `./outputpackages`