### PR TITLE
add homepage field for packages

### DIFF
--- a/lib/typescript/botbuilder-skills/package.json
+++ b/lib/typescript/botbuilder-skills/package.json
@@ -2,6 +2,7 @@
     "name": "botbuilder-skills",
     "version": "4.4.5",
     "description": "Shared library for building Conversational AI Skills.",
+    "homepage": "https://github.com/Microsoft/AI/",
     "author": "Microsoft",
     "license": "MIT",
     "main": "lib/index.js",

--- a/lib/typescript/botbuilder-solutions/package.json
+++ b/lib/typescript/botbuilder-solutions/package.json
@@ -2,6 +2,7 @@
     "name": "botbuilder-solutions",
     "version": "4.4.5",
     "description": "Shared library for Conversational AI Virtual Assistants and Skills.",
+    "homepage": "https://github.com/Microsoft/AI/",
     "author": "Microsoft",
     "license": "MIT",
     "main": "lib/index.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

botbuilder-skills and botbuilder-solutions are missing the readme/homepage. adding homepage field in package.json to enable it.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
