### PR TITLE
Enable Skills to be configured in remote-auth mode only and fix manifest generation issue

### DIFF
--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -50,11 +50,6 @@ namespace CalendarSkill.Dialogs
             ServiceManager = serviceManager;
             TelemetryClient = telemetryClient;
 
-            if (!Settings.OAuthConnections.Any())
-            {
-                throw new Exception("You must configure an authentication connection in your bot file before using this component.");
-            }
-
             AddDialog(new MultiProviderAuthDialog(settings.OAuthConnections));
             AddDialog(new TextPrompt(Actions.Prompt));
             AddDialog(new ConfirmPrompt(Actions.TakeFurtherAction, null, Culture.English) { Style = ListStyle.SuggestedAction });

--- a/skills/src/csharp/emailskill/emailskill/Dialogs/EmailSkillDialogBase.cs
+++ b/skills/src/csharp/emailskill/emailskill/Dialogs/EmailSkillDialogBase.cs
@@ -45,11 +45,6 @@ namespace EmailSkill.Dialogs
             ServiceManager = serviceManager;
             TelemetryClient = telemetryClient;
 
-            if (!Settings.OAuthConnections.Any())
-            {
-                throw new Exception("You must configure an authentication connection in your bot file before using this component.");
-            }
-
             AddDialog(new MultiProviderAuthDialog(settings.OAuthConnections));
             AddDialog(new TextPrompt(Actions.Prompt));
             AddDialog(new ConfirmPrompt(Actions.TakeFurtherAction, null, Culture.English) { Style = ListStyle.SuggestedAction });

--- a/skills/src/csharp/todoskill/todoskill/Dialogs/ToDoSkillDialogBase.cs
+++ b/skills/src/csharp/todoskill/todoskill/Dialogs/ToDoSkillDialogBase.cs
@@ -51,11 +51,6 @@ namespace ToDoSkill.Dialogs
             ServiceManager = serviceManager;
             TelemetryClient = telemetryClient;
 
-            if (!settings.OAuthConnections.Any())
-            {
-                throw new Exception("You must configure an authentication connection in your bot file before using this component.");
-            }
-
             AddDialog(new MultiProviderAuthDialog(settings.OAuthConnections));
             AddDialog(new TextPrompt(Actions.Prompt));
             AddDialog(new ConfirmPrompt(Actions.ConfirmPrompt, null, Culture.English) { Style = ListStyle.SuggestedAction });


### PR DESCRIPTION
Skills that make use of Authentication use the MultiAuthProvider within the Solutions package to enable tokens to be retrieved from a Parent Bot (e.g. VA) as well as locally using the usual AuthPrompt. 

<!--- Provide a general summary of your changes in the Title above -->
## Description

The productivity Skills can be deployed and then added to a VA. As part of this process for Office 365 we automatically add the Authentication connection to the VA Bot enabling the skill to request the token. However the older code in the MultiAuthProvider expected the Skill to **also** have it's own authentication connection which is no longer provided.

This issue was partially masked by the Productivity Skills having this placeholder fragment in the appSettings.config. This is nice as it shows developers what they need to provide (if done manually) but also meant the oauthconnection checks (`.any()`) weren't really valid. Then later on when adding the oAuthPrompt it relied on non empty/null Name which generated the exception.

```
 "oauthConnections": [
    {
      "name": "",
      "provider": "Azure Active Directory v2"
    }
  ],
  "properties": {
    "googleAppName": "",
    "googleClientId": "",
    "googleClientSecret": "",
    "googleScopes": "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts",
    "DisplaySize": "3"
  },
```
This was found through manifest generation. The call to `/api/skill/manifest` triggers each Dialog to be created as part of the DI work in startup. In the constructor MultiAuthProvider was created thus causing an exception which blocked manifest from working (even through it didn't need this!)

The proposed change enables MultiAuthProvider to only add local auth if configuration is provided otherwise it just adds remote auth. It checks that the authconnections are present before adding local-auth and if Name is null/empty it doesn't add it. 

We could remove the placeholders in the productivityskills to avoid the extra check but feels better to have placeholders.

### Bug Fixes
Resolves #1392 

### Maintenance

- Removed the oAuthConnection checks in productivity skills as this change makes them unnecessary (and they weren't working anyway)

## Testing Steps
- Deploy any of the productivity skills
- Launch in debugger
- request the `/api/skill/manifest` endpoint and validate it is shown (wasn't previously)

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [x ] I have commented my code, particularly in hard-to-understand areas