### PR TITLE
Add validation for Skill manifest id special characters

### DIFF
--- a/lib/typescript/botskills/src/functionality/connectSkill.ts
+++ b/lib/typescript/botskills/src/functionality/connectSkill.ts
@@ -51,6 +51,9 @@ function validateManifestSchema(skillManifest: ISkillManifest): void {
     }
     if (!skillManifest.id) {
         logger.error(`Missing property 'id' of the manifest`);
+    } else if (skillManifest.id.match(/^\d|[^\w]/g) !== null) {
+        // tslint:disable-next-line:max-line-length
+        logger.error(`The 'id' of the manifest contains some characters not allowed. Make sure the 'id' contains only letters, numbers and underscores, but doesn't start with number.`);
     }
     if (!skillManifest.endpoint) {
         logger.error(`Missing property 'endpoint' of the manifest`);


### PR DESCRIPTION
## Description
Related to #1246 
- Add validation for special characters in the Skill's manifest id.

## Testing Steps
1. Go to `AI\lib\typescript\botskills\`.
1. Open a terminal in that location.
1. Run the command `npm install` to install dependencies.
1. Run the command `npm run build` to build the project.
1. Run the command `npm link` to symlink the package folder.
1. Run the command `botskills connect` with the proper arguments pointing to a Skill manifest with a special character in the id
