### PR TITLE
[BotBuilder Skills][TypeScript] Fix skillContext issue in tests

### DIFF
--- a/lib/typescript/botbuilder-skills/test/skillMiddlewareTest.js
+++ b/lib/typescript/botbuilder-skills/test/skillMiddlewareTest.js
@@ -126,5 +126,5 @@ describe("skill middleware", function() {
 
 async function validateSkillContextData(context, skillTestDataToValidate){
     const skillContext = await skillContextAccessor.get(context, new SkillContext());
-    assert.deepEqual(true, skillContext === skillTestDataToValidate);
+    assert.deepEqual(JSON.stringify(skillContext), JSON.stringify(skillTestDataToValidate));
 }


### PR DESCRIPTION
## Description

- Fix an issue related to the comparison between **skillContexts** in tests

## Testing Steps

1. Go to `botframework-solutions\lib\typescript`
2. Run `rush update`
3. Run `rush rebuild`
4. Go to `botframework-solutions\lib\typescript\botbuilder-skills`
5. Run `npm run test` and check the following output

![image](https://user-images.githubusercontent.com/11904023/58202648-7aecbe00-7cae-11e9-85be-aa1b34d7d9b0.png)

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [X] I have added or updated the appropriate unit tests
