### PR TITLE
[Virtual Assistant Template][TypeScript] Add code-coverage and tests reports in Pipelines

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.gitignore
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 #generator tests
 test/
 
+# Test report
+test-results.xml
+
 #coverage
 coverage
 .nyc_output

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.nycrc
@@ -14,7 +14,8 @@
   ],
   "reporter": [
     "html",
-    "text"
+    "text",
+    "cobertura"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.gitignore
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.gitignore
@@ -7,5 +7,8 @@ lib/
 # Environment variables
 .env.*
 
+# Test report
+test-results.xml
+
 # Bot Files
 *.bot

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.nycrc
@@ -12,7 +12,8 @@
   ],
   "reporter": [
     "html",
-    "text"
+    "text",
+    "cobertura"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_package.json
@@ -47,6 +47,7 @@
         "@types/restify": "^7.2.4",
         "copyfiles": "^2.1.0",
         "mocha": "^6.1.4",
+        "mocha-junit-reporter": "^1.22.0",
         "nock": "^10.0.6",
         "nodemon": "^1.18.4",
         "nyc": "^14.1.1",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mocha.opts
@@ -1,3 +1,4 @@
+--reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.gitignore
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.gitignore
@@ -10,6 +10,9 @@ lib/
 # Bot Files
 *.bot
 
+# Test report
+test-results.xml
+
 #coverage
 coverage
 .nyc_output 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.nycrc
@@ -11,7 +11,8 @@
   ],
   "reporter": [
     "html",
-    "text"
+    "text",
+    "cobertura"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_package.json
@@ -36,7 +36,6 @@
         "dotenv": "^6.0.0",
         "i18next": "^15.0.6",
         "i18next-node-fs-backend": "^2.1.1",
-        "mocha": "^6.1.4",
         "ms-rest-azure": "^2.5.0",
         "restify": "^7.2.1"
     },
@@ -48,6 +47,8 @@
         "@types/restify": "^7.2.4",
         "copyfiles": "^2.1.0",
         "nock": "^10.0.6",
+        "mocha": "^6.1.4",
+        "mocha-junit-reporter": "^1.22.0",
         "nodemon": "^1.18.4",
         "nyc": "^14.1.1",
         "replace": "^1.0.0",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mocha.opts
@@ -1,5 +1,6 @@
 --require ts-node/register
 --require source-map-support/register
