### PR TITLE
add handling for timezone and location events to put them in state

### DIFF
--- a/skills/src/csharp/calendarskill/calendarskill/manifestTemplate.json
+++ b/skills/src/csharp/calendarskill/calendarskill/manifestTemplate.json
@@ -34,21 +34,25 @@
             "types": [ "string" ]
           },
           {
-            "name": "startDate",
+            "name": "startdate",
             "types": [ "string" ]
           },
           {
-            "name": "startTime",
+            "name": "starttime",
             "types": [ "string" ]
           },
           {
             "name": "duration",
             "types": [ "string" ]
           },
-          {
-            "name": "location",
-            "types": [ "string" ]
-          }
+					{
+						"name": "location",
+						"types": [ "string" ]
+					},
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
         ],
         "triggers": {
           "utteranceSources": [
@@ -67,16 +71,20 @@
       "id": "calendarskill_changeEventStatus",
       "definition": {
         "description": "Change the status of an event (accept/decline).",
-        "slots": [
-          {
-            "name": "startDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "startTime",
-            "types": [ "string" ]
-          }
-        ],
+				"slots": [
+					{
+						"name": "startdate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "starttime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "utteranceSources": [
             {
@@ -94,7 +102,12 @@
       "id": "calendarskill_joinEvent",
       "definition": {
         "description": "Join the upcoming meeting",
-        "slots": [],
+				"slots": [
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "utteranceSources": [
             {
@@ -111,7 +124,12 @@
       "id": "calendarskill_summary",
       "definition": {
         "description": "Retrieve a summary of meetings through an event invocation.",
-        "slots": [],
+				"slots": [
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "events": [
             {
@@ -125,7 +143,12 @@
       "id": "calendarskill_timeRemaining",
       "definition": {
         "description": "Find out how long until the next event",
-        "slots": [],
+				"slots": [
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "utteranceSources": [
             {
@@ -142,24 +165,28 @@
       "id": "calendarskill_summary",
       "definition": {
         "description": "Find an upcoming event",
-        "slots": [
-          {
-            "name": "startDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "startTime",
-            "types": [ "string" ]
-          },
-          {
-            "name": "endDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "endTime",
-            "types": [ "string" ]
-          }
-        ],
+				"slots": [
+					{
+						"name": "startdate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "starttime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "enddate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "endtime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "utteranceSources": [
             {
@@ -181,32 +208,36 @@
       "id": "calendarskill_updateEvent",
       "definition": {
         "description": "Update an existing event.",
-        "slots": [
-          {
-            "name": "startDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "startTime",
-            "types": [ "string" ]
-          },
-          {
-            "name": "endDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "endTime",
-            "types": [ "string" ]
-          },
-          {
-            "name": "newStartDate",
-            "types": [ "string" ]
-          },
-          {
-            "name": "newStartTime",
-            "types": [ "string" ]
-          }
-        ],
+				"slots": [
+					{
+						"name": "startdate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "starttime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "enddate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "endtime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "newstartdate",
+						"types": [ "string" ]
+					},
+					{
+						"name": "newstarttime",
+						"types": [ "string" ]
+					},
+					{
+						"name": "timezone",
+						"types": [ "string" ]
+					}
+				],
         "triggers": {
           "utteranceSources": [
             {

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
@@ -155,7 +155,7 @@ namespace PointOfInterestSkill.Dialogs
                 case Events.Location:
                     {
                         // Test trigger with
-                        // /event:{ "Name": "IPA.Location", "Value": "34.05222222222222,-118.2427777777777" }
+                        // /event:{ "Name": "Location", "Value": "34.05222222222222,-118.2427777777777" }
                         var value = dc.Context.Activity.Value.ToString();
 
                         if (!string.IsNullOrEmpty(value))
@@ -180,7 +180,6 @@ namespace PointOfInterestSkill.Dialogs
 
                 case Events.ActiveLocation:
                     {
-                        // Test trigger with...
                         var activeLocationName = dc.Context.Activity.Value.ToString();
 
                         // Set ActiveLocation if one w/ matching name is found in FoundLocations
@@ -351,10 +350,9 @@ namespace PointOfInterestSkill.Dialogs
 
         public class Events
         {
-            public const string ActiveLocation = "IPA.ActiveLocation";
-            public const string ActiveRoute = "IPA.ActiveRoute";
-            public const string Location = "IPA.Location";
-            public const string SkillBeginEvent = "skillBegin";
+            public const string ActiveLocation = "ActiveLocation";
+            public const string ActiveRoute = "ActiveRoute";
+            public const string Location = "Location";
         }
     }
 }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/manifestTemplate.json
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/manifestTemplate.json
@@ -11,7 +11,7 @@
         "description": "Find a route from X to Y",
         "slots": [
           {
-            "name": "Location",
+            "name": "location",
             "types": [ "string" ]
           }
         ],
@@ -32,10 +32,10 @@
       "definition": {
         "description": "Cancel an active route.",
         "slots": [
-          {
-            "name": "Location",
-            "types": [ "string" ]
-          }
+					{
+						"name": "location",
+						"types": [ "string" ]
+					}
         ],
         "triggers": {
           "utteranceSources": [
@@ -54,10 +54,10 @@
       "definition": {
         "description": "Find a point of interest.",
         "slots": [
-          {
-            "name": "Location",
-            "types": [ "string" ]
-          }
+					{
+						"name": "location",
+						"types": [ "string" ]
+					}
         ],
         "triggers": {
           "utteranceSources": [
@@ -76,10 +76,10 @@
       "definition": {
         "description": "Find parking",
         "slots": [
-          {
-            "name": "Location",
-            "types": [ "string" ]
-          }
+					{
+						"name": "location",
+						"types": [ "string" ]
+					}
         ],
         "triggers": {
           "utteranceSources": [

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/Utterances/PointOfInterestDialogUtterances.Designer.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/Utterances/PointOfInterestDialogUtterances.Designer.cs
@@ -19,7 +19,7 @@ namespace PointOfInterestSkillTests.Flow.Utterances {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class PointOfInterestDialogUtterances {
@@ -61,7 +61,7 @@ namespace PointOfInterestSkillTests.Flow.Utterances {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /event:{ &quot;Name&quot;: &quot;IPA.ActiveLocation&quot;, &quot;Value&quot;: &quot;Microsoft Corporation&quot;,&quot;Text&quot;:&quot;find a route&quot; }.
+        ///   Looks up a localized string similar to /event:{ &quot;Name&quot;: &quot;ActiveLocation&quot;, &quot;Value&quot;: &quot;Microsoft Corporation&quot;,&quot;Text&quot;:&quot;find a route&quot; }.
         /// </summary>
         internal static string ActiveLocationEvent {
             get {
@@ -133,7 +133,7 @@ namespace PointOfInterestSkillTests.Flow.Utterances {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /event:{ &quot;Name&quot;: &quot;IPA.Location&quot;, &quot;Value&quot;: &quot;47.639620,-122.130610&quot; }.
+        ///   Looks up a localized string similar to /event:{ &quot;Name&quot;: &quot;Location&quot;, &quot;Value&quot;: &quot;47.639620,-122.130610&quot; }.
         /// </summary>
         internal static string LocationEvent {
             get {

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/Utterances/PointOfInterestDialogUtterances.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/Utterances/PointOfInterestDialogUtterances.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActiveLocationEvent" xml:space="preserve">
-    <value>/event:{ "Name": "IPA.ActiveLocation", "Value": "Microsoft Corporation","Text":"find a route" }</value>
+    <value>/event:{ "Name": "ActiveLocation", "Value": "Microsoft Corporation","Text":"find a route" }</value>
   </data>
   <data name="CancelRoute" xml:space="preserve">
     <value>cancel my route</value>
@@ -142,7 +142,7 @@
     <value>I found the following matches.</value>
   </data>
   <data name="LocationEvent" xml:space="preserve">
-    <value>/event:{ "Name": "IPA.Location", "Value": "47.639620,-122.130610" }</value>
+    <value>/event:{ "Name": "Location", "Value": "47.639620,-122.130610" }</value>
   </data>
   <data name="WhatElseCanIHelpYouWith" xml:space="preserve">
     <value>What else can I help you with?</value>

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -22,315 +22,373 @@ using VirtualAssistantSample.Services;
 
 namespace VirtualAssistantSample.Dialogs
 {
-    public class MainDialog : RouterDialog
-    {
-        private BotSettings _settings;
-        private BotServices _services;
-        private MainResponses _responder = new MainResponses();
-        private IStatePropertyAccessor<OnboardingState> _onboardingState;
+	public class MainDialog : RouterDialog
+	{
+		private const string Location = "location";
+		private const string TimeZone = "timezone";
+		private BotSettings _settings;
+		private BotServices _services;
+		private MainResponses _responder = new MainResponses();
+		private IStatePropertyAccessor<OnboardingState> _onboardingState;
+		private IStatePropertyAccessor<SkillContext> _skillContextAccessor;
 
-        public MainDialog(
-            BotSettings settings,
-            BotServices services,
-            OnboardingDialog onboardingDialog,
-            EscalateDialog escalateDialog,
-            CancelDialog cancelDialog,
-            List<SkillDialog> skillDialogs,
-            IBotTelemetryClient telemetryClient,
-            UserState userState)
-            : base(nameof(MainDialog), telemetryClient)
-        {
-            _settings = settings;
-            _services = services;
-            TelemetryClient = telemetryClient;
-            _onboardingState = userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
+		public MainDialog(
+			BotSettings settings,
+			BotServices services,
+			OnboardingDialog onboardingDialog,
+			EscalateDialog escalateDialog,
+			CancelDialog cancelDialog,
+			List<SkillDialog> skillDialogs,
+			IBotTelemetryClient telemetryClient,
+			UserState userState)
+			: base(nameof(MainDialog), telemetryClient)
+		{
+			_settings = settings;
+			_services = services;
+			TelemetryClient = telemetryClient;
+			_onboardingState = userState.CreateProperty<OnboardingState>(nameof(OnboardingState));
+			_skillContextAccessor = userState.CreateProperty<SkillContext>(nameof(SkillContext));
 
-            AddDialog(onboardingDialog);
-            AddDialog(escalateDialog);
-            AddDialog(cancelDialog);
+			AddDialog(onboardingDialog);
+			AddDialog(escalateDialog);
+			AddDialog(cancelDialog);
 
-            foreach (var skillDialog in skillDialogs)
-            {
-                AddDialog(skillDialog);
-            }
-        }
+			foreach (var skillDialog in skillDialogs)
+			{
+				AddDialog(skillDialog);
+			}
+		}
 
-        protected override async Task OnStartAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var view = new MainResponses();
-            var onboardingState = await _onboardingState.GetAsync(dc.Context, () => new OnboardingState());
+		protected override async Task OnStartAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			var view = new MainResponses();
+			var onboardingState = await _onboardingState.GetAsync(dc.Context, () => new OnboardingState());
 
-            if (string.IsNullOrEmpty(onboardingState.Name))
-            {
-                await view.ReplyWith(dc.Context, MainResponses.ResponseIds.NewUserGreeting);
-            }
-            else
-            {
-                await view.ReplyWith(dc.Context, MainResponses.ResponseIds.ReturningUserGreeting);
-            }
-        }
+			if (string.IsNullOrEmpty(onboardingState.Name))
+			{
+				await view.ReplyWith(dc.Context, MainResponses.ResponseIds.NewUserGreeting);
+			}
+			else
+			{
+				await view.ReplyWith(dc.Context, MainResponses.ResponseIds.ReturningUserGreeting);
+			}
+		}
 
-        protected override async Task RouteAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // Get cognitive models for locale
-            var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            var cognitiveModels = _services.CognitiveModelSets[locale];
+		protected override async Task RouteAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			// Get cognitive models for locale
+			var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+			var cognitiveModels = _services.CognitiveModelSets[locale];
 
-            // Check dispatch result
-            var dispatchResult = await cognitiveModels.DispatchService.RecognizeAsync<DispatchLuis>(dc.Context, CancellationToken.None);
-            var intent = dispatchResult.TopIntent().intent;
+			// Check dispatch result
+			var dispatchResult = await cognitiveModels.DispatchService.RecognizeAsync<DispatchLuis>(dc.Context, CancellationToken.None);
+			var intent = dispatchResult.TopIntent().intent;
 
-            // Identify if the dispatch intent matches any Action within a Skill if so, we pass to the appropriate SkillDialog to hand-off
-            var identifiedSkill = SkillRouter.IsSkill(_settings.Skills, intent.ToString());
+			// Identify if the dispatch intent matches any Action within a Skill if so, we pass to the appropriate SkillDialog to hand-off
+			var identifiedSkill = SkillRouter.IsSkill(_settings.Skills, intent.ToString());
 
-            if (identifiedSkill != null)
-            {
-                // We have identiifed a skill so initialize the skill connection with the target skill
-                await dc.BeginDialogAsync(identifiedSkill.Id);
+			if (identifiedSkill != null)
+			{
+				// We have identiifed a skill so initialize the skill connection with the target skill
+				await dc.BeginDialogAsync(identifiedSkill.Id);
 
-                // Pass the activity we have
-                var result = await dc.ContinueDialogAsync();
+				// Pass the activity we have
+				var result = await dc.ContinueDialogAsync();
 
-                if (result.Status == DialogTurnStatus.Complete)
-                {
-                    await CompleteAsync(dc);
-                }
-            }
-            else if (intent == DispatchLuis.Intent.l_general)
-            {
-                // If dispatch result is general luis model
-                cognitiveModels.LuisServices.TryGetValue("general", out var luisService);
+				if (result.Status == DialogTurnStatus.Complete)
+				{
+					await CompleteAsync(dc);
+				}
+			}
+			else if (intent == DispatchLuis.Intent.l_general)
+			{
+				// If dispatch result is general luis model
+				cognitiveModels.LuisServices.TryGetValue("general", out var luisService);
 
-                if (luisService == null)
-                {
-                    throw new Exception("The general LUIS Model could not be found in your Bot Services configuration.");
-                }
-                else
-                {
-                    var result = await luisService.RecognizeAsync<GeneralLuis>(dc.Context, CancellationToken.None);
+				if (luisService == null)
+				{
+					throw new Exception("The general LUIS Model could not be found in your Bot Services configuration.");
+				}
+				else
+				{
+					var result = await luisService.RecognizeAsync<GeneralLuis>(dc.Context, CancellationToken.None);
 
-                    var generalIntent = result?.TopIntent().intent;
+					var generalIntent = result?.TopIntent().intent;
 
-                    // switch on general intents
-                    switch (generalIntent)
-                    {
-                        case GeneralLuis.Intent.Escalate:
-                            {
-                                // start escalate dialog
-                                await dc.BeginDialogAsync(nameof(EscalateDialog));
-                                break;
-                            }
+					// switch on general intents
+					switch (generalIntent)
+					{
+						case GeneralLuis.Intent.Escalate:
+							{
+								// start escalate dialog
+								await dc.BeginDialogAsync(nameof(EscalateDialog));
+								break;
+							}
 
-                        case GeneralLuis.Intent.None:
-                        default:
-                            {
-                                // No intent was identified, send confused message
-                                await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
-                                break;
-                            }
-                    }
-                }
-            }
-            else if (intent == DispatchLuis.Intent.q_faq)
-            {
-                cognitiveModels.QnAServices.TryGetValue("faq", out var qnaService);
+						case GeneralLuis.Intent.None:
+						default:
+							{
+								// No intent was identified, send confused message
+								await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
+								break;
+							}
+					}
+				}
+			}
+			else if (intent == DispatchLuis.Intent.q_faq)
+			{
+				cognitiveModels.QnAServices.TryGetValue("faq", out var qnaService);
 
-                if (qnaService == null)
-                {
-                    throw new Exception("The specified QnA Maker Service could not be found in your Bot Services configuration.");
-                }
-                else
-                {
-                    var answers = await qnaService.GetAnswersAsync(dc.Context, null, null);
+				if (qnaService == null)
+				{
+					throw new Exception("The specified QnA Maker Service could not be found in your Bot Services configuration.");
+				}
+				else
+				{
+					var answers = await qnaService.GetAnswersAsync(dc.Context, null, null);
 
-                    if (answers != null && answers.Count() > 0)
-                    {
-                        await dc.Context.SendActivityAsync(answers[0].Answer, speak: answers[0].Answer);
-                    }
-                    else
-                    {
-                        await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
-                    }
-                }
-            }
-            else if (intent == DispatchLuis.Intent.q_chitchat)
-            {
-                cognitiveModels.QnAServices.TryGetValue("chitchat", out var qnaService);
+					if (answers != null && answers.Count() > 0)
+					{
+						await dc.Context.SendActivityAsync(answers[0].Answer, speak: answers[0].Answer);
+					}
+					else
+					{
+						await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
+					}
+				}
+			}
+			else if (intent == DispatchLuis.Intent.q_chitchat)
+			{
+				cognitiveModels.QnAServices.TryGetValue("chitchat", out var qnaService);
 
-                if (qnaService == null)
-                {
-                    throw new Exception("The specified QnA Maker Service could not be found in your Bot Services configuration.");
-                }
-                else
-                {
-                    var answers = await qnaService.GetAnswersAsync(dc.Context, null, null);
+				if (qnaService == null)
+				{
+					throw new Exception("The specified QnA Maker Service could not be found in your Bot Services configuration.");
+				}
+				else
+				{
+					var answers = await qnaService.GetAnswersAsync(dc.Context, null, null);
 
-                    if (answers != null && answers.Count() > 0)
-                    {
-                        await dc.Context.SendActivityAsync(answers[0].Answer, speak: answers[0].Answer);
-                    }
-                    else
-                    {
-                        await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
-                    }
-                }
-            }
-            else
-            {
-                // If dispatch intent does not map to configured models, send "confused" response.
-                await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
-            }
-        }
+					if (answers != null && answers.Count() > 0)
+					{
+						await dc.Context.SendActivityAsync(answers[0].Answer, speak: answers[0].Answer);
+					}
+					else
+					{
+						await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
+					}
+				}
+			}
+			else
+			{
+				// If dispatch intent does not map to configured models, send "confused" response.
+				await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Confused);
+			}
+		}
 
-        protected override async Task OnEventAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // Check if there was an action submitted from intro card
-            var value = dc.Context.Activity.Value;
+		protected override async Task OnEventAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			// Check if there was an action submitted from intro card
+			var value = dc.Context.Activity.Value;
 
-            if (value.GetType() == typeof(JObject))
-            {
-                var submit = JObject.Parse(value.ToString());
-                if (value != null && (string)submit["action"] == "startOnboarding")
-                {
-                    await dc.BeginDialogAsync(nameof(OnboardingDialog));
-                    return;
-                }
-            }
+			if (value.GetType() == typeof(JObject))
+			{
+				var submit = JObject.Parse(value.ToString());
+				if (value != null && (string)submit["action"] == "startOnboarding")
+				{
+					await dc.BeginDialogAsync(nameof(OnboardingDialog));
+					return;
+				}
+			}
 
-            var forward = true;
-            var ev = dc.Context.Activity.AsEventActivity();
-            if (!string.IsNullOrWhiteSpace(ev.Name))
-            {
-                switch (ev.Name)
-                {
-                    case TokenEvents.TokenResponseEventName:
-                        {
-                            forward = true;
-                            break;
-                        }
+			var forward = true;
+			var ev = dc.Context.Activity.AsEventActivity();
+			if (!string.IsNullOrWhiteSpace(ev.Name))
+			{
+				switch (ev.Name)
+				{
+					case Events.TimezoneEvent:
+						{
+							try
+							{
+								var timezone = ev.Value.ToString();
+								var tz = TimeZoneInfo.FindSystemTimeZoneById(timezone);
 
-                    default:
-                        {
-                            await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Unknown Event {ev.Name} was received but not processed."));
-                            forward = false;
-                            break;
-                        }
-                }
-            }
+								var skillContext = await _skillContextAccessor.GetAsync(dc.Context, () => new SkillContext());
+								if (skillContext.ContainsKey(TimeZone))
+								{
+									skillContext[TimeZone] = tz;
+								}
+								else
+								{
+									skillContext.Add(TimeZone, tz);
+								}
 
-            if (forward)
-            {
-                var result = await dc.ContinueDialogAsync();
+								await _skillContextAccessor.SetAsync(dc.Context, skillContext);
+							}
+							catch
+							{
+								await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Timezone passed could not be mapped to a valid Timezone. Property not set."));
+							}
 
-                if (result.Status == DialogTurnStatus.Complete)
-                {
-                    await CompleteAsync(dc);
-                }
-            }
-        }
+							forward = false;
+							break;
+						}
 
-        protected override async Task CompleteAsync(DialogContext dc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // The active dialog's stack ended with a complete status
-            await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Completed);
-        }
+					case Events.LocationEvent:
+						{
+							var location = ev.Value.ToString();
 
-        protected override async Task<InterruptionAction> OnInterruptDialogAsync(DialogContext dc, CancellationToken cancellationToken)
-        {
-            if (dc.Context.Activity.Type == ActivityTypes.Message && !string.IsNullOrWhiteSpace(dc.Context.Activity.Text))
-            {
-                // get current activity locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var cognitiveModels = _services.CognitiveModelSets[locale];
+							var skillContext = await _skillContextAccessor.GetAsync(dc.Context, () => new SkillContext());
+							if (skillContext.ContainsKey(Location))
+							{
+								skillContext[Location] = location;
+							}
+							else
+							{
+								skillContext.Add(Location, location);
+							}
 
-                // check luis intent
-                cognitiveModels.LuisServices.TryGetValue("general", out var luisService);
-                if (luisService == null)
-                {
-                    throw new Exception("The general LUIS Model could not be found in your Bot Services configuration.");
-                }
-                else
-                {
-                    var luisResult = await luisService.RecognizeAsync<GeneralLuis>(dc.Context, cancellationToken);
-                    var intent = luisResult.TopIntent().intent;
+							await _skillContextAccessor.SetAsync(dc.Context, skillContext);
 
-                    if (luisResult.TopIntent().score > 0.5)
-                    {
-                        switch (intent)
-                        {
-                            case GeneralLuis.Intent.Cancel:
-                                {
-                                    return await OnCancel(dc);
-                                }
+							forward = false;
+							break;
+						}
 
-                            case GeneralLuis.Intent.Help:
-                                {
-                                    return await OnHelp(dc);
-                                }
+					case TokenEvents.TokenResponseEventName:
+						{
+							forward = true;
+							break;
+						}
 
-                            case GeneralLuis.Intent.Logout:
-                                {
-                                    return await OnLogout(dc);
-                                }
-                        }
-                    }
-                }
-            }
+					default:
+						{
+							await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Unknown Event {ev.Name} was received but not processed."));
+							forward = false;
+							break;
+						}
+				}
+			}
 
-            return InterruptionAction.NoAction;
-        }
+			if (forward)
+			{
+				var result = await dc.ContinueDialogAsync();
 
-        private async Task<InterruptionAction> OnCancel(DialogContext dc)
-        {
-            if (dc.ActiveDialog != null && dc.ActiveDialog.Id != nameof(CancelDialog))
-            {
-                // Don't start restart cancel dialog
-                await dc.BeginDialogAsync(nameof(CancelDialog));
+				if (result.Status == DialogTurnStatus.Complete)
+				{
+					await CompleteAsync(dc);
+				}
+			}
+		}
 
-                // Signal that the dialog is waiting on user response
-                return InterruptionAction.StartedDialog;
-            }
+		protected override async Task CompleteAsync(DialogContext dc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			// The active dialog's stack ended with a complete status
+			await _responder.ReplyWith(dc.Context, MainResponses.ResponseIds.Completed);
+		}
 
-            var view = new CancelResponses();
-            await view.ReplyWith(dc.Context, CancelResponses.ResponseIds.NothingToCancelMessage);
+		protected override async Task<InterruptionAction> OnInterruptDialogAsync(DialogContext dc, CancellationToken cancellationToken)
+		{
+			if (dc.Context.Activity.Type == ActivityTypes.Message && !string.IsNullOrWhiteSpace(dc.Context.Activity.Text))
+			{
+				// get current activity locale
+				var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+				var cognitiveModels = _services.CognitiveModelSets[locale];
 
-            return InterruptionAction.StartedDialog;
-        }
+				// check luis intent
+				cognitiveModels.LuisServices.TryGetValue("general", out var luisService);
+				if (luisService == null)
+				{
+					throw new Exception("The general LUIS Model could not be found in your Bot Services configuration.");
+				}
+				else
+				{
+					var luisResult = await luisService.RecognizeAsync<GeneralLuis>(dc.Context, cancellationToken);
+					var intent = luisResult.TopIntent().intent;
 
-        private async Task<InterruptionAction> OnHelp(DialogContext dc)
-        {
-            var view = new MainResponses();
-            await view.ReplyWith(dc.Context, MainResponses.ResponseIds.Help);
+					if (luisResult.TopIntent().score > 0.5)
+					{
+						switch (intent)
+						{
+							case GeneralLuis.Intent.Cancel:
+								{
+									return await OnCancel(dc);
+								}
 
-            // Signal the conversation was interrupted and should immediately continue
-            return InterruptionAction.MessageSentToUser;
-        }
+							case GeneralLuis.Intent.Help:
+								{
+									return await OnHelp(dc);
+								}
 
-        private async Task<InterruptionAction> OnLogout(DialogContext dc)
-        {
-            IUserTokenProvider tokenProvider;
-            var supported = dc.Context.Adapter is IUserTokenProvider;
-            if (!supported)
-            {
-                throw new InvalidOperationException("OAuthPrompt.SignOutUser(): not supported by the current adapter");
-            }
-            else
-            {
-                tokenProvider = (IUserTokenProvider)dc.Context.Adapter;
-            }
+							case GeneralLuis.Intent.Logout:
+								{
+									return await OnLogout(dc);
+								}
+						}
+					}
+				}
+			}
 
-            await dc.CancelAllDialogsAsync();
+			return InterruptionAction.NoAction;
+		}
 
-            // Sign out user
-            var tokens = await tokenProvider.GetTokenStatusAsync(dc.Context, dc.Context.Activity.From.Id);
-            foreach (var token in tokens)
-            {
-                await tokenProvider.SignOutUserAsync(dc.Context, token.ConnectionName);
-            }
+		private async Task<InterruptionAction> OnCancel(DialogContext dc)
+		{
+			if (dc.ActiveDialog != null && dc.ActiveDialog.Id != nameof(CancelDialog))
+			{
+				// Don't start restart cancel dialog
+				await dc.BeginDialogAsync(nameof(CancelDialog));
 
-            await dc.Context.SendActivityAsync(MainStrings.LOGOUT);
+				// Signal that the dialog is waiting on user response
+				return InterruptionAction.StartedDialog;
+			}
 
-            return InterruptionAction.StartedDialog;
-        }
-    }
+			var view = new CancelResponses();
+			await view.ReplyWith(dc.Context, CancelResponses.ResponseIds.NothingToCancelMessage);
+
+			return InterruptionAction.StartedDialog;
+		}
+
+		private async Task<InterruptionAction> OnHelp(DialogContext dc)
+		{
+			var view = new MainResponses();
+			await view.ReplyWith(dc.Context, MainResponses.ResponseIds.Help);
+
+			// Signal the conversation was interrupted and should immediately continue
+			return InterruptionAction.MessageSentToUser;
+		}
+
+		private async Task<InterruptionAction> OnLogout(DialogContext dc)
+		{
+			IUserTokenProvider tokenProvider;
+			var supported = dc.Context.Adapter is IUserTokenProvider;
+			if (!supported)
+			{
+				throw new InvalidOperationException("OAuthPrompt.SignOutUser(): not supported by the current adapter");
+			}
+			else
+			{
+				tokenProvider = (IUserTokenProvider)dc.Context.Adapter;
+			}
+
+			await dc.CancelAllDialogsAsync();
+
+			// Sign out user
+			var tokens = await tokenProvider.GetTokenStatusAsync(dc.Context, dc.Context.Activity.From.Id);
+			foreach (var token in tokens)
+			{
+				await tokenProvider.SignOutUserAsync(dc.Context, token.ConnectionName);
+			}
+
+			await dc.Context.SendActivityAsync(MainStrings.LOGOUT);
+
+			return InterruptionAction.StartedDialog;
+		}
+
+		private class Events
+		{
+			public const string TimezoneEvent = "VA.Timezone";
+			public const string LocationEvent = "VA.Location";
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

In VASample, there's no handling for timezone and current location events. We should add them and save them correctly in state so when calling skills they can be passed along within skillContext. Also changing the slot names to be lower case in skills to avoid possible bugs.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
