### PR TITLE
[Botskills] Modify listed property in list command

### DIFF
--- a/lib/typescript/botskills/src/functionality/listSkill.ts
+++ b/lib/typescript/botskills/src/functionality/listSkill.ts
@@ -29,7 +29,7 @@ export async function listSkill(configuration: IListConfiguration): Promise<bool
         } else {
             let message: string = `The skills already connected to the assistant are the following:`;
             assistantSkills.forEach((skillManifest: ISkillManifest) => {
-                message += `\n\t- ${skillManifest.name}`;
+                message += `\n\t- ${skillManifest.id}`;
             });
 
             logger.message(message);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Related issue: #1246 

- Change the listed property from 'name' to 'id' when listing the connected skills. This is due to the `disconnect` command taking in the id, so when listing by id, the user can easily copy and paste the id shown

## Testing Steps
1. Go to `AI\lib\typescript\botskills\`.
1. Open a terminal in that location.
1. Run the command `npm install` to install dependencies.
1. Run the command `npm run build` to build the project.
1. Run the command `npm link` to symlink the package folder.
1. Run the command `botskills list` with the proper arguments and check that the ids from the skills in the `skills.json` file are printed and not the names.