+--reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package-lock.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package-lock.json
@@ -516,6 +516,12 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -721,6 +727,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "dargs": {
       "version": "6.1.0",
@@ -2319,6 +2331,17 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -2573,6 +2596,45 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.22.0.tgz",
+      "integrity": "sha512-nRBCVxzYYhOqQr2XlByLRj5MAAy7djArRkGUSx9dGc+B9NMu4yCeo74uXKALAnMhXjuLmtAL9F8WGe3wQV30IA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4279,6 +4341,12 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
@@ -40,6 +40,7 @@
     "eslint-config-xo": "^0.26.0",
     "eslint-plugin-prettier": "^3.0.1",
     "mocha": "^6.1.4",
+    "mocha-junit-reporter": "^1.22.0",
     "nyc": "^14.1.1",
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/mocha.opts
@@ -1,4 +1,5 @@
 --require ts-node/register
 --require source-map-support/register
+--reporter mocha-junit-reporter
 --timeout 30000
 --recursive

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.gitignore
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.gitignore
@@ -10,6 +10,9 @@ lib/
 # Bot Files
 *.bot
 
-# Coverage
+# Test report
+test-results.xml
+
+# Coverage report
 coverage
-.nyc_output  
+.nyc_output

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.nycrc
@@ -12,7 +12,8 @@
   ],
   "reporter": [
     "html",
-    "text"
+    "text",
+    "cobertura"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package-lock.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package-lock.json
@@ -1,0 +1,9020 @@
+{
+    "name": "sample-assistant",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@azure/cognitiveservices-luis-runtime": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cognitiveservices-luis-runtime/-/@azure/cognitiveservices-luis-runtime-2.0.0.tgz",
+            "integrity": "sha1-l2hvKJfuLjwvjWuhrta5h1ehC5g=",
+            "requires": {
+                "@azure/ms-rest-js": "^1.6.0",
+                "tslib": "^1.9.3"
+            },
+            "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.8.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.6.tgz",
+                    "integrity": "sha1-RwR0p73XP7SEyLwOMpaMWHN+er0=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.18.0",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    }
+                },
+                "tunnel": {
+                    "version": "0.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.6.tgz",
+                    "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+                }
+            }
+        },
+        "@azure/ms-rest-js": {
+            "version": "1.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
+            "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+            "requires": {
+                "axios": "^0.18.0",
+                "form-data": "^2.3.2",
+                "tough-cookie": "^2.4.3",
+                "tslib": "^1.9.2",
+                "uuid": "^3.2.1",
+                "xml2js": "^0.4.19"
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.0.0.tgz",
+            "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.4.4.tgz",
+            "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.1.0.tgz",
+            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.0.0.tgz",
+            "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.4.4.tgz",
+            "integrity": "sha1-WXcSlDG4/jNHFzDSVc6GVK4SULY=",
+            "dev": true
+        },
+        "@babel/runtime": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.4.4.tgz",
+            "integrity": "sha1-3C40mC6yNoA6onoH/qaFevG5Fx0=",
+            "requires": {
+                "regenerator-runtime": "^0.13.2"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+                    "integrity": "sha1-MuWcmm+5saSv8JtJMMotRHc0NEc="
+                }
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.4.4.tgz",
+            "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.4.4.tgz",
+            "integrity": "sha1-B3bwOPbXg2GGC2gjiH1POTcTP+g=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.4.4.tgz",
+            "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@microsoft/microsoft-graph-client": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-client/-/@microsoft/microsoft-graph-client-1.7.0.tgz",
+            "integrity": "sha1-bbarlQYMoCM3hOoN6XSVGzdC2t4=",
+            "requires": {
+                "es6-promise": "^4.2.6",
+                "isomorphic-fetch": "^2.2.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@microsoft/microsoft-graph-types": {
+            "version": "1.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.9.0.tgz",
+            "integrity": "sha1-K1Y/OBZUCoKGRSixv7GgKONYirU="
+        },
+        "@microsoft/recognizers-text": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.1.4.tgz",
+            "integrity": "sha1-JkUw90iyytP6xU1TU4+IrSv5m34="
+        },
+        "@microsoft/recognizers-text-choice": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.2.tgz",
+            "integrity": "sha1-9HWbwSFM2sZ32HQCIIBpy8DGD4g=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "grapheme-splitter": "^1.0.2"
+            }
+        },
+        "@microsoft/recognizers-text-date-time": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.1.2.tgz",
+            "integrity": "sha1-pV+UhW5iHKfjkBWMkWym0z5YiPA=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "@microsoft/recognizers-text-number": "~1.1.2",
+                "@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+                "lodash.isequal": "^4.5.0",
+                "lodash.tonumber": "^4.0.3"
+            }
+        },
+        "@microsoft/recognizers-text-number": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.4.tgz",
+            "integrity": "sha1-H74EczIuYpK7k/mvhsbKXOBSEtk=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "bignumber.js": "^7.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.sortby": "^4.7.0",
+                "lodash.trimend": "^4.5.1"
+            }
+        },
+        "@microsoft/recognizers-text-number-with-unit": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.1.4.tgz",
+            "integrity": "sha1-p/JhTUGa2y/qmeXDJBUepFUmKqg=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "@microsoft/recognizers-text-number": "~1.1.4",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.last": "^3.0.0",
+                "lodash.max": "^4.0.1"
+            }
+        },
+        "@microsoft/recognizers-text-sequence": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.1.4.tgz",
+            "integrity": "sha1-M584KSuiB8147ife/uoat5IG+l0=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "grapheme-splitter": "^1.0.2"
+            }
+        },
+        "@microsoft/recognizers-text-suite": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.1.2.tgz",
+            "integrity": "sha1-2sRcXNgN3TEq05wUbQMktm1+Zk8=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "@microsoft/recognizers-text-choice": "~1.1.2",
+                "@microsoft/recognizers-text-date-time": "~1.1.2",
+                "@microsoft/recognizers-text-number": "~1.1.2",
+                "@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+                "@microsoft/recognizers-text-sequence": "~1.1.2"
+            }
+        },
+        "@types/body-parser": {
+            "version": "1.17.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/body-parser/-/@types/body-parser-1.17.0.tgz",
+            "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/bunyan": {
+            "version": "1.8.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/bunyan/-/@types/bunyan-1.8.6.tgz",
+            "integrity": "sha1-ZSdkHMowvt7F/rmrUnt4A7gABYI=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/caseless": {
+            "version": "0.12.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/caseless/-/@types/caseless-0.12.2.tgz",
+            "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+        },
+        "@types/connect": {
+            "version": "3.4.32",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.32.tgz",
+            "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/documentdb": {
+            "version": "1.10.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.5.tgz",
+            "integrity": "sha1-hsbsm+nOB/+fysXKPBdXDDhdQKQ=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/dotenv": {
+            "version": "6.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/dotenv/-/@types/dotenv-6.1.1.tgz",
+            "integrity": "sha1-984cxP408KQ3O6mf76Q3sL7FS0Y=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/express": {
+            "version": "4.16.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.16.1.tgz",
+            "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "@types/express-jwt": {
+            "version": "0.0.34",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-jwt/-/@types/express-jwt-0.0.34.tgz",
+            "integrity": "sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=",
+            "requires": {
+                "@types/express": "*",
+                "@types/express-unless": "*"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "4.16.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.16.4.tgz",
+            "integrity": "sha1-VruL5FWUAdaK9KNiSundMWYQPmA=",
+            "requires": {
+                "@types/node": "*",
+                "@types/range-parser": "*"
+            }
+        },
+        "@types/express-unless": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-unless/-/@types/express-unless-0.5.1.tgz",
+            "integrity": "sha1-T0QLkF5Cu/Uzgrgge8M33F/5/R8=",
+            "requires": {
+                "@types/express": "*"
+            }
+        },
+        "@types/filenamify": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/filenamify/-/@types/filenamify-2.0.2.tgz",
+            "integrity": "sha1-bhoD88Y25sco/+cHdOrU8LP4i90=",
+            "requires": {
+                "filenamify": "*"
+            }
+        },
+        "@types/form-data": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
+            "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/html-entities": {
+            "version": "1.2.16",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/html-entities/-/@types/html-entities-1.2.16.tgz",
+            "integrity": "sha1-TR/iCMTDNyesRlfm9dkr/lJCcCM="
+        },
+        "@types/i18next": {
+            "version": "2.3.41",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next/-/@types/i18next-2.3.41.tgz",
+            "integrity": "sha1-Wj69y0lCBSyi73HE9jQUOMV8sYw=",
+            "dev": true
+        },
+        "@types/i18next-node-fs-backend": {
+            "version": "0.0.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next-node-fs-backend/-/@types/i18next-node-fs-backend-0.0.30.tgz",
+            "integrity": "sha1-dFT46SN5ii6/FjCb78/f3jLpCnw=",
+            "dev": true,
+            "requires": {
+                "@types/i18next": "^2"
+            }
+        },
+        "@types/jsonwebtoken": {
+            "version": "7.2.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/jsonwebtoken/-/@types/jsonwebtoken-7.2.8.tgz",
+            "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/mime": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.1.tgz",
+            "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
+        },
+        "@types/node": {
+            "version": "10.14.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.6.tgz",
+            "integrity": "sha1-nL/LYsUJRyF/TYjU0nTMQMImJak="
+        },
+        "@types/range-parser": {
+            "version": "1.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/range-parser/-/@types/range-parser-1.2.3.tgz",
+            "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+        },
+        "@types/request": {
+            "version": "2.48.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/request/-/@types/request-2.48.1.tgz",
+            "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
+            "requires": {
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
+            }
+        },
+        "@types/request-promise-native": {
+            "version": "1.0.16",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/request-promise-native/-/@types/request-promise-native-1.0.16.tgz",
+            "integrity": "sha1-oyam+1QdpjxscTKTwZNeVLfYTTs=",
+            "requires": {
+                "@types/request": "*"
+            }
+        },
+        "@types/restify": {
+            "version": "7.2.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-7.2.10.tgz",
+            "integrity": "sha1-rsvWK5NOLmdUJGQJ4qMaIp+yaCg=",
+            "dev": true,
+            "requires": {
+                "@types/bunyan": "*",
+                "@types/node": "*",
+                "@types/spdy": "*"
+            }
+        },
+        "@types/serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.2.tgz",
+            "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+            "requires": {
+                "@types/express-serve-static-core": "*",
+                "@types/mime": "*"
+            }
+        },
+        "@types/spdy": {
+            "version": "3.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/spdy/-/@types/spdy-3.4.4.tgz",
+            "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/tough-cookie": {
+            "version": "2.3.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.5.tgz",
+            "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+        },
+        "@types/tunnel": {
+            "version": "0.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tunnel/-/@types/tunnel-0.0.0.tgz",
+            "integrity": "sha1-wqQpQ+5jyQZSpVV7jE5Wzad/lE4=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+        },
+        "adal-node": {
+            "version": "0.1.28",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.1.28.tgz",
+            "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+            "requires": {
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "8.10.48",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.48.tgz",
+                    "integrity": "sha1-44UHNWFkOpumGZoZhf/ANTD5B4E="
+                }
+            }
+        },
+        "adaptivecards": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptivecards/-/adaptivecards-1.1.3.tgz",
+            "integrity": "sha1-MnEyWblzGoi2QMfy8VelhkXmjo8="
+        },
+        "ajv": {
+            "version": "6.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ambi": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ambi/-/ambi-2.5.0.tgz",
+            "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+            "requires": {
+                "editions": "^1.1.1",
+                "typechecker": "^4.3.0"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "4.7.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-4.7.0.tgz",
+                    "integrity": "sha1-Ukn0JzWPRbclDEkk/U0B7ZukNek=",
+                    "requires": {
+                        "editions": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "editions": {
+                            "version": "2.1.3",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-2.1.3.tgz",
+                            "integrity": "sha1-cnzPPsLHsS3MZSxxAA8WxIJNb30=",
+                            "requires": {
+                                "errlop": "^1.1.1",
+                                "semver": "^5.6.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ansi-align": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-align/-/ansi-align-2.0.0.tgz",
+            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.0.0"
+            }
+        },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+            "optional": true,
+            "requires": {
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
+            }
+        },
+        "append-transform": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^2.0.0"
+            }
+        },
+        "appinsights-usage": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/appinsights-usage/-/appinsights-usage-1.0.2.tgz",
+            "integrity": "sha1-wzIiq0rRYNWdbeydILqrEKHD4M0=",
+            "requires": {
+                "applicationinsights-js": "^1.0.3",
+                "away": "^1.0.0",
+                "babel-cli": "^6.14.0",
+                "babel-preset-es2015": "^6.14.0",
+                "remove-value": "^1.0.0"
+            }
+        },
+        "applicationinsights": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.2.0.tgz",
+            "integrity": "sha1-xMHYqEWquuwJD2+chK9JBnk8j64=",
+            "requires": {
+                "cls-hooked": "^4.2.2",
+                "continuation-local-storage": "^3.2.1",
+                "diagnostic-channel": "0.2.0",
+                "diagnostic-channel-publishers": "0.3.0"
+            }
+        },
+        "applicationinsights-js": {
+            "version": "1.0.20",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights-js/-/applicationinsights-js-1.0.20.tgz",
+            "integrity": "sha1-4FGaLAQ+m0aD0y0yegbD8Yxj1co="
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                }
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "optional": true,
+            "requires": {
+                "arr-flatten": "^1.0.1"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "optional": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async/-/async-2.6.0.tgz",
+            "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+            "requires": {
+                "lodash": "^4.14.0"
+            }
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8="
+        },
+        "async-hook-jl": {
+            "version": "1.7.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+            "integrity": "sha1-T9JcL4ZNuvJ5xhDXO/l7GyhZXmg=",
+            "requires": {
+                "stack-chain": "^1.3.7"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
+        },
+        "async-listener": {
+            "version": "0.6.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-listener/-/async-listener-0.6.10.tgz",
+            "integrity": "sha1-p8l6vlcLpgLXgic8DeYKUePhfLw=",
+            "requires": {
+                "semver": "^5.3.0",
+                "shimmer": "^1.1.0"
+            }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+        },
+        "away": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/away/-/away-1.0.0.tgz",
+            "integrity": "sha1-0G8Yf15HJELD9HxYJurxj2Twsao=",
+            "requires": {
+                "xtend": "2.0.3"
+            },
+            "dependencies": {
+                "xtend": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xtend/-/xtend-2.0.3.tgz",
+                    "integrity": "sha1-YmAJAPCWrWoRHjyjfbuQh3ZJMJQ="
+                }
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+        },
+        "axios": {
+            "version": "0.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.0.tgz",
+            "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+            "requires": {
+                "follow-redirects": "^1.3.0",
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "azure-cognitiveservices-contentmoderator": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/azure-cognitiveservices-contentmoderator/-/azure-cognitiveservices-contentmoderator-4.1.1.tgz",
+            "integrity": "sha1-oj+BC5dUdYKehpV2og6B98hhEfE=",
+            "requires": {
+                "ms-rest": "^2.3.3"
+            }
+        },
+        "azure-storage": {
+            "version": "2.10.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/azure-storage/-/azure-storage-2.10.2.tgz",
+            "integrity": "sha1-O8q9vxDnL9CZDbgRFuSQI8SmdbY=",
+            "requires": {
+                "browserify-mime": "~1.2.9",
+                "extend": "^3.0.2",
+                "json-edm-parser": "0.1.2",
+                "md5.js": "1.3.4",
+                "readable-stream": "~2.0.0",
+                "request": "^2.86.0",
+                "underscore": "~1.8.3",
+                "uuid": "^3.0.0",
+                "validator": "~9.4.1",
+                "xml2js": "0.2.8",
+                "xmlbuilder": "^9.0.7"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "sax": {
+                    "version": "0.5.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sax/-/sax-0.5.8.tgz",
+                    "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "xml2js": {
+                    "version": "0.2.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml2js/-/xml2js-0.2.8.tgz",
+                    "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+                    "requires": {
+                        "sax": "0.5.x"
+                    }
+                }
+            }
+        },
+        "babel-cli": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-cli/-/babel-cli-6.26.0.tgz",
+            "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+            "requires": {
+                "babel-core": "^6.26.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "chokidar": "^1.6.1",
+                "commander": "^2.11.0",
+                "convert-source-map": "^1.5.0",
+                "fs-readdir-recursive": "^1.0.0",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "output-file-sync": "^1.1.2",
+                "path-is-absolute": "^1.0.1",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6",
+                "v8flags": "^2.1.1"
+            }
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            }
+        },
+        "babel-core": {
+            "version": "6.26.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "babel-generator": {
+            "version": "6.26.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
+            "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "babel-helper-call-delegate": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-define-map": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "requires": {
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-get-function-arity": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-hoist-variables": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-optimise-call-expression": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-regex": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-replace-supers": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+            "requires": {
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-check-es2015-constants": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-plugin-transform-es2015-classes": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+            "requires": {
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-literals": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+            "requires": {
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+            "version": "6.26.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
+            "requires": {
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+            "requires": {
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+            "requires": {
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+            "requires": {
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-spread": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
+            }
+        },
+        "babel-plugin-transform-regenerator": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+            "requires": {
+                "regenerator-transform": "^0.10.0"
+            }
+        },
+        "babel-plugin-transform-strict-mode": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-polyfill": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+            "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+                }
+            }
+        },
+        "babel-preset-es2015": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+            "requires": {
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+                "babel-plugin-transform-es2015-classes": "^6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+                "babel-plugin-transform-es2015-for-of": "^6.22.0",
+                "babel-plugin-transform-es2015-function-name": "^6.24.1",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.24.1",
+                "babel-plugin-transform-es2015-parameters": "^6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+                "babel-plugin-transform-regenerator": "^6.24.1"
+            }
+        },
+        "babel-register": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "requires": {
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/base/-/base-0.11.2.tgz",
+            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "base64url": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/base64url/-/base64url-3.0.1.tgz",
+            "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "big-integer": {
+            "version": "1.6.43",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/big-integer/-/big-integer-1.6.43.tgz",
+            "integrity": "sha1-isFb8T6T5QlQCFkGEjPhnY0NmdE="
+        },
+        "bignumber.js": {
+            "version": "7.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bignumber.js/-/bignumber.js-7.2.1.tgz",
+            "integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
+        },
+        "binary-extensions": {
+            "version": "1.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U="
+        },
+        "binary-search-bounds": {
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+            "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+        },
+        "botbuilder": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.4.0.tgz",
+            "integrity": "sha1-h3xiqxDyOp1JJAQfjr86dyY/TTI=",
+            "requires": {
+                "@types/filenamify": "^2.0.1",
+                "@types/node": "^10.12.18",
+                "botbuilder-core": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "filenamify": "^2.0.0",
+                "fs-extra": "^7.0.1"
+            }
+        },
+        "botbuilder-ai": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.4.0.tgz",
+            "integrity": "sha1-PTLP8buGtIjYZTGTAD9nDKVsgkI=",
+            "requires": {
+                "@azure/cognitiveservices-luis-runtime": "2.0.0",
+                "@azure/ms-rest-js": "~1.8.2",
+                "@microsoft/recognizers-text-date-time": "1.1.2",
+                "@types/html-entities": "^1.2.16",
+                "@types/node": "^10.12.18",
+                "@types/request-promise-native": "^1.0.10",
+                "botbuilder-core": "^4.4.0",
+                "html-entities": "^1.2.1",
+                "moment": "^2.20.1",
+                "request": "^2.87.0",
+                "request-promise-native": "1.0.5",
+                "url-parse": "^1.4.4"
+            },
+            "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.8.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.6.tgz",
+                    "integrity": "sha1-RwR0p73XP7SEyLwOMpaMWHN+er0=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.18.0",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    }
+                },
+                "tunnel": {
+                    "version": "0.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.6.tgz",
+                    "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+                }
+            }
+        },
+        "botbuilder-applicationinsights": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.4.0.tgz",
+            "integrity": "sha1-G5o7MSZ3iCehzQKqrBU+Pq2F67Q=",
+            "requires": {
+                "appinsights-usage": "1.0.2",
+                "applicationinsights": "1.2.0",
+                "applicationinsights-js": "1.0.20",
+                "botbuilder-core": "^4.4.0",
+                "cls-hooked": "^4.2.2"
+            }
+        },
+        "botbuilder-azure": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.4.0.tgz",
+            "integrity": "sha1-znzJz6T/RB5dasJeoIw9/rlWrFU=",
+            "requires": {
+                "@types/documentdb": "^1.10.5",
+                "@types/node": "^10.12.18",
+                "azure-storage": "2.10.2",
+                "botbuilder": "^4.4.0",
+                "documentdb": "1.14.5",
+                "flat": "^4.0.0",
+                "semaphore": "^1.1.0"
+            }
+        },
+        "botbuilder-core": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.4.0.tgz",
+            "integrity": "sha1-4smEQxvncp/wxZWD/H1FpYZIMNE=",
+            "requires": {
+                "assert": "^1.4.1",
+                "botframework-schema": "^4.4.0"
+            }
+        },
+        "botbuilder-dialogs": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.4.0.tgz",
+            "integrity": "sha1-M+qPlV+PwywBskuuNjQahuhG/Wo=",
+            "requires": {
+                "@microsoft/recognizers-text-choice": "1.1.2",
+                "@microsoft/recognizers-text-date-time": "1.1.2",
+                "@microsoft/recognizers-text-number": "1.1.2",
+                "@microsoft/recognizers-text-suite": "1.1.2",
+                "@types/node": "^10.12.18",
+                "botbuilder-core": "^4.4.0"
+            },
+            "dependencies": {
+                "@microsoft/recognizers-text-number": {
+                    "version": "1.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.2.tgz",
+                    "integrity": "sha1-tydc9UC6AY4CJcXV4H7AsENSZ+w=",
+                    "requires": {
+                        "@microsoft/recognizers-text": "~1.1.2",
+                        "bignumber.js": "^7.2.1",
+                        "lodash.escaperegexp": "^4.1.2",
+                        "lodash.sortby": "^4.7.0",
+                        "lodash.trimend": "^4.5.1"
+                    }
+                }
+            }
+        },
+        "botbuilder-skills": {
+            "version": "4.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-skills/-/botbuilder-skills-4.4.5.tgz",
+            "integrity": "sha1-G7Msz1xoIVSpVWX4xAvpjhhrVwg=",
+            "requires": {
+                "@azure/ms-rest-js": "1.2.6",
+                "botbuilder": "^4.4.0",
+                "botbuilder-ai": "^4.4.0",
+                "botbuilder-azure": "^4.4.0",
+                "botbuilder-core": "^4.4.0",
+                "botbuilder-dialogs": "^4.4.0",
+                "botbuilder-solutions": "^4.4.5",
+                "botframework-config": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "botframework-schema": "^4.4.0",
+                "i18n": "^0.8.3",
+                "jsonwebtoken": "^8.5.1",
+                "jwks-rsa": "^1.4.0",
+                "microsoft-bot-protocol": "^0.0.1",
+                "microsoft-bot-protocol-websocket": "^0.0.1",
+                "p-queue": "^4.0.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "jsonwebtoken": {
+                    "version": "8.5.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+                    "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+                    "requires": {
+                        "jws": "^3.2.2",
+                        "lodash.includes": "^4.3.0",
+                        "lodash.isboolean": "^3.0.3",
+                        "lodash.isinteger": "^4.0.4",
+                        "lodash.isnumber": "^3.0.3",
+                        "lodash.isplainobject": "^4.0.6",
+                        "lodash.isstring": "^4.0.1",
+                        "lodash.once": "^4.0.0",
+                        "ms": "^2.1.1",
+                        "semver": "^5.6.0"
+                    }
+                }
+            }
+        },
+        "botbuilder-solutions": {
+            "version": "4.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-solutions/-/botbuilder-solutions-4.4.5.tgz",
+            "integrity": "sha1-hFj37SvoCoG92RWMDg0AfMHOA9M=",
+            "requires": {
+                "@microsoft/recognizers-text": "^1.1.4",
+                "@microsoft/recognizers-text-choice": "^1.1.4",
+                "adaptivecards": "^1.1.3",
+                "azure-cognitiveservices-contentmoderator": "^4.0.0",
+                "botbuilder": "^4.4.0",
+                "botbuilder-ai": "^4.4.0",
+                "botbuilder-azure": "^4.4.0",
+                "botbuilder-core": "^4.4.0",
+                "botbuilder-dialogs": "^4.4.0",
+                "botframework-config": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "botframework-schema": "^4.4.0",
+                "dateformat": "^3.0.3",
+                "i18next": "^15.0.6",
+                "ms-rest-azure": "^2.5.0",
+                "p-queue": "^4.0.0"
+            },
+            "dependencies": {
+                "@microsoft/recognizers-text-choice": {
+                    "version": "1.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.4.tgz",
+                    "integrity": "sha1-jpro+ASuSb1X3Wu/InoqsOFKkEE=",
+                    "requires": {
+                        "@microsoft/recognizers-text": "~1.1.4",
+                        "grapheme-splitter": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "botframework-config": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.4.0.tgz",
+            "integrity": "sha1-nkLbhpuLXz4KM71R/1ydxInJ6K4=",
+            "requires": {
+                "fs-extra": "^7.0.0",
+                "process": "^0.11.10",
+                "read-text-file": "^1.1.0",
+                "url": "^0.11.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "botframework-connector": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.4.0.tgz",
+            "integrity": "sha1-a20bUdRO+drnsiyE8e74qczenfU=",
+            "requires": {
+                "@azure/ms-rest-js": "1.2.6",
+                "@types/jsonwebtoken": "7.2.8",
+                "@types/node": "^10.12.18",
+                "base64url": "^3.0.0",
+                "botframework-schema": "^4.4.0",
+                "form-data": "^2.3.3",
+                "jsonwebtoken": "8.0.1",
+                "nock": "^10.0.3",
+                "node-fetch": "^2.2.1",
+                "rsa-pem-from-mod-exp": "^0.8.4"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
+                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                }
+            }
+        },
+        "botframework-schema": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.4.0.tgz",
+            "integrity": "sha1-g7wFIh5Qu58dYJzlKoJCvsvs+zA="
+        },
+        "boxen": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/boxen/-/boxen-1.3.0.tgz",
+            "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+            "dev": true,
+            "requires": {
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "optional": true,
+            "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "dev": true
+        },
+        "browserify-mime": {
+            "version": "1.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browserify-mime/-/browserify-mime-1.2.9.tgz",
+            "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "bunyan": {
+            "version": "1.8.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.12.tgz",
+            "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+            "requires": {
+                "dtrace-provider": "~0.8",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "caching-transform": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/caching-transform/-/caching-transform-3.0.2.tgz",
+            "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+            "dev": true,
+            "requires": {
+                "hasha": "^3.0.0",
+                "make-dir": "^2.0.0",
+                "package-hash": "^3.0.0",
+                "write-file-atomic": "^2.4.2"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "camelcase": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-4.1.0.tgz",
+            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "dev": true
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            }
+        },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "optional": true,
+            "requires": {
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
+            }
+        },
+        "ci-info": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
+            "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "cli-boxes": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "cls-hooked": {
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cls-hooked/-/cls-hooked-4.2.2.tgz",
+            "integrity": "sha1-rS6aQJJoDNr/6y01UdoOIl6uGQg=",
+            "requires": {
+                "async-hook-jl": "^1.7.6",
+                "emitter-listener": "^1.0.1",
+                "semver": "^5.4.1"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/colors/-/colors-1.2.4.tgz",
+            "integrity": "sha1-4MtB0+SyCAazv8J/RVnwG5S8L3w=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.20.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI="
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "configstore": {
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            }
+        },
+        "continuation-local-storage": {
+            "version": "3.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+            "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
+            "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.1.1"
+            }
+        },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "copyfiles": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.1.0.tgz",
+            "integrity": "sha1-DipBiBYtay88Wt/jTpwL1WTSMWQ=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.5",
+                "minimatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "noms": "0.0.0",
+                "through2": "^2.0.1",
+                "yargs": "^11.0.0"
+            }
+        },
+        "core-js": {
+            "version": "2.6.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/core-js/-/core-js-2.6.5.tgz",
+            "integrity": "sha1-RLyNJJ5/sv9dAOA0Gn/7lPv2eJU="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cp-file": {
+            "version": "6.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cp-file/-/cp-file-6.2.0.tgz",
+            "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^2.0.0",
+                "nested-error-stacks": "^2.0.0",
+                "pify": "^4.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dev": true,
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
+            }
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+            "dev": true
+        },
+        "crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+            "dev": true
+        },
+        "csextends": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csextends/-/csextends-1.2.0.tgz",
+            "integrity": "sha1-Y3SyEJhLVNRJXynJnT3QabgFQ+U="
+        },
+        "csv": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-1.2.1.tgz",
+            "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
+            "requires": {
+                "csv-generate": "^1.1.2",
+                "csv-parse": "^1.3.3",
+                "csv-stringify": "^1.1.2",
+                "stream-transform": "^0.2.2"
+            }
+        },
+        "csv-generate": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-1.1.2.tgz",
+            "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
+        },
+        "csv-parse": {
+            "version": "1.3.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-1.3.3.tgz",
+            "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+        },
+        "csv-stringify": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-1.1.2.tgz",
+            "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+            "requires": {
+                "lodash.get": "~4.4.2"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "date-utils": {
+            "version": "1.2.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/date-utils/-/date-utils-1.2.21.tgz",
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
+        },
+        "debug": {
+            "version": "3.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
+        },
+        "deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+            "dev": true
+        },
+        "default-require-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
+        },
+        "diagnostic-channel": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "diagnostic-channel-publishers": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.0.tgz",
+            "integrity": "sha1-oyZJxuD98fT+aiG95k3BO1AMvwI="
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+            "dev": true
+        },
+        "documentdb": {
+            "version": "1.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/documentdb/-/documentdb-1.14.5.tgz",
+            "integrity": "sha1-NWhR8KpefxiuDtIC3g3ROwWz92I=",
+            "requires": {
+                "big-integer": "^1.6.25",
+                "binary-search-bounds": "2.0.3",
+                "int64-buffer": "^0.1.9",
+                "priorityqueuejs": "1.0.0",
+                "semaphore": "1.0.5",
+                "tunnel": "0.0.5",
+                "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "semaphore": {
+                    "version": "1.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semaphore/-/semaphore-1.0.5.tgz",
+                    "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+                }
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
+        "dotenv": {
+            "version": "6.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dotenv/-/dotenv-6.2.0.tgz",
+            "integrity": "sha1-lBwEEFNdlCyL7PKNPzV9vZ1HYGQ="
+        },
+        "dtrace-provider": {
+            "version": "0.8.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+            "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+            "requires": {
+                "nan": "^2.10.0"
+            }
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
+        },
+        "eachr": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eachr/-/eachr-2.0.4.tgz",
+            "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
+            "requires": {
+                "typechecker": "^2.0.8"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "editions": {
+            "version": "1.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-1.3.4.tgz",
+            "integrity": "sha1-NmLLWSNHwxaOuOSYoP9zJx1n9Qs="
+        },
+        "emitter-listener": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha1-VrFA6PaZI3Wz18ssqxzHQy2WMug=",
+            "requires": {
+                "shimmer": "^1.2.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+            "dev": true
+        },
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "~0.4.13"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "errlop": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/errlop/-/errlop-1.1.1.tgz",
+            "integrity": "sha1-2a5MdsPmSVbF155uA11jQ7/WIlA=",
+            "requires": {
+                "editions": "^2.1.2"
+            },
+            "dependencies": {
+                "editions": {
+                    "version": "2.1.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-2.1.3.tgz",
+                    "integrity": "sha1-cnzPPsLHsS3MZSxxAA8WxIJNb30=",
+                    "requires": {
+                        "errlop": "^1.1.1",
+                        "semver": "^5.6.0"
+                    }
+                }
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "4.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es6-promise/-/es6-promise-4.2.6.tgz",
+            "integrity": "sha1-toXt2CWIhjZepitX0w3ij63Nl08="
+        },
+        "escape-regexp-component": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+            "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+        },
+        "eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
+        },
+        "ewma": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ewma/-/ewma-2.0.1.tgz",
+            "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "optional": true,
+            "requires": {
+                "is-posix-bracket": "^0.1.0"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "optional": true,
+            "requires": {
+                "fill-range": "^2.1.0"
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extendr": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extendr/-/extendr-2.1.0.tgz",
+            "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
+            "requires": {
+                "typechecker": "~2.0.1"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "2.0.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.0.8.tgz",
+                    "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
+                }
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "optional": true,
+            "requires": {
+                "is-extglob": "^1.0.0"
+            }
+        },
+        "extract-opts": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extract-opts/-/extract-opts-2.2.0.tgz",
+            "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
+            "requires": {
+                "typechecker": "~2.0.1"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "2.0.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.0.8.tgz",
+                    "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha1-Rvi2wisw/3qBNX1PWav66TggJUM="
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "optional": true
+        },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+        },
+        "filenamify": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-2.1.0.tgz",
+            "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+            "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.0",
+                "trim-repeated": "^1.0.0"
+            }
+        },
+        "fill-range": {
+            "version": "2.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-2.2.4.tgz",
+            "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
+            "optional": true,
+            "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+            }
+        },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+            "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "find-my-way": {
+            "version": "1.18.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-1.18.1.tgz",
+            "integrity": "sha1-XbYF6rchHuaverCOtPVoBgqo6fY=",
+            "requires": {
+                "fast-decode-uri-component": "^1.0.0",
+                "safe-regex": "^1.1.0",
+                "semver-store": "^0.3.0"
+            }
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^2.0.0"
+            }
+        },
+        "flat": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.0.tgz",
+            "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+            "requires": {
+                "is-buffer": "~2.0.3"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+                }
+            }
+        },
+        "follow-redirects": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha1-SJ68GY3A5/ZBZ70jsDxMGbV4THY=",
+            "requires": {
+                "debug": "^3.2.6"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "optional": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/foreground-child/-/foreground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                }
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "formidable": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/formidable/-/formidable-1.2.1.tgz",
+            "integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk="
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs-readdir-recursive": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+            "version": "1.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
+            "optional": true,
+            "requires": {
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "optional": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "^4.1.0",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.1",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.2.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "optional": true
+                }
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+        },
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "optional": true,
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "optional": true,
+            "requires": {
+                "is-glob": "^2.0.0"
+            }
+        },
+        "global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4"
+            }
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+        },
+        "got": {
+            "version": "6.7.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/got/-/got-6.7.1.tgz",
+            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+            "dev": true,
+            "requires": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+        },
+        "grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4="
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "dev": true
+        },
+        "handle-thing": {
+            "version": "1.2.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/handle-thing/-/handle-thing-1.2.5.tgz",
+            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+        },
+        "handlebars": {
+            "version": "4.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+            "dev": true,
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has/-/has-1.0.3.tgz",
+            "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "hasha": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hasha/-/hasha-3.0.0.tgz",
+            "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+            "dev": true,
+            "requires": {
+                "is-stream": "^1.0.1"
+            }
+        },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/he/-/he-1.2.0.tgz",
+            "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+            "dev": true
+        },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+        },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "i18n": {
+            "version": "0.8.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18n/-/i18n-0.8.3.tgz",
+            "integrity": "sha1-LYzxwkciYCwgQdAbpq5eqlE4jw4=",
+            "requires": {
+                "debug": "*",
+                "make-plural": "^3.0.3",
+                "math-interval-parser": "^1.1.0",
+                "messageformat": "^0.3.1",
+                "mustache": "*",
+                "sprintf-js": ">=1.0.3"
+            }
+        },
+        "i18next": {
+            "version": "15.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.1.tgz",
+            "integrity": "sha1-LWDN7hUbAZ4XHkSmZszWtwSshno=",
+            "requires": {
+                "@babel/runtime": "^7.3.1"
+            }
+        },
+        "i18next-node-fs-backend": {
+            "version": "2.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
+            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
+            "requires": {
+                "js-yaml": "3.13.1",
+                "json5": "2.0.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
+                    "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore-by-default": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+            "dev": true
+        },
+        "ignorefs": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorefs/-/ignorefs-1.2.0.tgz",
+            "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+            "requires": {
+                "editions": "^1.3.3",
+                "ignorepatterns": "^1.1.0"
+            }
+        },
+        "ignorepatterns": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
+            "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
+        },
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.1.tgz",
+            "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "dev": true
+        },
+        "int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "requires": {
+                "binary-extensions": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+        },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
+        },
+        "is-ci": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-ci/-/is-ci-1.2.1.tgz",
+            "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
+            "dev": true,
+            "requires": {
+                "ci-info": "^1.5.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+                }
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "optional": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "optional": true,
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "optional": true
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "optional": true,
+            "requires": {
+                "is-extglob": "^1.0.0"
+            }
+        },
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-npm": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-npm/-/is-npm-1.0.0.tgz",
+            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "optional": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "^1.0.1"
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "requires": {
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "optional": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "optional": true
+        },
+        "is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "optional": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "2.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+            "dev": true,
+            "requires": {
+                "append-transform": "^1.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha1-BeNZ7lceWtftZBpu7B5Ue6Ut6mU=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+            "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.1.2"
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jschardet": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jschardet/-/jschardet-1.6.0.tgz",
+            "integrity": "sha1-x9GnHtz/KDnbL57DD8XV69PBpng="
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        },
+        "json-edm-parser": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+            "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+            "requires": {
+                "jsonparse": "~1.2.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonparse": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonparse/-/jsonparse-1.2.0.tgz",
+            "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+        },
+        "jsonwebtoken": {
+            "version": "8.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+            "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+            "requires": {
+                "jws": "^3.1.4",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jwks-rsa": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jwks-rsa/-/jwks-rsa-1.5.0.tgz",
+            "integrity": "sha1-FXXvCQOGjSgxDGuSNUiVRwrIkdw=",
+            "requires": {
+                "@types/express-jwt": "0.0.34",
+                "debug": "^2.2.0",
+                "limiter": "^1.1.0",
+                "lru-memoizer": "^1.6.0",
+                "ms": "^2.0.0",
+                "request": "^2.73.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
+                    }
+                }
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "latest-version": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/latest-version/-/latest-version-3.1.0.tgz",
+            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+            "dev": true,
+            "requires": {
+                "package-json": "^4.0.0"
+            }
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "limiter": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/limiter/-/limiter-1.1.4.tgz",
+            "integrity": "sha1-h8nDly04n9sLpnpFqtvF0vhBO8E="
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lock": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lock/-/lock-0.1.4.tgz",
+            "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.last": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.last/-/lodash.last-3.0.0.tgz",
+            "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
+        },
+        "lodash.max": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.max/-/lodash.max-4.0.1.tgz",
+            "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+        },
+        "lodash.tonumber": {
+            "version": "4.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+            "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
+        },
+        "lodash.trimend": {
+            "version": "4.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+            "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "4.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-4.0.2.tgz",
+            "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+            "requires": {
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
+            }
+        },
+        "lru-memoizer": {
+            "version": "1.12.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-memoizer/-/lru-memoizer-1.12.0.tgz",
+            "integrity": "sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=",
+            "requires": {
+                "lock": "~0.1.2",
+                "lodash": "^4.17.4",
+                "lru-cache": "~4.0.0",
+                "very-fast-args": "^1.1.0"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "make-plural": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-plural/-/make-plural-3.0.6.tgz",
+            "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
+            "requires": {
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "optional": true
+                }
+            }
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "math-interval-parser": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/math-interval-parser/-/math-interval-parser-1.1.0.tgz",
+            "integrity": "sha1-2+2lsGsySZc8bfYXD94jhvCv2JM=",
+            "requires": {
+                "xregexp": "^2.0.0"
+            }
+        },
+        "math-random": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
+            "optional": true
+        },
+        "md5": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.2.1.tgz",
+            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "dev": true,
+            "requires": {
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
+            }
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/merge-source-map/-/merge-source-map-1.1.0.tgz",
+            "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "messageformat": {
+            "version": "0.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/messageformat/-/messageformat-0.3.1.tgz",
+            "integrity": "sha1-5Y//gkXps5cXmeW0PbWLPpQX9aI=",
+            "requires": {
+                "async": "~1.5.2",
+                "glob": "~6.0.4",
+                "make-plural": "~3.0.3",
+                "nopt": "~3.0.6",
+                "watchr": "~2.4.13"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "optional": true,
+            "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+            }
+        },
+        "microsoft-bot-protocol": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/microsoft-bot-protocol/-/microsoft-bot-protocol-0.0.1.tgz",
+            "integrity": "sha1-ur2NXDtoMBxCKIoTf4BYyrVF+Wk=",
+            "requires": {
+                "promise.prototype.finally": "^3.1.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "microsoft-bot-protocol-websocket": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/microsoft-bot-protocol-websocket/-/microsoft-bot-protocol-websocket-0.0.1.tgz",
+            "integrity": "sha1-RLaXZwmbvZQmaRHGo2CKTzmxmmA=",
+            "requires": {
+                "microsoft-bot-protocol": "^0.0.1",
+                "uuid": "^3.3.2",
+                "watershed": "^0.4.0",
+                "ws": "^6.2.1"
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+        },
+        "mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI="
+        },
+        "mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+            "requires": {
+                "mime-db": "1.40.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+            "dev": true
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "6.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha/-/mocha-6.1.4.tgz",
+            "integrity": "sha1-41+tokLVQ0p+Fj1VXHBfaHWVFkA=",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "3.2.3",
+                "browser-stdout": "1.3.1",
+                "debug": "3.2.6",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "find-up": "3.0.0",
+                "glob": "7.1.3",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "3.13.1",
+                "log-symbols": "2.2.0",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.5",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "13.2.2",
+                "yargs-parser": "13.0.0",
+                "yargs-unparser": "1.5.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-4.3.0.tgz",
+                    "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^2.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.0.0.tgz",
+                    "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "13.2.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-13.2.2.tgz",
+                    "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "os-locale": "^3.1.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-13.0.0.tgz",
+                    "integrity": "sha1-P8RPPnaovbHMNgLoYBCGAuXM3os=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "mocha-junit-reporter": {
+            "version": "1.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha-junit-reporter/-/mocha-junit-reporter-1.22.0.tgz",
+            "integrity": "sha1-Tu4vMxg5i/Qkpkt1lMp6OdkkR5w=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "md5": "^2.1.0",
+                "mkdirp": "~0.5.1",
+                "strip-ansi": "^4.0.0",
+                "xml": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s="
+        },
+        "ms": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        },
+        "ms-rest": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms-rest/-/ms-rest-2.5.0.tgz",
+            "integrity": "sha1-1IPAA/fedwOt5rwZw7Qxmv+sJoc=",
+            "requires": {
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.88.0",
+                "through": "^2.3.8",
+                "tunnel": "0.0.5",
+                "uuid": "^3.2.1"
+            }
+        },
+        "ms-rest-azure": {
+            "version": "2.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms-rest-azure/-/ms-rest-azure-2.6.0.tgz",
+            "integrity": "sha1-IJjv7FKe7PoMbiFbaRQ6vKuhIUA=",
+            "requires": {
+                "adal-node": "^0.1.28",
+                "async": "2.6.0",
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "request": "^2.88.0",
+                "uuid": "^3.2.1"
+            }
+        },
+        "mustache": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mustache/-/mustache-3.0.1.tgz",
+            "integrity": "sha1-hzhV8jqoqVsVD7ltmDbtvFodJIo="
+        },
+        "mv": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mv/-/mv-2.1.1.tgz",
+            "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+            "optional": true,
+            "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "optional": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.4.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rimraf/-/rimraf-2.4.5.tgz",
+                    "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+                    "optional": true,
+                    "requires": {
+                        "glob": "^6.0.1"
+                    }
+                }
+            }
+        },
+        "nan": {
+            "version": "2.13.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.13.2.tgz",
+            "integrity": "sha1-9R3Hrma6fV1V4ebU2AkugCya7+c="
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "ncp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ncp/-/ncp-2.0.0.tgz",
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+            "optional": true
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+            "dev": true
+        },
+        "nested-error-stacks": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+            "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
+        },
+        "nock": {
+            "version": "10.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nock/-/nock-10.0.6.tgz",
+            "integrity": "sha1-5tkO56aLjPwqt/YSfn2Zqn0T0RE=",
+            "requires": {
+                "chai": "^4.1.2",
+                "debug": "^4.1.0",
+                "deep-equal": "^1.0.0",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.5",
+                "mkdirp": "^0.5.0",
+                "propagate": "^1.0.0",
+                "qs": "^6.5.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "node-environment-flags": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+            "integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
+            "dev": true,
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3",
+                "semver": "^5.7.0"
+            }
+        },
+        "node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+            "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+            }
+        },
+        "nodemon": {
+            "version": "1.19.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-1.19.0.tgz",
+            "integrity": "sha1-NY4AVUmh6eEUjLK5uLKJV9xORSc=",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.1.5",
+                "debug": "^3.1.0",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.6",
+                "semver": "^5.5.0",
+                "supports-color": "^5.2.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.2",
+                "update-notifier": "^2.5.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "dev": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chokidar": {
+                    "version": "2.1.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-2.1.6.tgz",
+                    "integrity": "sha1-tsrWU6kp4kTOioNCRBZNJB+pVMU=",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "noms": {
+            "version": "0.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/noms/-/noms-0.0.0.tgz",
+            "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "~1.0.31"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "optional": true,
+            "requires": {
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nyc": {
+            "version": "14.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nyc/-/nyc-14.1.1.tgz",
+            "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "caching-transform": "^3.0.2",
+                "convert-source-map": "^1.6.0",
+                "cp-file": "^6.2.0",
+                "find-cache-dir": "^2.1.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.5",
+                "istanbul-lib-hook": "^2.0.7",
+                "istanbul-lib-instrument": "^3.3.0",
+                "istanbul-lib-report": "^2.0.8",
+                "istanbul-lib-source-maps": "^3.0.6",
+                "istanbul-reports": "^2.2.4",
+                "js-yaml": "^3.13.1",
+                "make-dir": "^2.1.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.2.3",
+                "uuid": "^3.3.2",
+                "yargs": "^13.2.2",
+                "yargs-parser": "^13.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-4.3.0.tgz",
+                    "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^2.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "13.2.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-13.2.4.tgz",
+                    "integrity": "sha1-C1YreUAW65ZRuYvTes82SqXW3IM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "os-locale": "^3.1.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-13.1.0.tgz",
+                    "integrity": "sha1-cBa23QPijhQYpRDiWL5L/1oxE48=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "requires": {
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "optional": true,
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "requires": {
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-locale": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-2.1.0.tgz",
+            "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+            "dev": true,
+            "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "output-file-sync": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/output-file-sync/-/output-file-sync-1.1.2.tgz",
+            "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+            "requires": {
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
+            }
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+            "dev": true,
+            "requires": {
+                "p-try": "^1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^1.1.0"
+            }
+        },
+        "p-queue": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-4.0.0.tgz",
+            "integrity": "sha1-7Q7uh5iSftbywvX1t3/bIGGl00Y=",
+            "requires": {
+                "eventemitter3": "^3.1.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "package-hash": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/package-hash/-/package-hash-3.0.0.tgz",
+            "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^3.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
+        },
+        "package-json": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/package-json/-/package-json-4.0.1.tgz",
+            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+            "dev": true,
+            "requires": {
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "optional": true,
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "pidusage": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-1.2.0.tgz",
+            "integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI="
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                }
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "optional": true
+        },
+        "priorityqueuejs": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+            "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/private/-/private-0.1.8.tgz",
+            "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+        },
+        "promise.prototype.finally": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
+            "integrity": "sha1-ZvFhsWQ2NuUOfPIB3BuEqFfzhk4=",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.9.0",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "propagate": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/propagate/-/propagate-1.0.0.tgz",
+            "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+        },
+        "pstree.remy": {
+            "version": "1.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pstree.remy/-/pstree.remy-1.1.6.tgz",
+            "integrity": "sha1-c6VarZ4tlYFJJxMfv03Bti0ln0c=",
+            "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4="
+        },
+        "randomatic": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
+            "optional": true,
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
+                    "optional": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+                    "optional": true
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                }
+            }
+        },
+        "read-text-file": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-text-file/-/read-text-file-1.1.0.tgz",
+            "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
+            "requires": {
+                "iconv-lite": "^0.4.17",
+                "jschardet": "^1.4.2"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                }
+            }
+        },
+        "readdirp": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+        },
+        "regenerator-transform": {
+            "version": "0.10.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+            "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+            "requires": {
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+            "optional": true,
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpu-core": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpu-core/-/regexpu-core-2.0.0.tgz",
+            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+            "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+            }
+        },
+        "registry-auth-token": {
+            "version": "3.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+            "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
+            "dev": true,
+            "requires": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+            "dev": true,
+            "requires": {
+                "rc": "^1.0.1"
+            }
+        },
+        "regjsgen": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regjsgen/-/regjsgen-0.2.0.tgz",
+            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+        },
+        "regjsparser": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regjsparser/-/regjsparser-0.1.5.tgz",
+            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                }
+            }
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "remove-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/remove-value/-/remove-value-1.0.0.tgz",
+            "integrity": "sha1-uKmd0TbRbt5YsZvKjnkjVbqt0SM="
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "replace": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/replace/-/replace-1.1.0.tgz",
+            "integrity": "sha1-TLBPE40U83xHufLSFOtKBXvZSyI=",
+            "dev": true,
+            "requires": {
+                "colors": "1.2.4",
+                "minimatch": "3.0.4",
+                "yargs": "12.0.5"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-4.3.0.tgz",
+                    "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^2.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request/-/request-2.88.0.tgz",
+            "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "requires": {
+                "lodash": "^4.13.1"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        },
+        "resolve": {
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.11.0.tgz",
+            "integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "restify": {
+            "version": "7.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify/-/restify-7.7.0.tgz",
+            "integrity": "sha1-Tg44hPyHFvFL6iksKVfKcG/EJ/c=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "bunyan": "^1.8.12",
+                "csv": "^1.1.1",
+                "dtrace-provider": "^0.8.1",
+                "escape-regexp-component": "^1.0.2",
+                "ewma": "^2.0.1",
+                "find-my-way": "^1.13.0",
+                "formidable": "^1.2.1",
+                "http-signature": "^1.2.0",
+                "lodash": "^4.17.10",
+                "lru-cache": "^4.1.3",
+                "mime": "^1.5.0",
+                "negotiator": "^0.6.1",
+                "once": "^1.4.0",
+                "pidusage": "^1.2.0",
+                "qs": "^6.5.2",
+                "restify-errors": "^5.0.0",
+                "semver": "^5.4.1",
+                "spdy": "^3.4.7",
+                "uuid": "^3.1.0",
+                "vasync": "^1.6.4",
+                "verror": "^1.10.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                }
+            }
+        },
+        "restify-errors": {
+            "version": "5.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify-errors/-/restify-errors-5.0.0.tgz",
+            "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "lodash": "^4.2.1",
+                "safe-json-stringify": "^1.0.3",
+                "verror": "^1.8.1"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "rsa-pem-from-mod-exp": {
+            "version": "0.8.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+            "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        },
+        "safe-json-stringify": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+            "integrity": "sha1-NW5EvJjx+TzkXfFLzXwBzahuCv0=",
+            "optional": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safefs": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safefs/-/safefs-3.2.2.tgz",
+            "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+            "requires": {
+                "graceful-fs": "*"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+        },
+        "scandirectory": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/scandirectory/-/scandirectory-2.5.0.tgz",
+            "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+            "requires": {
+                "ignorefs": "^1.0.0",
+                "safefs": "^3.1.2",
+                "taskgroup": "^4.0.5"
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+        },
+        "semaphore": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semaphore/-/semaphore-1.1.0.tgz",
+            "integrity": "sha1-qq2LhrIP6OmzKxbcLuaCqM0mqKo="
+        },
+        "semver": {
+            "version": "5.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        },
+        "semver-diff": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver-diff/-/semver-diff-2.1.0.tgz",
+            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+            "dev": true,
+            "requires": {
+                "semver": "^5.0.3"
+            }
+        },
+        "semver-store": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver-store/-/semver-store-0.3.0.tgz",
+            "integrity": "sha1-zmAv8H3zcIDsn0+0CylXZUe+++k="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+            "requires": {
+                "kind-of": "^3.2.0"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+            "requires": {
+                "source-map": "^0.5.6"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "spawn-wrap": {
+            "version": "1.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+            "integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+            "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
+            "dev": true
+        },
+        "spdy": {
+            "version": "3.4.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdy/-/spdy-3.4.7.tgz",
+            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "requires": {
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "spdy-transport": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+            "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
+            "requires": {
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM="
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-chain": {
+            "version": "1.3.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stack-chain/-/stack-chain-1.3.7.tgz",
+            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+        },
+        "stream-transform": {
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-0.2.2.tgz",
+            "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg="
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "taskgroup": {
+            "version": "4.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/taskgroup/-/taskgroup-4.3.1.tgz",
+            "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+            "requires": {
+                "ambi": "^2.2.0",
+                "csextends": "^1.0.3"
+            }
+        },
+        "term-size": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-1.2.0.tgz",
+            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+            "dev": true,
+            "requires": {
+                "execa": "^0.7.0"
+            }
+        },
+        "test-exclude": {
+            "version": "5.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/test-exclude/-/test-exclude-5.2.3.tgz",
+            "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+            },
+            "dependencies": {
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+                    "dev": true
+                }
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "touch": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/touch/-/touch-3.1.0.tgz",
+            "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
+            "dev": true,
+            "requires": {
+                "nopt": "~1.0.10"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "1.0.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nopt/-/nopt-1.0.10.tgz",
+                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
+            }
+        },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+        },
+        "tslint": {
+            "version": "5.16.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint/-/tslint-5.16.0.tgz",
+            "integrity": "sha1-rmH5xamNKVuaT0VTsbHoMcGYTWc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "tslint-microsoft-contrib": {
+            "version": "6.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz",
+            "integrity": "sha1-e/9zya16C361zbBJBt5Y9Cor96I=",
+            "dev": true,
+            "requires": {
+                "tsutils": "^2.27.2 <2.29.0"
+            },
+            "dependencies": {
+                "tsutils": {
+                    "version": "2.28.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.28.0.tgz",
+                    "integrity": "sha1-a9ceFggo+dAZtvToRHQiKPhRaaE=",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.8.1"
+                    }
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "tunnel": {
+            "version": "0.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.5.tgz",
+            "integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
+        },
+        "typechecker": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.1.0.tgz",
+            "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
+        },
+        "typescript": {
+            "version": "3.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.4.5.tgz",
+            "integrity": "sha1-LSYY0Qu1ZlcrjXqtUYDYQlfXCpk=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.5.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uglify-js/-/uglify-js-3.5.12.tgz",
+            "integrity": "sha1-a3Wcq8CMPpH+gjI9Y4cBnwxYZM0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "undefsafe": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/undefsafe/-/undefsafe-2.0.2.tgz",
+            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "underscore": {
+            "version": "1.8.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                }
+            }
+        },
+        "unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^1.0.0"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+            "dev": true
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
+            "dev": true
+        },
+        "update-notifier": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-2.5.0.tgz",
+            "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+            "dev": true,
+            "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "dev": true,
+            "requires": {
+                "prepend-http": "^1.0.1"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/use/-/use-3.1.1.tgz",
+            "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
+        },
+        "user-home": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/user-home/-/user-home-1.1.1.tgz",
+            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "requires": {
+                "inherits": "2.0.1"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+        },
+        "v8flags": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/v8flags/-/v8flags-2.1.1.tgz",
+            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "requires": {
+                "user-home": "^1.1.1"
+            }
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "validator": {
+            "version": "9.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/validator/-/validator-9.4.1.tgz",
+            "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
+        },
+        "vasync": {
+            "version": "1.6.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/vasync/-/vasync-1.6.4.tgz",
+            "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+            "requires": {
+                "verror": "1.6.0"
+            },
+            "dependencies": {
+                "extsprintf": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.2.0.tgz",
+                    "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+                },
+                "verror": {
+                    "version": "1.6.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/verror/-/verror-1.6.0.tgz",
+                    "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+                    "requires": {
+                        "extsprintf": "1.2.0"
+                    }
+                }
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "very-fast-args": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/very-fast-args/-/very-fast-args-1.1.0.tgz",
+            "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
+        },
+        "watchr": {
+            "version": "2.4.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/watchr/-/watchr-2.4.13.tgz",
+            "integrity": "sha1-10hHu01vkPYf4sdPn2hmKqDgdgE=",
+            "requires": {
+                "eachr": "^2.0.2",
+                "extendr": "^2.1.0",
+                "extract-opts": "^2.2.0",
+                "ignorefs": "^1.0.0",
+                "safefs": "^3.1.2",
+                "scandirectory": "^2.5.0",
+                "taskgroup": "^4.2.0",
+                "typechecker": "^2.0.8"
+            }
+        },
+        "watershed": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/watershed/-/watershed-0.4.0.tgz",
+            "integrity": "sha1-5BJLh3EptHZSJHdn63IgKfgJVTE=",
+            "requires": {
+                "dtrace-provider": "~0.8",
+                "readable-stream": "1.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-1.0.2.tgz",
+                    "integrity": "sha1-ITzjaGT8Hw1OmOA7nrksZAQimdQ="
+                }
+            }
+        },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "whatwg-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+            "integrity": "sha1-/IBORYzEYACbGiuWa8iBfSV4rvs="
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which/-/which-1.3.1.tgz",
+            "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "widest-line": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/widest-line/-/widest-line-2.0.1.tgz",
+            "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1"
+            }
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write-file-atomic": {
+            "version": "2.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+            "integrity": "sha1-pxgXBt+6F4VdIhFAqcBuFfzdh7k=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ws": {
+            "version": "6.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-6.2.1.tgz",
+            "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+            "dev": true
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        },
+        "xmldom": {
+            "version": "0.1.27",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.1.27.tgz",
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+        },
+        "xpath.js": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xpath.js/-/xpath.js-1.1.0.tgz",
+            "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+        },
+        "xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs": {
+            "version": "11.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-11.1.0.tgz",
+            "integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
+            "dev": true,
+            "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "9.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-9.0.2.tgz",
+            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^4.1.0"
+            }
+        },
+        "yargs-unparser": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+            "integrity": "sha1-8rsqfoPLyHu5XI5XKCigbJrdbg0=",
+            "dev": true,
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.11",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
+                    "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-4.3.0.tgz",
+                    "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^2.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package.json
@@ -47,6 +47,7 @@
         "@types/restify": "^7.2.4",
         "copyfiles": "^2.1.0",
         "mocha": "^6.1.4",
