### PR TITLE
[Skill Template][TypeScript] Add documentation

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/readme.md
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/readme.md
@@ -1,1 +1,1 @@
-Please refer to the [Skill Template documentation](http://aka.ms/skilldocs) for deployment and customization instructions.
+Please refer to the [Skill Template documentation](http://aka.ms/virtualassistantdocs) for deployment and customization instructions.

--- a/templates/Skill-Template/csharp/Template/Skill/readme.md
+++ b/templates/Skill-Template/csharp/Template/Skill/readme.md
@@ -1,1 +1,1 @@
-Please refer to the [Skill Template documentation](http://aka.ms/skilldocs) for deployment and customization instructions.
+Please refer to the [Skill Template documentation](http://aka.ms/virtualassistantdocs) for deployment and customization instructions.

--- a/templates/Skill-Template/typescript/README.md
+++ b/templates/Skill-Template/typescript/README.md
@@ -1,1 +1,1 @@
-Please refer to the [Skill Template]('../../Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/README.md') which is a sub-generator of the **Virtual Assistant Template**.
+Please refer to the [Skill Template](../../Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/README.md) which is a sub-generator of the **Virtual Assistant Template**.

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/README.md
@@ -1,0 +1,1 @@
+Please refer to the [Skill Template documentation](http://aka.ms/virtualassistantdocs) for deployment and customization instructions.

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/README.md
@@ -1,0 +1,1 @@
+Please refer to the [Skill Template documentation](http://aka.ms/virtualassistantdocs) for deployment and customization instructions.


### PR DESCRIPTION
## Description
- Add `Skill Template` documentation
- Fix URLs

Related to #1199 

## Testing Steps
1. Go to `AI\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant\generators\skill\templates\customSkill`
1. Open the **README** and check that the content is the same as C# version
1. Go to `AI\templates\Skill-Template\csharp`
1. Check the **README** for **Sample** and **Template** that the link was fixed.
1. Check the same for `AI\templates\Skill-Template\typescript` **README**

## Checklist
- [X] I have updated related documentation