### PR TITLE
[TypeScript] Fix ESLint issue in generator-botbuilder-assistant

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
@@ -84,7 +84,13 @@ class Copier {
     selectedLanguages.forEach(language => {
       templateFiles.set(
         path.join(`deployment`, `resources`, `LU`, language, `_skill.lu`),
-        path.join(`deployment`, `resources`, `LU`, language, `${newSkill.skillName}.lu`)
+        path.join(
+          `deployment`,
+          `resources`,
+          `LU`,
+          language,
+          `${newSkill.skillName}.lu`
+        )
       );
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Fix ESLint issue.
## Testing Steps
1. Go to `./templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant`.
1. Run `npm install`.
1. Run `npm run lint` to check the ESLint issues.