+        "mocha-junit-reporter": "^1.22.0",
         "nock": "^10.0.6",
         "nodemon": "^1.18.4",
         "nyc": "^14.1.1",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mocha.opts
@@ -1,3 +1,4 @@
+--reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.gitignore
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.gitignore
@@ -10,6 +10,9 @@ lib/
 # Bot Files
 *.bot
 
+# Test report
+test-results.xml
+
 #coverage
 coverage
 .nyc_output 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.nycrc
@@ -11,7 +11,8 @@
   ],
   "reporter": [
     "html",
-    "text"
+    "text",
+    "cobertura"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package-lock.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package-lock.json
@@ -1,0 +1,8541 @@
+{
+    "name": "sample-skill",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@azure/cognitiveservices-luis-runtime": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cognitiveservices-luis-runtime/-/@azure/cognitiveservices-luis-runtime-2.0.0.tgz",
+            "integrity": "sha1-l2hvKJfuLjwvjWuhrta5h1ehC5g=",
+            "requires": {
+                "@azure/ms-rest-js": "^1.6.0",
+                "tslib": "^1.9.3"
+            },
+            "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.8.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.7.tgz",
+                    "integrity": "sha1-C04xkpvrmaoWFeIjrdHJH4iCjt8=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.18.0",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    }
+                },
+                "tunnel": {
+                    "version": "0.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.6.tgz",
+                    "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+                }
+            }
+        },
+        "@azure/ms-rest-js": {
+            "version": "1.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
+            "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+            "requires": {
+                "axios": "^0.18.0",
+                "form-data": "^2.3.2",
+                "tough-cookie": "^2.4.3",
+                "tslib": "^1.9.2",
+                "uuid": "^3.2.1",
+                "xml2js": "^0.4.19"
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.0.0.tgz",
+            "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.4.4.tgz",
+            "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "2.5.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-2.5.2.tgz",
+                    "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.1.0.tgz",
+            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.0.0.tgz",
+            "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.4.4.tgz",
+            "integrity": "sha1-WXcSlDG4/jNHFzDSVc6GVK4SULY=",
+            "dev": true
+        },
+        "@babel/runtime": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.4.4.tgz",
+            "integrity": "sha1-3C40mC6yNoA6onoH/qaFevG5Fx0=",
+            "requires": {
+                "regenerator-runtime": "^0.13.2"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+                    "integrity": "sha1-MuWcmm+5saSv8JtJMMotRHc0NEc="
+                }
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.4.4.tgz",
+            "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.4.4.tgz",
+            "integrity": "sha1-B3bwOPbXg2GGC2gjiH1POTcTP+g=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.4.4.tgz",
+            "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@microsoft/microsoft-graph-client": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-client/-/@microsoft/microsoft-graph-client-1.7.0.tgz",
+            "integrity": "sha1-bbarlQYMoCM3hOoN6XSVGzdC2t4=",
+            "requires": {
+                "es6-promise": "^4.2.6",
+                "isomorphic-fetch": "^2.2.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@microsoft/microsoft-graph-types": {
+            "version": "1.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.9.0.tgz",
+            "integrity": "sha1-K1Y/OBZUCoKGRSixv7GgKONYirU="
+        },
+        "@microsoft/recognizers-text": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.1.4.tgz",
+            "integrity": "sha1-JkUw90iyytP6xU1TU4+IrSv5m34="
+        },
+        "@microsoft/recognizers-text-choice": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.2.tgz",
+            "integrity": "sha1-9HWbwSFM2sZ32HQCIIBpy8DGD4g=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "grapheme-splitter": "^1.0.2"
+            }
+        },
+        "@microsoft/recognizers-text-date-time": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.1.2.tgz",
+            "integrity": "sha1-pV+UhW5iHKfjkBWMkWym0z5YiPA=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "@microsoft/recognizers-text-number": "~1.1.2",
+                "@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+                "lodash.isequal": "^4.5.0",
+                "lodash.tonumber": "^4.0.3"
+            }
+        },
+        "@microsoft/recognizers-text-number": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.4.tgz",
+            "integrity": "sha1-H74EczIuYpK7k/mvhsbKXOBSEtk=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "bignumber.js": "^7.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.sortby": "^4.7.0",
+                "lodash.trimend": "^4.5.1"
+            }
+        },
+        "@microsoft/recognizers-text-number-with-unit": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.1.4.tgz",
+            "integrity": "sha1-p/JhTUGa2y/qmeXDJBUepFUmKqg=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "@microsoft/recognizers-text-number": "~1.1.4",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.last": "^3.0.0",
+                "lodash.max": "^4.0.1"
+            }
+        },
+        "@microsoft/recognizers-text-sequence": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.1.4.tgz",
+            "integrity": "sha1-M584KSuiB8147ife/uoat5IG+l0=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.4",
+                "grapheme-splitter": "^1.0.2"
+            }
+        },
+        "@microsoft/recognizers-text-suite": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.1.2.tgz",
+            "integrity": "sha1-2sRcXNgN3TEq05wUbQMktm1+Zk8=",
+            "requires": {
+                "@microsoft/recognizers-text": "~1.1.2",
+                "@microsoft/recognizers-text-choice": "~1.1.2",
+                "@microsoft/recognizers-text-date-time": "~1.1.2",
+                "@microsoft/recognizers-text-number": "~1.1.2",
+                "@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+                "@microsoft/recognizers-text-sequence": "~1.1.2"
+            }
+        },
+        "@types/body-parser": {
+            "version": "1.17.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/body-parser/-/@types/body-parser-1.17.0.tgz",
+            "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/bunyan": {
+            "version": "1.8.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/bunyan/-/@types/bunyan-1.8.6.tgz",
+            "integrity": "sha1-ZSdkHMowvt7F/rmrUnt4A7gABYI=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/caseless": {
+            "version": "0.12.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/caseless/-/@types/caseless-0.12.2.tgz",
+            "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+        },
+        "@types/connect": {
+            "version": "3.4.32",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.32.tgz",
+            "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/documentdb": {
+            "version": "1.10.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.5.tgz",
+            "integrity": "sha1-hsbsm+nOB/+fysXKPBdXDDhdQKQ=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/dotenv": {
+            "version": "6.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/dotenv/-/@types/dotenv-6.1.1.tgz",
+            "integrity": "sha1-984cxP408KQ3O6mf76Q3sL7FS0Y=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/express": {
+            "version": "4.16.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.16.1.tgz",
+            "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "@types/express-jwt": {
+            "version": "0.0.34",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-jwt/-/@types/express-jwt-0.0.34.tgz",
+            "integrity": "sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=",
+            "requires": {
+                "@types/express": "*",
+                "@types/express-unless": "*"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "4.16.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.16.4.tgz",
+            "integrity": "sha1-VruL5FWUAdaK9KNiSundMWYQPmA=",
+            "requires": {
+                "@types/node": "*",
+                "@types/range-parser": "*"
+            }
+        },
+        "@types/express-unless": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-unless/-/@types/express-unless-0.5.1.tgz",
+            "integrity": "sha1-T0QLkF5Cu/Uzgrgge8M33F/5/R8=",
+            "requires": {
+                "@types/express": "*"
+            }
+        },
+        "@types/filenamify": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/filenamify/-/@types/filenamify-2.0.2.tgz",
+            "integrity": "sha1-bhoD88Y25sco/+cHdOrU8LP4i90=",
+            "requires": {
+                "filenamify": "*"
+            }
+        },
+        "@types/form-data": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
+            "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/html-entities": {
+            "version": "1.2.16",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/html-entities/-/@types/html-entities-1.2.16.tgz",
+            "integrity": "sha1-TR/iCMTDNyesRlfm9dkr/lJCcCM="
+        },
+        "@types/i18next": {
+            "version": "2.3.41",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next/-/@types/i18next-2.3.41.tgz",
+            "integrity": "sha1-Wj69y0lCBSyi73HE9jQUOMV8sYw=",
+            "dev": true
+        },
+        "@types/i18next-node-fs-backend": {
+            "version": "0.0.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next-node-fs-backend/-/@types/i18next-node-fs-backend-0.0.30.tgz",
+            "integrity": "sha1-dFT46SN5ii6/FjCb78/f3jLpCnw=",
+            "dev": true,
+            "requires": {
+                "@types/i18next": "^2"
+            }
+        },
+        "@types/jsonwebtoken": {
+            "version": "7.2.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/jsonwebtoken/-/@types/jsonwebtoken-7.2.8.tgz",
+            "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/mime": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.1.tgz",
+            "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
+        },
+        "@types/node": {
+            "version": "10.14.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.6.tgz",
+            "integrity": "sha1-nL/LYsUJRyF/TYjU0nTMQMImJak="
+        },
+        "@types/range-parser": {
+            "version": "1.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/range-parser/-/@types/range-parser-1.2.3.tgz",
+            "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+        },
+        "@types/request": {
+            "version": "2.48.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/request/-/@types/request-2.48.1.tgz",
+            "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
+            "requires": {
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
+            }
+        },
+        "@types/request-promise-native": {
+            "version": "1.0.16",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/request-promise-native/-/@types/request-promise-native-1.0.16.tgz",
+            "integrity": "sha1-oyam+1QdpjxscTKTwZNeVLfYTTs=",
+            "requires": {
+                "@types/request": "*"
+            }
+        },
+        "@types/restify": {
+            "version": "7.2.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-7.2.10.tgz",
+            "integrity": "sha1-rsvWK5NOLmdUJGQJ4qMaIp+yaCg=",
+            "dev": true,
+            "requires": {
+                "@types/bunyan": "*",
+                "@types/node": "*",
+                "@types/spdy": "*"
+            }
+        },
+        "@types/serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.2.tgz",
+            "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+            "requires": {
+                "@types/express-serve-static-core": "*",
+                "@types/mime": "*"
+            }
+        },
+        "@types/spdy": {
+            "version": "3.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/spdy/-/@types/spdy-3.4.4.tgz",
+            "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/tough-cookie": {
+            "version": "2.3.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.5.tgz",
+            "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+        },
+        "@types/tunnel": {
+            "version": "0.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tunnel/-/@types/tunnel-0.0.0.tgz",
+            "integrity": "sha1-wqQpQ+5jyQZSpVV7jE5Wzad/lE4=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+        },
+        "adal-node": {
+            "version": "0.1.28",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.1.28.tgz",
+            "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+            "requires": {
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "8.10.48",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.48.tgz",
+                    "integrity": "sha1-44UHNWFkOpumGZoZhf/ANTD5B4E="
+                }
+            }
+        },
+        "adaptivecards": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptivecards/-/adaptivecards-1.1.3.tgz",
+            "integrity": "sha1-MnEyWblzGoi2QMfy8VelhkXmjo8="
+        },
+        "ajv": {
+            "version": "6.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ambi": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ambi/-/ambi-2.5.0.tgz",
+            "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+            "requires": {
+                "editions": "^1.1.1",
+                "typechecker": "^4.3.0"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "4.7.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-4.7.0.tgz",
+                    "integrity": "sha1-Ukn0JzWPRbclDEkk/U0B7ZukNek=",
+                    "requires": {
+                        "editions": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "editions": {
+                            "version": "2.1.3",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-2.1.3.tgz",
+                            "integrity": "sha1-cnzPPsLHsS3MZSxxAA8WxIJNb30=",
+                            "requires": {
+                                "errlop": "^1.1.1",
+                                "semver": "^5.6.0"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ansi-align": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-align/-/ansi-align-2.0.0.tgz",
+            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.0.0"
+            }
+        },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+            "optional": true,
+            "requires": {
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
+            }
+        },
+        "append-transform": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^2.0.0"
+            }
+        },
+        "appinsights-usage": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/appinsights-usage/-/appinsights-usage-1.0.2.tgz",
+            "integrity": "sha1-wzIiq0rRYNWdbeydILqrEKHD4M0=",
+            "requires": {
+                "applicationinsights-js": "^1.0.3",
+                "away": "^1.0.0",
+                "babel-cli": "^6.14.0",
+                "babel-preset-es2015": "^6.14.0",
+                "remove-value": "^1.0.0"
+            }
+        },
+        "applicationinsights": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.2.0.tgz",
+            "integrity": "sha1-xMHYqEWquuwJD2+chK9JBnk8j64=",
+            "requires": {
+                "cls-hooked": "^4.2.2",
+                "continuation-local-storage": "^3.2.1",
+                "diagnostic-channel": "0.2.0",
+                "diagnostic-channel-publishers": "0.3.0"
+            }
+        },
+        "applicationinsights-js": {
+            "version": "1.0.20",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights-js/-/applicationinsights-js-1.0.20.tgz",
+            "integrity": "sha1-4FGaLAQ+m0aD0y0yegbD8Yxj1co="
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
+        },
+        "arg": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arg/-/arg-4.1.0.tgz",
+            "integrity": "sha1-WDxRgZlBngA3q7dAYsN/hRnldfA=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                }
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "optional": true,
+            "requires": {
+                "arr-flatten": "^1.0.1"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "optional": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async/-/async-2.6.0.tgz",
+            "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+            "requires": {
+                "lodash": "^4.14.0"
+            }
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8="
+        },
+        "async-hook-jl": {
+            "version": "1.7.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+            "integrity": "sha1-T9JcL4ZNuvJ5xhDXO/l7GyhZXmg=",
+            "requires": {
+                "stack-chain": "^1.3.7"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
+        },
+        "async-listener": {
+            "version": "0.6.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async-listener/-/async-listener-0.6.10.tgz",
+            "integrity": "sha1-p8l6vlcLpgLXgic8DeYKUePhfLw=",
+            "requires": {
+                "semver": "^5.3.0",
+                "shimmer": "^1.1.0"
+            }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+        },
+        "away": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/away/-/away-1.0.0.tgz",
+            "integrity": "sha1-0G8Yf15HJELD9HxYJurxj2Twsao=",
+            "requires": {
+                "xtend": "2.0.3"
+            },
+            "dependencies": {
+                "xtend": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xtend/-/xtend-2.0.3.tgz",
+                    "integrity": "sha1-YmAJAPCWrWoRHjyjfbuQh3ZJMJQ="
+                }
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+        },
+        "axios": {
+            "version": "0.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.0.tgz",
+            "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+            "requires": {
+                "follow-redirects": "^1.3.0",
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "azure-cognitiveservices-contentmoderator": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/azure-cognitiveservices-contentmoderator/-/azure-cognitiveservices-contentmoderator-4.1.1.tgz",
+            "integrity": "sha1-oj+BC5dUdYKehpV2og6B98hhEfE=",
+            "requires": {
+                "ms-rest": "^2.3.3"
+            }
+        },
+        "azure-storage": {
+            "version": "2.10.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/azure-storage/-/azure-storage-2.10.2.tgz",
+            "integrity": "sha1-O8q9vxDnL9CZDbgRFuSQI8SmdbY=",
+            "requires": {
+                "browserify-mime": "~1.2.9",
+                "extend": "^3.0.2",
+                "json-edm-parser": "0.1.2",
+                "md5.js": "1.3.4",
+                "readable-stream": "~2.0.0",
+                "request": "^2.86.0",
+                "underscore": "~1.8.3",
+                "uuid": "^3.0.0",
+                "validator": "~9.4.1",
+                "xml2js": "0.2.8",
+                "xmlbuilder": "^9.0.7"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "sax": {
+                    "version": "0.5.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sax/-/sax-0.5.8.tgz",
+                    "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "xml2js": {
+                    "version": "0.2.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml2js/-/xml2js-0.2.8.tgz",
+                    "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+                    "requires": {
+                        "sax": "0.5.x"
+                    }
+                }
+            }
+        },
+        "babel-cli": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-cli/-/babel-cli-6.26.0.tgz",
+            "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+            "requires": {
+                "babel-core": "^6.26.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "chokidar": "^1.6.1",
+                "commander": "^2.11.0",
+                "convert-source-map": "^1.5.0",
+                "fs-readdir-recursive": "^1.0.0",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "output-file-sync": "^1.1.2",
+                "path-is-absolute": "^1.0.1",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6",
+                "v8flags": "^2.1.1"
+            }
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            }
+        },
+        "babel-core": {
+            "version": "6.26.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "babel-generator": {
+            "version": "6.26.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
+            "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "babel-helper-call-delegate": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-define-map": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+            "requires": {
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-get-function-arity": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-hoist-variables": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-optimise-call-expression": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helper-regex": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-helper-replace-supers": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+            "requires": {
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-check-es2015-constants": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-plugin-transform-es2015-classes": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+            "requires": {
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+            "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-literals": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+            "requires": {
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+            "version": "6.26.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
+            "requires": {
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+            "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+            "requires": {
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+            "requires": {
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+            "requires": {
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-spread": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+            "version": "6.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+            "version": "6.23.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+            "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
+            }
+        },
+        "babel-plugin-transform-regenerator": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+            "requires": {
+                "regenerator-transform": "^0.10.0"
+            }
+        },
+        "babel-plugin-transform-strict-mode": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+            "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+            }
+        },
+        "babel-polyfill": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+            "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+                }
+            }
+        },
+        "babel-preset-es2015": {
+            "version": "6.24.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+            "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+            "requires": {
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+                "babel-plugin-transform-es2015-classes": "^6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+                "babel-plugin-transform-es2015-for-of": "^6.22.0",
+                "babel-plugin-transform-es2015-function-name": "^6.24.1",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.24.1",
+                "babel-plugin-transform-es2015-parameters": "^6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+                "babel-plugin-transform-regenerator": "^6.24.1"
+            }
+        },
+        "babel-register": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "requires": {
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+                    "requires": {
+                        "source-map": "^0.5.6"
+                    }
+                }
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/base/-/base-0.11.2.tgz",
+            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "base64url": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/base64url/-/base64url-3.0.1.tgz",
+            "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "big-integer": {
+            "version": "1.6.43",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/big-integer/-/big-integer-1.6.43.tgz",
+            "integrity": "sha1-isFb8T6T5QlQCFkGEjPhnY0NmdE="
+        },
+        "bignumber.js": {
+            "version": "7.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bignumber.js/-/bignumber.js-7.2.1.tgz",
+            "integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
+        },
+        "binary-extensions": {
+            "version": "1.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U="
+        },
+        "binary-search-bounds": {
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+            "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+        },
+        "botbuilder": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.4.0.tgz",
+            "integrity": "sha1-h3xiqxDyOp1JJAQfjr86dyY/TTI=",
+            "requires": {
+                "@types/filenamify": "^2.0.1",
+                "@types/node": "^10.12.18",
+                "botbuilder-core": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "filenamify": "^2.0.0",
+                "fs-extra": "^7.0.1"
+            }
+        },
+        "botbuilder-ai": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.4.0.tgz",
+            "integrity": "sha1-PTLP8buGtIjYZTGTAD9nDKVsgkI=",
+            "requires": {
+                "@azure/cognitiveservices-luis-runtime": "2.0.0",
+                "@azure/ms-rest-js": "~1.8.2",
+                "@microsoft/recognizers-text-date-time": "1.1.2",
+                "@types/html-entities": "^1.2.16",
+                "@types/node": "^10.12.18",
+                "@types/request-promise-native": "^1.0.10",
+                "botbuilder-core": "^4.4.0",
+                "html-entities": "^1.2.1",
+                "moment": "^2.20.1",
+                "request": "^2.87.0",
+                "request-promise-native": "1.0.5",
+                "url-parse": "^1.4.4"
+            },
+            "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.8.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.7.tgz",
+                    "integrity": "sha1-C04xkpvrmaoWFeIjrdHJH4iCjt8=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.18.0",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    }
+                },
+                "tunnel": {
+                    "version": "0.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.6.tgz",
+                    "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+                }
+            }
+        },
+        "botbuilder-applicationinsights": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.4.0.tgz",
+            "integrity": "sha1-G5o7MSZ3iCehzQKqrBU+Pq2F67Q=",
+            "requires": {
+                "appinsights-usage": "1.0.2",
+                "applicationinsights": "1.2.0",
+                "applicationinsights-js": "1.0.20",
+                "botbuilder-core": "^4.4.0",
+                "cls-hooked": "^4.2.2"
+            }
+        },
+        "botbuilder-azure": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.4.0.tgz",
+            "integrity": "sha1-znzJz6T/RB5dasJeoIw9/rlWrFU=",
+            "requires": {
+                "@types/documentdb": "^1.10.5",
+                "@types/node": "^10.12.18",
+                "azure-storage": "2.10.2",
+                "botbuilder": "^4.4.0",
+                "documentdb": "1.14.5",
+                "flat": "^4.0.0",
+                "semaphore": "^1.1.0"
+            }
+        },
+        "botbuilder-core": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.4.0.tgz",
+            "integrity": "sha1-4smEQxvncp/wxZWD/H1FpYZIMNE=",
+            "requires": {
+                "assert": "^1.4.1",
+                "botframework-schema": "^4.4.0"
+            }
+        },
+        "botbuilder-dialogs": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.4.0.tgz",
+            "integrity": "sha1-M+qPlV+PwywBskuuNjQahuhG/Wo=",
+            "requires": {
+                "@microsoft/recognizers-text-choice": "1.1.2",
+                "@microsoft/recognizers-text-date-time": "1.1.2",
+                "@microsoft/recognizers-text-number": "1.1.2",
+                "@microsoft/recognizers-text-suite": "1.1.2",
+                "@types/node": "^10.12.18",
+                "botbuilder-core": "^4.4.0"
+            },
+            "dependencies": {
+                "@microsoft/recognizers-text-number": {
+                    "version": "1.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.2.tgz",
+                    "integrity": "sha1-tydc9UC6AY4CJcXV4H7AsENSZ+w=",
+                    "requires": {
+                        "@microsoft/recognizers-text": "~1.1.2",
+                        "bignumber.js": "^7.2.1",
+                        "lodash.escaperegexp": "^4.1.2",
+                        "lodash.sortby": "^4.7.0",
+                        "lodash.trimend": "^4.5.1"
+                    }
+                }
+            }
+        },
+        "botbuilder-skills": {
+            "version": "4.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-skills/-/botbuilder-skills-4.4.5.tgz",
+            "integrity": "sha1-G7Msz1xoIVSpVWX4xAvpjhhrVwg=",
+            "requires": {
+                "@azure/ms-rest-js": "1.2.6",
+                "botbuilder": "^4.4.0",
+                "botbuilder-ai": "^4.4.0",
+                "botbuilder-azure": "^4.4.0",
+                "botbuilder-core": "^4.4.0",
+                "botbuilder-dialogs": "^4.4.0",
+                "botbuilder-solutions": "^4.4.5",
+                "botframework-config": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "botframework-schema": "^4.4.0",
+                "i18n": "^0.8.3",
+                "jsonwebtoken": "^8.5.1",
+                "jwks-rsa": "^1.4.0",
+                "microsoft-bot-protocol": "^0.0.1",
+                "microsoft-bot-protocol-websocket": "^0.0.1",
+                "p-queue": "^4.0.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "jsonwebtoken": {
+                    "version": "8.5.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+                    "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+                    "requires": {
+                        "jws": "^3.2.2",
+                        "lodash.includes": "^4.3.0",
+                        "lodash.isboolean": "^3.0.3",
+                        "lodash.isinteger": "^4.0.4",
+                        "lodash.isnumber": "^3.0.3",
+                        "lodash.isplainobject": "^4.0.6",
+                        "lodash.isstring": "^4.0.1",
+                        "lodash.once": "^4.0.0",
+                        "ms": "^2.1.1",
+                        "semver": "^5.6.0"
+                    }
+                }
+            }
+        },
+        "botbuilder-solutions": {
+            "version": "4.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-solutions/-/botbuilder-solutions-4.4.5.tgz",
+            "integrity": "sha1-hFj37SvoCoG92RWMDg0AfMHOA9M=",
+            "requires": {
+                "@microsoft/recognizers-text": "^1.1.4",
+                "@microsoft/recognizers-text-choice": "^1.1.4",
+                "adaptivecards": "^1.1.3",
+                "azure-cognitiveservices-contentmoderator": "^4.0.0",
+                "botbuilder": "^4.4.0",
+                "botbuilder-ai": "^4.4.0",
+                "botbuilder-azure": "^4.4.0",
+                "botbuilder-core": "^4.4.0",
+                "botbuilder-dialogs": "^4.4.0",
+                "botframework-config": "^4.4.0",
+                "botframework-connector": "^4.4.0",
+                "botframework-schema": "^4.4.0",
+                "dateformat": "^3.0.3",
+                "i18next": "^15.0.6",
+                "ms-rest-azure": "^2.5.0",
+                "p-queue": "^4.0.0"
+            },
+            "dependencies": {
+                "@microsoft/recognizers-text-choice": {
+                    "version": "1.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.4.tgz",
+                    "integrity": "sha1-jpro+ASuSb1X3Wu/InoqsOFKkEE=",
+                    "requires": {
+                        "@microsoft/recognizers-text": "~1.1.4",
+                        "grapheme-splitter": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "botframework-config": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.4.0.tgz",
+            "integrity": "sha1-nkLbhpuLXz4KM71R/1ydxInJ6K4=",
+            "requires": {
+                "fs-extra": "^7.0.0",
+                "process": "^0.11.10",
+                "read-text-file": "^1.1.0",
+                "url": "^0.11.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "botframework-connector": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.4.0.tgz",
+            "integrity": "sha1-a20bUdRO+drnsiyE8e74qczenfU=",
+            "requires": {
+                "@azure/ms-rest-js": "1.2.6",
+                "@types/jsonwebtoken": "7.2.8",
+                "@types/node": "^10.12.18",
+                "base64url": "^3.0.0",
+                "botframework-schema": "^4.4.0",
+                "form-data": "^2.3.3",
+                "jsonwebtoken": "8.0.1",
+                "nock": "^10.0.3",
+                "node-fetch": "^2.2.1",
+                "rsa-pem-from-mod-exp": "^0.8.4"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
+                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                }
+            }
+        },
+        "botframework-schema": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.4.0.tgz",
+            "integrity": "sha1-g7wFIh5Qu58dYJzlKoJCvsvs+zA="
+        },
+        "boxen": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/boxen/-/boxen-1.3.0.tgz",
+            "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+            "dev": true,
+            "requires": {
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "optional": true,
+            "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "dev": true
+        },
+        "browserify-mime": {
+            "version": "1.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browserify-mime/-/browserify-mime-1.2.9.tgz",
+            "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "bunyan": {
+            "version": "1.8.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.12.tgz",
+            "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+            "requires": {
+                "dtrace-provider": "~0.8",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "caching-transform": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/caching-transform/-/caching-transform-3.0.2.tgz",
+            "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+            "dev": true,
+            "requires": {
+                "hasha": "^3.0.0",
+                "make-dir": "^2.0.0",
+                "package-hash": "^3.0.0",
+                "write-file-atomic": "^2.4.2"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+            "dev": true
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            }
+        },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "optional": true,
+            "requires": {
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
+            }
+        },
+        "ci-info": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
+            "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "cli-boxes": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "cls-hooked": {
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cls-hooked/-/cls-hooked-4.2.2.tgz",
+            "integrity": "sha1-rS6aQJJoDNr/6y01UdoOIl6uGQg=",
+            "requires": {
+                "async-hook-jl": "^1.7.6",
+                "emitter-listener": "^1.0.1",
+                "semver": "^5.4.1"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/colors/-/colors-1.2.4.tgz",
+            "integrity": "sha1-4MtB0+SyCAazv8J/RVnwG5S8L3w=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.20.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI="
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "configstore": {
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            }
+        },
+        "continuation-local-storage": {
+            "version": "3.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+            "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
+            "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.1.1"
+            }
+        },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "copyfiles": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.1.0.tgz",
+            "integrity": "sha1-DipBiBYtay88Wt/jTpwL1WTSMWQ=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.5",
+                "minimatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "noms": "0.0.0",
+                "through2": "^2.0.1",
+                "yargs": "^11.0.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-1.1.0.tgz",
+                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-11.1.0.tgz",
+                    "integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "core-js": {
+            "version": "2.6.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/core-js/-/core-js-2.6.5.tgz",
+            "integrity": "sha1-RLyNJJ5/sv9dAOA0Gn/7lPv2eJU="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cp-file": {
+            "version": "6.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cp-file/-/cp-file-6.2.0.tgz",
+            "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^2.0.0",
+                "nested-error-stacks": "^2.0.0",
+                "pify": "^4.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dev": true,
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
+            }
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+            "dev": true
+        },
+        "crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+            "dev": true
+        },
+        "csextends": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csextends/-/csextends-1.2.0.tgz",
+            "integrity": "sha1-Y3SyEJhLVNRJXynJnT3QabgFQ+U="
+        },
+        "csv": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-1.2.1.tgz",
+            "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
+            "requires": {
+                "csv-generate": "^1.1.2",
+                "csv-parse": "^1.3.3",
+                "csv-stringify": "^1.1.2",
+                "stream-transform": "^0.2.2"
+            }
+        },
+        "csv-generate": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-1.1.2.tgz",
+            "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
+        },
+        "csv-parse": {
+            "version": "1.3.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-1.3.3.tgz",
+            "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+        },
+        "csv-stringify": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-1.1.2.tgz",
+            "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+            "requires": {
+                "lodash.get": "~4.4.2"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "date-utils": {
+            "version": "1.2.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/date-utils/-/date-utils-1.2.21.tgz",
+            "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
+        },
+        "debug": {
+            "version": "3.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
+        },
+        "deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+            "dev": true
+        },
+        "default-require-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
+        },
+        "diagnostic-channel": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "diagnostic-channel-publishers": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.0.tgz",
+            "integrity": "sha1-oyZJxuD98fT+aiG95k3BO1AMvwI="
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+            "dev": true
+        },
+        "documentdb": {
+            "version": "1.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/documentdb/-/documentdb-1.14.5.tgz",
+            "integrity": "sha1-NWhR8KpefxiuDtIC3g3ROwWz92I=",
+            "requires": {
+                "big-integer": "^1.6.25",
+                "binary-search-bounds": "2.0.3",
+                "int64-buffer": "^0.1.9",
+                "priorityqueuejs": "1.0.0",
+                "semaphore": "1.0.5",
+                "tunnel": "0.0.5",
+                "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "semaphore": {
+                    "version": "1.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semaphore/-/semaphore-1.0.5.tgz",
+                    "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+                }
+            }
+        },
+        "dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
+        "dotenv": {
+            "version": "6.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dotenv/-/dotenv-6.2.0.tgz",
+            "integrity": "sha1-lBwEEFNdlCyL7PKNPzV9vZ1HYGQ="
+        },
+        "dtrace-provider": {
+            "version": "0.8.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+            "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+            "requires": {
+                "nan": "^2.10.0"
+            }
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
+        },
+        "eachr": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eachr/-/eachr-2.0.4.tgz",
+            "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
+            "requires": {
+                "typechecker": "^2.0.8"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "editions": {
+            "version": "1.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-1.3.4.tgz",
+            "integrity": "sha1-NmLLWSNHwxaOuOSYoP9zJx1n9Qs="
+        },
+        "emitter-listener": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha1-VrFA6PaZI3Wz18ssqxzHQy2WMug=",
+            "requires": {
+                "shimmer": "^1.2.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+            "dev": true
+        },
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "~0.4.13"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "errlop": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/errlop/-/errlop-1.1.1.tgz",
+            "integrity": "sha1-2a5MdsPmSVbF155uA11jQ7/WIlA=",
+            "requires": {
+                "editions": "^2.1.2"
+            },
+            "dependencies": {
+                "editions": {
+                    "version": "2.1.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/editions/-/editions-2.1.3.tgz",
+                    "integrity": "sha1-cnzPPsLHsS3MZSxxAA8WxIJNb30=",
+                    "requires": {
+                        "errlop": "^1.1.1",
+                        "semver": "^5.6.0"
+                    }
+                }
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.13.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "4.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es6-promise/-/es6-promise-4.2.6.tgz",
+            "integrity": "sha1-toXt2CWIhjZepitX0w3ij63Nl08="
+        },
+        "escape-regexp-component": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+            "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+        },
+        "eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
+        },
+        "ewma": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ewma/-/ewma-2.0.1.tgz",
+            "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "optional": true,
+            "requires": {
+                "is-posix-bracket": "^0.1.0"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "optional": true,
+            "requires": {
+                "fill-range": "^2.1.0"
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extendr": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extendr/-/extendr-2.1.0.tgz",
+            "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
+            "requires": {
+                "typechecker": "~2.0.1"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "2.0.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.0.8.tgz",
+                    "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
+                }
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "optional": true,
+            "requires": {
+                "is-extglob": "^1.0.0"
+            }
+        },
+        "extract-opts": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extract-opts/-/extract-opts-2.2.0.tgz",
+            "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
+            "requires": {
+                "typechecker": "~2.0.1"
+            },
+            "dependencies": {
+                "typechecker": {
+                    "version": "2.0.8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.0.8.tgz",
+                    "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha1-Rvi2wisw/3qBNX1PWav66TggJUM="
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "optional": true
+        },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+        },
+        "filenamify": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-2.1.0.tgz",
+            "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+            "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.0",
+                "trim-repeated": "^1.0.0"
+            }
+        },
+        "fill-range": {
+            "version": "2.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-2.2.4.tgz",
+            "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
+            "optional": true,
+            "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+            }
+        },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+            "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "find-my-way": {
+            "version": "1.18.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-1.18.1.tgz",
+            "integrity": "sha1-XbYF6rchHuaverCOtPVoBgqo6fY=",
+            "requires": {
+                "fast-decode-uri-component": "^1.0.0",
+                "safe-regex": "^1.1.0",
+                "semver-store": "^0.3.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "flat": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.0.tgz",
+            "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+            "requires": {
+                "is-buffer": "~2.0.3"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+                }
+            }
+        },
+        "follow-redirects": {
+            "version": "1.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.7.0.tgz",
+            "integrity": "sha1-SJ68GY3A5/ZBZ70jsDxMGbV4THY=",
+            "requires": {
+                "debug": "^3.2.6"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "optional": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/foreground-child/-/foreground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                }
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "formidable": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/formidable/-/formidable-1.2.1.tgz",
+            "integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk="
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs-readdir-recursive": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+            "version": "1.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
+            "optional": true,
+            "requires": {
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "^4.1.0",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.1",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.2.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true
+                }
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "optional": true,
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "requires": {
+                "is-glob": "^2.0.0"
+            }
+        },
+        "global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4"
+            }
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+        },
+        "got": {
+            "version": "6.7.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/got/-/got-6.7.1.tgz",
+            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+            "dev": true,
+            "requires": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+        },
+        "grapheme-splitter": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4="
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "dev": true
+        },
+        "handle-thing": {
+            "version": "1.2.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/handle-thing/-/handle-thing-1.2.5.tgz",
+            "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+        },
+        "handlebars": {
+            "version": "4.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+            "dev": true,
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has/-/has-1.0.3.tgz",
+            "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "hasha": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hasha/-/hasha-3.0.0.tgz",
+            "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+            "dev": true,
+            "requires": {
+                "is-stream": "^1.0.1"
+            }
+        },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/he/-/he-1.2.0.tgz",
+            "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+            "dev": true
+        },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+        },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "i18n": {
+            "version": "0.8.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18n/-/i18n-0.8.3.tgz",
+            "integrity": "sha1-LYzxwkciYCwgQdAbpq5eqlE4jw4=",
+            "requires": {
+                "debug": "*",
+                "make-plural": "^3.0.3",
+                "math-interval-parser": "^1.1.0",
+                "messageformat": "^0.3.1",
+                "mustache": "*",
+                "sprintf-js": ">=1.0.3"
+            }
+        },
+        "i18next": {
+            "version": "15.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.1.tgz",
+            "integrity": "sha1-LWDN7hUbAZ4XHkSmZszWtwSshno=",
+            "requires": {
+                "@babel/runtime": "^7.3.1"
+            }
+        },
+        "i18next-node-fs-backend": {
+            "version": "2.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
+            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
+            "requires": {
+                "js-yaml": "3.13.1",
+                "json5": "2.0.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
+                    "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore-by-default": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+            "dev": true
+        },
+        "ignorefs": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorefs/-/ignorefs-1.2.0.tgz",
+            "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+            "requires": {
+                "editions": "^1.3.3",
+                "ignorepatterns": "^1.1.0"
+            }
+        },
+        "ignorepatterns": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
+            "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
+        },
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.1.tgz",
+            "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "dev": true
+        },
+        "int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "invert-kv": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "requires": {
+                "binary-extensions": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+        },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
+        },
+        "is-ci": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-ci/-/is-ci-1.2.1.tgz",
+            "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
+            "dev": true,
+            "requires": {
+                "ci-info": "^1.5.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+                }
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "optional": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "optional": true,
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "requires": {
+                "is-extglob": "^1.0.0"
+            }
+        },
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-npm": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-npm/-/is-npm-1.0.0.tgz",
+            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "optional": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "^1.0.1"
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "requires": {
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "optional": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "optional": true
+        },
+        "is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "optional": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "2.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+            "dev": true,
+            "requires": {
+                "append-transform": "^1.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha1-BeNZ7lceWtftZBpu7B5Ue6Ut6mU=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+            "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.1.2"
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jschardet": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jschardet/-/jschardet-1.6.0.tgz",
+            "integrity": "sha1-x9GnHtz/KDnbL57DD8XV69PBpng="
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        },
+        "json-edm-parser": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+            "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+            "requires": {
+                "jsonparse": "~1.2.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonparse": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonparse/-/jsonparse-1.2.0.tgz",
+            "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+        },
+        "jsonwebtoken": {
+            "version": "8.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+            "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+            "requires": {
+                "jws": "^3.1.4",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jwa": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jwa/-/jwa-1.4.1.tgz",
+            "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jwks-rsa": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jwks-rsa/-/jwks-rsa-1.5.0.tgz",
+            "integrity": "sha1-FXXvCQOGjSgxDGuSNUiVRwrIkdw=",
+            "requires": {
+                "@types/express-jwt": "0.0.34",
+                "debug": "^2.2.0",
+                "limiter": "^1.1.0",
+                "lru-memoizer": "^1.6.0",
+                "ms": "^2.0.0",
+                "request": "^2.73.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
+                    }
+                }
+            }
+        },
+        "jws": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jws/-/jws-3.2.2.tgz",
+            "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+            "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "latest-version": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/latest-version/-/latest-version-3.1.0.tgz",
+            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+            "dev": true,
+            "requires": {
+                "package-json": "^4.0.0"
+            }
+        },
+        "lcid": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^2.0.0"
+            }
+        },
+        "limiter": {
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/limiter/-/limiter-1.1.4.tgz",
+            "integrity": "sha1-h8nDly04n9sLpnpFqtvF0vhBO8E="
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lock": {
+            "version": "0.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lock/-/lock-0.1.4.tgz",
+            "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.last": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.last/-/lodash.last-3.0.0.tgz",
+            "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
+        },
+        "lodash.max": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.max/-/lodash.max-4.0.1.tgz",
+            "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+        },
+        "lodash.tonumber": {
+            "version": "4.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+            "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
+        },
+        "lodash.trimend": {
+            "version": "4.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+            "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+        },
+        "log-symbols": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/log-symbols/-/log-symbols-2.2.0.tgz",
+            "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "4.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-4.0.2.tgz",
+            "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+            "requires": {
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
+            }
+        },
+        "lru-memoizer": {
+            "version": "1.12.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-memoizer/-/lru-memoizer-1.12.0.tgz",
+            "integrity": "sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=",
+            "requires": {
+                "lock": "~0.1.2",
+                "lodash": "^4.17.4",
+                "lru-cache": "~4.0.0",
+                "very-fast-args": "^1.1.0"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-error/-/make-error-1.3.5.tgz",
+            "integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
+            "dev": true
+        },
+        "make-plural": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-plural/-/make-plural-3.0.6.tgz",
+            "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
+            "requires": {
+                "minimist": "^1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "optional": true
+                }
+            }
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "math-interval-parser": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/math-interval-parser/-/math-interval-parser-1.1.0.tgz",
+            "integrity": "sha1-2+2lsGsySZc8bfYXD94jhvCv2JM=",
+            "requires": {
+                "xregexp": "^2.0.0"
+            }
+        },
+        "math-random": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
+            "optional": true
+        },
+        "md5": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.2.1.tgz",
+            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "dev": true,
+            "requires": {
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
+            }
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "mem": {
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
+            }
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/merge-source-map/-/merge-source-map-1.1.0.tgz",
+            "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "messageformat": {
+            "version": "0.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/messageformat/-/messageformat-0.3.1.tgz",
+            "integrity": "sha1-5Y//gkXps5cXmeW0PbWLPpQX9aI=",
+            "requires": {
+                "async": "~1.5.2",
+                "glob": "~6.0.4",
+                "make-plural": "~3.0.3",
+                "nopt": "~3.0.6",
+                "watchr": "~2.4.13"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "optional": true,
+            "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+            }
+        },
+        "microsoft-bot-protocol": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/microsoft-bot-protocol/-/microsoft-bot-protocol-0.0.1.tgz",
+            "integrity": "sha1-ur2NXDtoMBxCKIoTf4BYyrVF+Wk=",
+            "requires": {
+                "promise.prototype.finally": "^3.1.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "microsoft-bot-protocol-websocket": {
+            "version": "0.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/microsoft-bot-protocol-websocket/-/microsoft-bot-protocol-websocket-0.0.1.tgz",
+            "integrity": "sha1-RLaXZwmbvZQmaRHGo2CKTzmxmmA=",
+            "requires": {
+                "microsoft-bot-protocol": "^0.0.1",
+                "uuid": "^3.3.2",
+                "watershed": "^0.4.0",
+                "ws": "^6.2.1"
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+        },
+        "mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI="
+        },
+        "mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+            "requires": {
+                "mime-db": "1.40.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+            "dev": true
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "6.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha/-/mocha-6.1.4.tgz",
+            "integrity": "sha1-41+tokLVQ0p+Fj1VXHBfaHWVFkA=",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "3.2.3",
+                "browser-stdout": "1.3.1",
+                "debug": "3.2.6",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "find-up": "3.0.0",
+                "glob": "7.1.3",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "3.13.1",
+                "log-symbols": "2.2.0",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "ms": "2.1.1",
+                "node-environment-flags": "1.0.5",
+                "object.assign": "4.1.0",
+                "strip-json-comments": "2.0.1",
+                "supports-color": "6.0.0",
+                "which": "1.3.1",
+                "wide-align": "1.1.3",
+                "yargs": "13.2.2",
+                "yargs-parser": "13.0.0",
+                "yargs-unparser": "1.5.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.0.0.tgz",
+                    "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "mocha-junit-reporter": {
+            "version": "1.22.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha-junit-reporter/-/mocha-junit-reporter-1.22.0.tgz",
+            "integrity": "sha1-Tu4vMxg5i/Qkpkt1lMp6OdkkR5w=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "md5": "^2.1.0",
+                "mkdirp": "~0.5.1",
+                "strip-ansi": "^4.0.0",
+                "xml": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s="
+        },
+        "ms": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        },
+        "ms-rest": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms-rest/-/ms-rest-2.5.0.tgz",
+            "integrity": "sha1-1IPAA/fedwOt5rwZw7Qxmv+sJoc=",
+            "requires": {
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.88.0",
+                "through": "^2.3.8",
+                "tunnel": "0.0.5",
+                "uuid": "^3.2.1"
+            }
+        },
+        "ms-rest-azure": {
+            "version": "2.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms-rest-azure/-/ms-rest-azure-2.6.0.tgz",
+            "integrity": "sha1-IJjv7FKe7PoMbiFbaRQ6vKuhIUA=",
+            "requires": {
+                "adal-node": "^0.1.28",
+                "async": "2.6.0",
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "request": "^2.88.0",
+                "uuid": "^3.2.1"
+            }
+        },
+        "mustache": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mustache/-/mustache-3.0.1.tgz",
+            "integrity": "sha1-hzhV8jqoqVsVD7ltmDbtvFodJIo="
+        },
+        "mv": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mv/-/mv-2.1.1.tgz",
+            "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+            "optional": true,
+            "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "6.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-6.0.4.tgz",
+                    "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+                    "optional": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.4.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rimraf/-/rimraf-2.4.5.tgz",
+                    "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+                    "optional": true,
+                    "requires": {
+                        "glob": "^6.0.1"
+                    }
+                }
+            }
+        },
+        "nan": {
+            "version": "2.14.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw="
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "ncp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ncp/-/ncp-2.0.0.tgz",
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+            "optional": true
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+            "dev": true
+        },
+        "nested-error-stacks": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+            "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
+        },
+        "nock": {
+            "version": "10.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nock/-/nock-10.0.6.tgz",
+            "integrity": "sha1-5tkO56aLjPwqt/YSfn2Zqn0T0RE=",
+            "requires": {
+                "chai": "^4.1.2",
+                "debug": "^4.1.0",
+                "deep-equal": "^1.0.0",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.5",
+                "mkdirp": "^0.5.0",
+                "propagate": "^1.0.0",
+                "qs": "^6.5.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "node-environment-flags": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+            "integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
+            "dev": true,
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3",
+                "semver": "^5.7.0"
+            }
+        },
+        "node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+            "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+            }
+        },
+        "nodemon": {
+            "version": "1.19.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-1.19.0.tgz",
+            "integrity": "sha1-NY4AVUmh6eEUjLK5uLKJV9xORSc=",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.1.5",
+                "debug": "^3.1.0",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.6",
+                "semver": "^5.5.0",
+                "supports-color": "^5.2.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.2",
+                "update-notifier": "^2.5.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "dev": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chokidar": {
+                    "version": "2.1.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-2.1.6.tgz",
+                    "integrity": "sha1-tsrWU6kp4kTOioNCRBZNJB+pVMU=",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "noms": {
+            "version": "0.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/noms/-/noms-0.0.0.tgz",
+            "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "~1.0.31"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "requires": {
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nyc": {
+            "version": "14.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nyc/-/nyc-14.1.1.tgz",
+            "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "caching-transform": "^3.0.2",
+                "convert-source-map": "^1.6.0",
+                "cp-file": "^6.2.0",
+                "find-cache-dir": "^2.1.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.5",
+                "istanbul-lib-hook": "^2.0.7",
+                "istanbul-lib-instrument": "^3.3.0",
+                "istanbul-lib-report": "^2.0.8",
+                "istanbul-lib-source-maps": "^3.0.6",
+                "istanbul-reports": "^2.2.4",
+                "js-yaml": "^3.13.1",
+                "make-dir": "^2.1.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.2.3",
+                "uuid": "^3.3.2",
+                "yargs": "^13.2.2",
+                "yargs-parser": "^13.0.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "requires": {
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "optional": true,
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "requires": {
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "output-file-sync": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/output-file-sync/-/output-file-sync-1.1.2.tgz",
+            "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+            "requires": {
+                "graceful-fs": "^4.1.4",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^4.1.0"
+            }
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.2.0.tgz",
+            "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-queue": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-4.0.0.tgz",
+            "integrity": "sha1-7Q7uh5iSftbywvX1t3/bIGGl00Y=",
+            "requires": {
+                "eventemitter3": "^3.1.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+            "dev": true
+        },
+        "package-hash": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/package-hash/-/package-hash-3.0.0.tgz",
+            "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^3.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
+        },
+        "package-json": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/package-json/-/package-json-4.0.1.tgz",
+            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+            "dev": true,
+            "requires": {
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "optional": true,
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "pidusage": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-1.2.0.tgz",
+            "integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI="
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "optional": true
+        },
+        "priorityqueuejs": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+            "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/private/-/private-0.1.8.tgz",
+            "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+        },
+        "promise.prototype.finally": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
+            "integrity": "sha1-ZvFhsWQ2NuUOfPIB3BuEqFfzhk4=",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.9.0",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "propagate": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/propagate/-/propagate-1.0.0.tgz",
+            "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+        },
+        "pstree.remy": {
+            "version": "1.1.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pstree.remy/-/pstree.remy-1.1.6.tgz",
+            "integrity": "sha1-c6VarZ4tlYFJJxMfv03Bti0ln0c=",
+            "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4="
+        },
+        "randomatic": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
+            "optional": true,
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
+                    "optional": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+                    "optional": true
+                }
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            }
+        },
+        "read-text-file": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-text-file/-/read-text-file-1.1.0.tgz",
+            "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
+            "requires": {
+                "iconv-lite": "^0.4.17",
+                "jschardet": "^1.4.2"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                }
+            }
+        },
+        "readdirp": {
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+        },
+        "regenerator-transform": {
+            "version": "0.10.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+            "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+            "requires": {
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+            "optional": true,
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpu-core": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpu-core/-/regexpu-core-2.0.0.tgz",
+            "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+            "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+            }
+        },
+        "registry-auth-token": {
+            "version": "3.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+            "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
+            "dev": true,
+            "requires": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+            "dev": true,
+            "requires": {
+                "rc": "^1.0.1"
+            }
+        },
+        "regjsgen": {
+            "version": "0.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regjsgen/-/regjsgen-0.2.0.tgz",
+            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+        },
+        "regjsparser": {
+            "version": "0.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regjsparser/-/regjsparser-0.1.5.tgz",
+            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                }
+            }
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "remove-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/remove-value/-/remove-value-1.0.0.tgz",
+            "integrity": "sha1-uKmd0TbRbt5YsZvKjnkjVbqt0SM="
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "replace": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/replace/-/replace-1.1.0.tgz",
+            "integrity": "sha1-TLBPE40U83xHufLSFOtKBXvZSyI=",
+            "dev": true,
+            "requires": {
+                "colors": "1.2.4",
+                "minimatch": "3.0.4",
+                "yargs": "12.0.5"
+            },
+            "dependencies": {
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request/-/request-2.88.0.tgz",
+            "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "requires": {
+                "lodash": "^4.13.1"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        },
+        "resolve": {
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.11.0.tgz",
+            "integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "restify": {
+            "version": "7.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify/-/restify-7.7.0.tgz",
+            "integrity": "sha1-Tg44hPyHFvFL6iksKVfKcG/EJ/c=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "bunyan": "^1.8.12",
+                "csv": "^1.1.1",
+                "dtrace-provider": "^0.8.1",
+                "escape-regexp-component": "^1.0.2",
+                "ewma": "^2.0.1",
+                "find-my-way": "^1.13.0",
+                "formidable": "^1.2.1",
+                "http-signature": "^1.2.0",
+                "lodash": "^4.17.10",
+                "lru-cache": "^4.1.3",
+                "mime": "^1.5.0",
+                "negotiator": "^0.6.1",
+                "once": "^1.4.0",
+                "pidusage": "^1.2.0",
+                "qs": "^6.5.2",
+                "restify-errors": "^5.0.0",
+                "semver": "^5.4.1",
+                "spdy": "^3.4.7",
+                "uuid": "^3.1.0",
+                "vasync": "^1.6.4",
+                "verror": "^1.10.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                }
+            }
+        },
+        "restify-errors": {
+            "version": "5.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify-errors/-/restify-errors-5.0.0.tgz",
+            "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "lodash": "^4.2.1",
+                "safe-json-stringify": "^1.0.3",
+                "verror": "^1.8.1"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "rsa-pem-from-mod-exp": {
+            "version": "0.8.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+            "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        },
+        "safe-json-stringify": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+            "integrity": "sha1-NW5EvJjx+TzkXfFLzXwBzahuCv0=",
+            "optional": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safefs": {
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safefs/-/safefs-3.2.2.tgz",
+            "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+            "requires": {
+                "graceful-fs": "*"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+        },
+        "scandirectory": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/scandirectory/-/scandirectory-2.5.0.tgz",
+            "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+            "requires": {
+                "ignorefs": "^1.0.0",
+                "safefs": "^3.1.2",
+                "taskgroup": "^4.0.5"
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+        },
+        "semaphore": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semaphore/-/semaphore-1.1.0.tgz",
+            "integrity": "sha1-qq2LhrIP6OmzKxbcLuaCqM0mqKo="
+        },
+        "semver": {
+            "version": "5.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        },
+        "semver-diff": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver-diff/-/semver-diff-2.1.0.tgz",
+            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+            "dev": true,
+            "requires": {
+                "semver": "^5.0.3"
+            }
+        },
+        "semver-store": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver-store/-/semver-store-0.3.0.tgz",
+            "integrity": "sha1-zmAv8H3zcIDsn0+0CylXZUe+++k="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+            "requires": {
+                "kind-of": "^3.2.0"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-support/-/source-map-support-0.5.12.tgz",
+            "integrity": "sha1-tPOxDVGFelrwE4086AA7IBYT1Zk=",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "spawn-wrap": {
+            "version": "1.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+            "integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+            "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
+            "dev": true
+        },
+        "spdy": {
+            "version": "3.4.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdy/-/spdy-3.4.7.tgz",
+            "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+            "requires": {
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "spdy-transport": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+            "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
+            "requires": {
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM="
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-chain": {
+            "version": "1.3.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stack-chain/-/stack-chain-1.3.7.tgz",
+            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+        },
+        "stream-transform": {
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-0.2.2.tgz",
+            "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg="
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "taskgroup": {
+            "version": "4.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/taskgroup/-/taskgroup-4.3.1.tgz",
+            "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+            "requires": {
+                "ambi": "^2.2.0",
+                "csextends": "^1.0.3"
+            }
+        },
+        "term-size": {
+            "version": "1.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-1.2.0.tgz",
+            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+            "dev": true,
+            "requires": {
+                "execa": "^0.7.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                }
+            }
+        },
+        "test-exclude": {
+            "version": "5.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/test-exclude/-/test-exclude-5.2.3.tgz",
+            "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "touch": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/touch/-/touch-3.1.0.tgz",
+            "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
+            "dev": true,
+            "requires": {
+                "nopt": "~1.0.10"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "1.0.10",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nopt/-/nopt-1.0.10.tgz",
+                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
+            }
+        },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+        },
+        "ts-node": {
+            "version": "8.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ts-node/-/ts-node-8.1.0.tgz",
+            "integrity": "sha1-jEs3A2q9RIV32yKgYf16Z9R+ZY4=",
+            "dev": true,
+            "requires": {
+                "arg": "^4.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^3.0.0"
+            }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+        },
+        "tslint": {
+            "version": "5.16.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint/-/tslint-5.16.0.tgz",
+            "integrity": "sha1-rmH5xamNKVuaT0VTsbHoMcGYTWc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.13.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "tslint-microsoft-contrib": {
+            "version": "6.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz",
+            "integrity": "sha1-e/9zya16C361zbBJBt5Y9Cor96I=",
+            "dev": true,
+            "requires": {
+                "tsutils": "^2.27.2 <2.29.0"
+            },
+            "dependencies": {
+                "tsutils": {
+                    "version": "2.28.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.28.0.tgz",
+                    "integrity": "sha1-a9ceFggo+dAZtvToRHQiKPhRaaE=",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.8.1"
+                    }
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "tunnel": {
+            "version": "0.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel/-/tunnel-0.0.5.tgz",
+            "integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
+        },
+        "typechecker": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-2.1.0.tgz",
+            "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
+        },
+        "typescript": {
+            "version": "3.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.4.5.tgz",
+            "integrity": "sha1-LSYY0Qu1ZlcrjXqtUYDYQlfXCpk=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.5.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uglify-js/-/uglify-js-3.5.13.tgz",
+            "integrity": "sha1-0tiFe1mNd/h2SuO/z5C7HfE00r0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "undefsafe": {
+            "version": "2.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/undefsafe/-/undefsafe-2.0.2.tgz",
+            "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "underscore": {
+            "version": "1.8.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                }
+            }
+        },
+        "unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "dev": true,
+            "requires": {
+                "crypto-random-string": "^1.0.0"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
+        },
+        "unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+            "dev": true
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
+            "dev": true
+        },
+        "update-notifier": {
+            "version": "2.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-2.5.0.tgz",
+            "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+            "dev": true,
+            "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "dev": true,
+            "requires": {
+                "prepend-http": "^1.0.1"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/use/-/use-3.1.1.tgz",
+            "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
+        },
+        "user-home": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/user-home/-/user-home-1.1.1.tgz",
+            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "requires": {
+                "inherits": "2.0.1"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+        },
+        "v8flags": {
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/v8flags/-/v8flags-2.1.1.tgz",
+            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "requires": {
+                "user-home": "^1.1.1"
+            }
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "validator": {
+            "version": "9.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/validator/-/validator-9.4.1.tgz",
+            "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
+        },
+        "vasync": {
+            "version": "1.6.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/vasync/-/vasync-1.6.4.tgz",
+            "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+            "requires": {
+                "verror": "1.6.0"
+            },
+            "dependencies": {
+                "extsprintf": {
+                    "version": "1.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.2.0.tgz",
+                    "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+                },
+                "verror": {
+                    "version": "1.6.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/verror/-/verror-1.6.0.tgz",
+                    "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+                    "requires": {
+                        "extsprintf": "1.2.0"
+                    }
+                }
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "very-fast-args": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/very-fast-args/-/very-fast-args-1.1.0.tgz",
+            "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
+        },
+        "watchr": {
+            "version": "2.4.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/watchr/-/watchr-2.4.13.tgz",
+            "integrity": "sha1-10hHu01vkPYf4sdPn2hmKqDgdgE=",
+            "requires": {
+                "eachr": "^2.0.2",
+                "extendr": "^2.1.0",
+                "extract-opts": "^2.2.0",
+                "ignorefs": "^1.0.0",
+                "safefs": "^3.1.2",
+                "scandirectory": "^2.5.0",
+                "taskgroup": "^4.2.0",
+                "typechecker": "^2.0.8"
+            }
+        },
+        "watershed": {
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/watershed/-/watershed-0.4.0.tgz",
+            "integrity": "sha1-5BJLh3EptHZSJHdn63IgKfgJVTE=",
+            "requires": {
+                "dtrace-provider": "~0.8",
+                "readable-stream": "1.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-1.0.2.tgz",
+                    "integrity": "sha1-ITzjaGT8Hw1OmOA7nrksZAQimdQ="
+                }
+            }
+        },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "whatwg-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+            "integrity": "sha1-/IBORYzEYACbGiuWa8iBfSV4rvs="
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which/-/which-1.3.1.tgz",
+            "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "widest-line": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/widest-line/-/widest-line-2.0.1.tgz",
+            "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1"
+            }
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write-file-atomic": {
+            "version": "2.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+            "integrity": "sha1-pxgXBt+6F4VdIhFAqcBuFfzdh7k=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "ws": {
+            "version": "6.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-6.2.1.tgz",
+            "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+            "dev": true
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        },
+        "xmldom": {
+            "version": "0.1.27",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.1.27.tgz",
+            "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+        },
+        "xpath.js": {
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xpath.js/-/xpath.js-1.1.0.tgz",
+            "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+        },
+        "xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs": {
+            "version": "13.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-13.2.2.tgz",
+            "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
+            "dev": true,
+            "requires": {
+                "cliui": "^4.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "os-locale": "^3.1.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-13.0.0.tgz",
+            "integrity": "sha1-P8RPPnaovbHMNgLoYBCGAuXM3os=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yargs-unparser": {
+            "version": "1.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+            "integrity": "sha1-8rsqfoPLyHu5XI5XKCigbJrdbg0=",
+            "dev": true,
+            "requires": {
+                "flat": "^4.1.0",
+                "lodash": "^4.17.11",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+                    "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "yn": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yn/-/yn-3.1.0.tgz",
+            "integrity": "sha1-/L4ttjYQNhr8xeueCskel20EYRQ=",
+            "dev": true
+        }
+    }
+}

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package.json
@@ -36,7 +36,6 @@
         "dotenv": "^6.0.0",
         "i18next": "^15.0.6",
         "i18next-node-fs-backend": "^2.1.1",
-        "mocha": "^6.1.4",
         "ms-rest-azure": "^2.5.0",
         "restify": "^7.2.1"
     },
@@ -48,6 +47,8 @@
         "@types/restify": "^7.2.4",
         "copyfiles": "^2.1.0",
         "nock": "^10.0.6",
+        "mocha": "^6.1.4",
+        "mocha-junit-reporter": "^1.22.0",
         "nodemon": "^1.18.4",
         "nyc": "^14.1.1",
         "replace": "^1.0.0",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mocha.opts
@@ -1,5 +1,6 @@
 --require ts-node/register
 --require source-map-support/register
+--reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors


### PR DESCRIPTION
## Description
The following changes were implemented in `Sample Skill`, `Skill Template`, `Sample Assistant`, `Virtual Assistant Template` and the `generator-botbuilder-assistant`
- Add `mocha JUnit reporter` (enabling publishing tests reports to Azure Pipeline)
- Add test results in `.gitignore`
- Update `package.json` 
- Update `nycrc` files
- Update `package.lock.json` 
- Update `mocha.opts`
- Add `Cobertura` report as additional reporter (enabling publishing Code Coverage reports to Azure Pipeline)
## Testing Steps
### Sample-Assistant
1. Go to `AI/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant` 
1. Run `npm install`
1. Execute `npm run build`
1. Execute `npm run test` and check that mocha run successfully the tests
1. Execute `npm run coverage` and check the output for code coverage

### Sample-Skill

1. Go to `AI/templates/Virtual-Assistant-Template/typescript/samples/sample-skill` 
1. Run `npm install`
1. Execute `npm run build`
1. Execute `npm run test` and check that mocha run successfully the tests
1. Execute `npm run coverage` and check the output for code coverage

### generator-botbuilder-assistant

1. Go to `AI/templates/Virtual-Assistant-Template/typescript/samples/generator-botbuilder-assistant` 
1. Run `npm install`
1. Execute `npm run test` and check that mocha run successfully the tests
1. Execute `npm run coverage` and check the output for code coverage
## Checklist
*-*
