### PR TITLE
[Botskill] Add validation for .lu and .dispatch file's path

### DIFF
--- a/lib/typescript/botskills/src/functionality/connectSkill.ts
+++ b/lib/typescript/botskills/src/functionality/connectSkill.ts
@@ -63,77 +63,104 @@ function validateManifestSchema(skillManifest: ISkillManifest): void {
     }
 }
 
+// tslint:disable-next-line:max-func-body-length
 async function updateDispatch(configuration: IConnectConfiguration, manifest: ISkillManifest): Promise<void> {
-    // Initializing variables for the updateDispatch scope
-    const dispatchFile: string = `${configuration.dispatchName}.dispatch`;
-    const dispatchJsonFile: string = `${configuration.dispatchName}.json`;
-    const intentName: string = manifest.id;
-    let luisDictionary: Map<string, string>;
+    try {
+        // Initializing variables for the updateDispatch scope
+        const dispatchFile: string = `${configuration.dispatchName}.dispatch`;
+        const dispatchJsonFile: string = `${configuration.dispatchName}.json`;
+        const dispatchFilePath: string = join(configuration.dispatchFolder, dispatchFile);
+        const intentName: string = manifest.id;
+        let luisDictionary: Map<string, string>;
 
-    logger.message('Getting intents for dispatch...');
+        logger.message('Getting intents for dispatch...');
+        luisDictionary = manifest.actions.filter((action: IAction) => action.definition.triggers.utteranceSources)
+        .reduce((acc: IUtteranceSource[], val: IAction) => acc.concat(val.definition.triggers.utteranceSources), [])
+        .reduce((acc: string[], val: IUtteranceSource) => acc.concat(val.source), [])
+        .reduce(
+            (acc: Map<string, string>, val: string) => {
+            const luis: string[] = val.split('#');
+            if (acc.has(luis[0])) {
+                const previous: string | undefined = acc.get(luis[0]);
+                acc.set(luis[0], previous + luis[1]);
+            } else {
+                acc.set(luis[0], luis[1]);
+            }
 
-    luisDictionary = manifest.actions.filter((action: IAction) => action.definition.triggers.utteranceSources)
-    .reduce((acc: IUtteranceSource[], val: IAction) => acc.concat(val.definition.triggers.utteranceSources), [])
-    .reduce((acc: string[], val: IUtteranceSource) => acc.concat(val.source), [])
-    .reduce(
-        (acc: Map<string, string>, val: string) => {
-        const luis: string[] = val.split('#');
-        if (acc.has(luis[0])) {
-            const previous: string | undefined = acc.get(luis[0]);
-            acc.set(luis[0], previous + luis[1]);
-        } else {
-            acc.set(luis[0], luis[1]);
-        }
+            return acc;
+            },
+            new Map());
 
-        return acc;
-        },
-        new Map());
+        logger.message('Adding skill to Dispatch');
+        await Promise.all(
+        Array.from(luisDictionary.entries())
+        .map(async(item: [string, string]) => {
+            const luisApp: string = item[0];
+            const luFile: string = `${luisApp}.lu`;
+            const luisFile: string = `${luisApp}.luis`;
+            const luFilePath: string = join(configuration.luisFolder, luFile);
+            const luisFilePath: string = join(configuration.luisFolder, luisFile);
 
-    logger.message('Adding skill to Dispatch');
+            // Validate 'ludown' arguments
+            if (!existsSync(configuration.luisFolder)) {
+                throw(new Error(`Path to the LUIS folder (${configuration.luisFolder}) leads to a nonexistent folder.`));
+            } else if (!existsSync(luFilePath)) {
+                throw(new Error(`Path to the ${luisApp}.lu file leads to a nonexistent file.`));
+            }
 
-    await Promise.all(
-    Array.from(luisDictionary.entries())
-    .map(async(item: [string, string]) => {
-        const luisApp: string = item[0];
-        const luFile: string = `${luisApp}.lu`;
-        const luisFile: string = `${luisApp}.luis`;
+            // Validate 'dispatch add' arguments
+            if (!existsSync(configuration.dispatchFolder)) {
+                throw(new Error(`Path to the Dispatch folder (${configuration.dispatchFolder}) leads to a nonexistent folder.`));
+            } else if (!existsSync(dispatchFilePath)) {
+                throw(new Error(`Path to the ${dispatchFile} file leads to a nonexistent file.`));
+            }
 
-        // Parse LU file
-        logger.message(`Parsing ${luisApp} LU file...`);
-        const ludownParseCommand: string[] = ['ludown', 'parse', 'toluis'];
-        ludownParseCommand.push(...['--in', join(configuration.luisFolder, luFile)]);
-        ludownParseCommand.push(...['--luis_culture', configuration.language]);
-        ludownParseCommand.push(...['--out_folder', configuration.luisFolder]); //luisFolder should point to 'en' folder inside LUIS folder
-        ludownParseCommand.push(...['--out', `"${luisApp}.luis"`]);
+            // Parse LU file
+            logger.message(`Parsing ${luisApp} LU file...`);
+            const ludownParseCommand: string[] = ['ludown', 'parse', 'toluis'];
+            ludownParseCommand.push(...['--in', luFilePath]);
+            ludownParseCommand.push(...['--luis_culture', configuration.language]);
+            ludownParseCommand.push(...['--out_folder', configuration.luisFolder]);
+            ludownParseCommand.push(...['--out', `"${luisApp}.luis"`]);
 
-        const dispatchAddCommand: string[] = ['dispatch', 'add'];
-        dispatchAddCommand.push(...['--type', 'file']);
-        dispatchAddCommand.push(...['--name', manifest.id]);
-        dispatchAddCommand.push(...['--filePath', join(configuration.luisFolder, luisFile)]);
-        dispatchAddCommand.push(...['--intentName', intentName]);
-        dispatchAddCommand.push(...['--dataFolder', configuration.dispatchFolder]);
-        dispatchAddCommand.push(...['--dispatch', join(configuration.dispatchFolder, dispatchFile)]);
+            await runCommand(ludownParseCommand, `Parsing ${luisApp} LU file`);
 
-        logger.message(await runCommand(ludownParseCommand, `Parsing ${luisApp} LU file`));
-        logger.message(await runCommand(dispatchAddCommand, `Executing dispatch add for the ${luisApp} LU file`));
-    }));
+            if (!existsSync(luisFilePath)) {
+                // tslint:disable-next-line: max-line-length
+                throw(new Error(`Path to the ${luisFile} leads to a nonexistent file. Make sure the ludown command is being executed successfully`));
+            }
+            // Update Dispatch file
+            const dispatchAddCommand: string[] = ['dispatch', 'add'];
+            dispatchAddCommand.push(...['--type', 'file']);
+            dispatchAddCommand.push(...['--name', manifest.id]);
+            dispatchAddCommand.push(...['--filePath', luisFilePath]);
+            dispatchAddCommand.push(...['--intentName', intentName]);
+            dispatchAddCommand.push(...['--dataFolder', configuration.dispatchFolder]);
+            dispatchAddCommand.push(...['--dispatch', dispatchFilePath]);
 
-    logger.message('Running dispatch refresh...');
+            await runCommand(dispatchAddCommand, `Executing dispatch add for the ${luisApp} LU file`);
+        }));
 
-    const dispatchRefreshCommand: string[] = ['dispatch', 'refresh'];
-    dispatchRefreshCommand.push(...['--dispatch', join(configuration.dispatchFolder, dispatchFile)]);
-    dispatchRefreshCommand.push(...['--dataFolder', configuration.dispatchFolder]);
+        logger.message('Running dispatch refresh...');
+        const dispatchRefreshCommand: string[] = ['dispatch', 'refresh'];
+        dispatchRefreshCommand.push(...['--dispatch', dispatchFilePath]);
+        dispatchRefreshCommand.push(...['--dataFolder', configuration.dispatchFolder]);
 
-    await runCommand(dispatchRefreshCommand, `Executing dispatch refresh for the ${configuration.dispatchName} file`);
+        await runCommand(dispatchRefreshCommand, `Executing dispatch refresh for the ${configuration.dispatchName} file`);
 
-    logger.message('Running LuisGen...');
+        logger.message('Running LuisGen...');
+        const luisgenCommand: string[] = ['luisgen'];
+        luisgenCommand.push(join(configuration.dispatchFolder, dispatchJsonFile));
+        luisgenCommand.push(...[`-${configuration.lgLanguage}`, `"DispatchLuis"`]);
+        luisgenCommand.push(...['-o', configuration.lgOutFolder]);
 
-    const luisgenCommand: string[] = ['luisgen'];
-    luisgenCommand.push(join(configuration.dispatchFolder, dispatchJsonFile));
-    luisgenCommand.push(...[`-${configuration.lgLanguage}`, `"DispatchLuis"`]);
-    luisgenCommand.push(...['-o', configuration.lgOutFolder]);
+        await runCommand(luisgenCommand, `Executing luisgen for the ${configuration.dispatchName} file`);
 
-    await runCommand(luisgenCommand, `Executing luisgen for the ${configuration.dispatchName} file`);
+        logger.success('Successfully updated Dispatch model');
+    } catch (err) {
+        logger.error(`An error ocurred while updating the Dispatch model: ${err}`);
+        process.exit(1);
+    }
 }
 
 export async function connectSkill(configuration: IConnectConfiguration): Promise<void> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Related issue #1246 

- Add validation for `.lu` file, throw Error if file does not exist, stop command execution.
- Add validation for `.dispatch` file, throw Error if file does not exist, stop command execution.'

## Testing Steps
1. Go to `AI\lib\typescript\botskills\`.
1. Open a terminal in that location.
1. Run the command `npm install` to install dependencies.
1. Run the command `npm run build` to build the project.
1. Run the command `npm link` to symlink the package folder.
1. Run the command `botskills connect` with the proper arguments, but leading to a nonexistent `.lu` file.
1. Check the error thrown for the nonexistent `.lu` file, and the execution of the command is stopped.
1. Repeat the execution of the command `botskills connect` but this time with a misleading `.dispatch` path.
1. Check the error thrown for the nonexistent `.dispatch` file, and the execution of the command is stopped.

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [x] I have commented my code, particularly in hard-to-understand areas
