### PR TITLE
[Communication VA - Skill][TypeScript] Fix communication between Assistant - Skills 

### DIFF
--- a/lib/typescript/botbuilder-skills/src/http/skillHttpBotAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpBotAdapter.ts
@@ -75,7 +75,7 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
         // Any Activity responses are now available (via SendActivitiesAsync) so we need to pass back for the response
         return {
             status: 200,
-            body: this.queuedActivities
+            body: this.queuedActivities.splice(0, this.queuedActivities.length)
         };
     }
 

--- a/lib/typescript/botbuilder-solutions/src/dialogs/interruptionAction.ts
+++ b/lib/typescript/botbuilder-solutions/src/dialogs/interruptionAction.ts
@@ -10,12 +10,12 @@ export enum InterruptionAction {
     MessageSentToUser,
 
     /**
-     * Indicates that the active dialog was interrupted and needs to resume.
+     * Indicates that there is a new dialog waiting and the active dialog needs to be shelved.
      */
     StartedDialog,
 
     /**
-     * Indicates that the active dialog was interrupted and needs to resume.
+     * Indicates that no interruption action is required.
      */
     NoAction
 }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/src/responses/sample/resources/SampleResponses.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/src/responses/sample/resources/SampleResponses.json
@@ -1,24 +1,24 @@
 {
-    "NamePrompt": {
-      "replies": [
-        {
-          "text": "What is your name?",
-          "speak": "What is your name?"
-        }
-      ],
-      "inputHint": "expectingInput"
-    },
-    "HaveNameMessage": {
-      "replies": [
-        {
-          "text": "Hi, {Name}!",
-          "speak": "Hi, {Name}!"
-        },
-        {
-          "text": "Nice to meet you, {Name}!",
-          "speak": "Nice to meet you, {Name}!"
-        }
-      ],
-      "inputHint": "acceptingInput"
-    }
+  "NamePrompt": {
+    "replies": [
+      {
+        "text": "What is your name?",
+        "speak": "What is your name?"
+      }
+    ],
+    "inputHint": "expectingInput"
+  },
+  "HaveNameMessage": {
+    "replies": [
+      {
+        "text": "Hi, {name}!",
+        "speak": "Hi, {name}!"
+      },
+      {
+        "text": "Nice to meet you, {name}!",
+        "speak": "Nice to meet you, {name}!"
+      }
+    ],
+    "inputHint": "acceptingInput"
+  }
 }


### PR DESCRIPTION
## Description 

- Fix accumulated activities
- Fix name placeholder 
- Fix comments for interruptionAction enum

## Testing Steps

1. Open a terminal in `./templates/Skill-Template/typescript/generator-botbuilder-assistant`
1. Install yeoman's CLI tools with `npm install --global yo`
1. Run the commands `npm install` and `npm link`
1. Run `yo botbuilder-assistant: skill` and follow the instructions to create a skill
1. Verify that the custom skill was created successfully
1. Run the `deploy.ps1` (which is inside the `deployment/scripts` folder) being in generated custom skill folder
1. Verify that the deployment finished successfully
1. Add a skill manifest to test the communication between the Assistant - Skill 
1. Run the command `npm install` and `npm run build`
1. Run the custom skill with the command `npm run start`
1. Go to `./templates/Virtual-Assistant-Template/src/typescript/sample-assistant` and open another terminal in this location
1. Run the deploy.ps1 (which is inside the `deployment/scripts` folder) being in generated sample assistant folder
1. Verify that the deployment finished successfully
1. Run the command `botskills connect` to establish the communication between the Assistant - Skill 
1. Run the command `npm install` and `npm run build`
1. Run the sample assistant with the command `npm run start`
1. Check on the bot emulator that the communication with Assistant - Skill works fine.

## Checklist
**-**