### PR TITLE
fix skill middleware handling of SkillContext

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogSlotFillingTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogSlotFillingTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
             // Simple skill, with one slot (param1)
             var slots = new List<Slot>();
-            slots.Add(new Slot("param1", new List<string>() { "string" }));
+            slots.Add(new Slot { Name = "param1", Types = new List<string>() { "string" } });
             _skillManifests.Add(ManifestUtilities.CreateSkill(
                 "testskillwithslots",
                 "testskillwithslots",
@@ -45,9 +45,9 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
             // Simple skill, with two actions and multiple slots
             var multiParamSlots = new List<Slot>();
-            multiParamSlots.Add(new Slot("param1", new List<string>() { "string" }));
-            multiParamSlots.Add(new Slot("param2", new List<string>() { "string" }));
-            multiParamSlots.Add(new Slot("param3", new List<string>() { "string" }));
+            multiParamSlots.Add(new Slot { Name = "param1", Types = new List<string>() { "string" } });
+            multiParamSlots.Add(new Slot { Name = "param2", Types = new List<string>() { "string" } });
+            multiParamSlots.Add(new Slot { Name = "param3", Types = new List<string>() { "string" } });
 
             var multiActionSkill = ManifestUtilities.CreateSkill(
                 "testskillwithmultipleactionsandslots",

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillMiddlewareTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillMiddlewareTests.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             skillContextData.Add("PARAM1", "TEST1");
             skillContextData.Add("PARAM2", "TEST2");
 
-            // Ensure we have a copy
-            skillBeginEvent.Value = new SkillContext(skillContextData);
+			// Ensure we have a copy
+			skillBeginEvent.Value = JsonConvert.SerializeObject(skillContextData);
 
             TestAdapter adapter = new TestAdapter()
                 .Use(new SkillMiddleware(_userState, _conversationState, _dialogStateAccessor));
@@ -77,11 +77,13 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
             var skillContextData = new SkillContext();
             skillContextData.Add("PARAM1", DateTime.Now);
-            skillContextData.Add("PARAM2", 3);
+
+			// using long 3 because it'll be how 3 is deserialized to after being serialized
+            skillContextData.Add("PARAM2", 3L);
             skillContextData.Add("PARAM3", null);
 
-            // Ensure we have a copy
-            skillBeginEvent.Value = new SkillContext(skillContextData);
+			// Ensure we have a copy
+			skillBeginEvent.Value = JsonConvert.SerializeObject(skillContextData);
 
             TestAdapter adapter = new TestAdapter()
                 .Use(new SkillMiddleware(_userState, _conversationState, _dialogStateAccessor));
@@ -100,9 +102,6 @@ namespace Microsoft.Bot.Builder.Skills.Tests
         {
             string jsonSkillBeginActivity = await File.ReadAllTextAsync(@".\TestData\skillBeginEvent.json");
             var skillBeginEvent = JsonConvert.DeserializeObject<Activity>(jsonSkillBeginActivity);
-
-            // Ensure we have a copy
-            skillBeginEvent.Value = new SkillContext();
 
             TestAdapter adapter = new TestAdapter()
                 .Use(new SkillMiddleware(_userState, _conversationState, _dialogStateAccessor));

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/Slot.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/Slot.cs
@@ -8,12 +8,6 @@ namespace Microsoft.Bot.Builder.Skills.Models.Manifest
     /// </summary>
     public class Slot
     {
-        public Slot(string name, List<string> types)
-        {
-            Name = name;
-            Types = types;
-        }
-
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Skills
             var activity = turnContext.Activity;
             if (activity != null && activity.Type == ActivityTypes.Event)
             {
-                if (activity.Name == SkillEvents.SkillBeginEventName && activity.Value != null)
+                if (activity.Name == SkillEvents.SkillBeginEventName && activity.Value != null && !string.IsNullOrWhiteSpace(activity.Value.ToString()))
 				{
 					var skillContext = JsonConvert.DeserializeObject<SkillContext>(activity.Value.ToString());
 					if (skillContext != null)

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Skills.Models;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Skills
 {
@@ -29,9 +30,9 @@ namespace Microsoft.Bot.Builder.Skills
             if (activity != null && activity.Type == ActivityTypes.Event)
             {
                 if (activity.Name == SkillEvents.SkillBeginEventName && activity.Value != null)
-                {
-                    var skillContext = activity.Value as SkillContext;
-                    if (skillContext != null)
+				{
+					var skillContext = JsonConvert.DeserializeObject<SkillContext>(activity.Value.ToString());
+					if (skillContext != null)
                     {
                         var accessor = _userState.CreateProperty<SkillContext>(nameof(SkillContext));
                         await accessor.SetAsync(turnContext, skillContext);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

In our SkillMiddleware, it cannot convert the activity.Value to SkillContext directly. We need to explicitly deserialize it. 

It appears the Slot definition's constructor will cause the Slots not being deserialized properly. Removing it to fix the issue.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
