### PR TITLE
[VA websocket] Skill invocation fail to work in Directline Speech Client

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Bot.Builder.Skills
         private bool endOfConversation = false;
 
         public SkillWebSocketTransport(
-			SkillManifest skillManifest,
-			IServiceClientCredentials serviceCLientCredentials,
-			IStreamingTransportClient streamingTransportClient = null)
+            SkillManifest skillManifest,
+            IServiceClientCredentials serviceCLientCredentials,
+            IStreamingTransportClient streamingTransportClient = null)
         {
             _skillManifest = skillManifest ?? throw new ArgumentNullException(nameof(skillManifest));
             _serviceClientCredentials = serviceCLientCredentials ?? throw new ArgumentNullException(nameof(serviceCLientCredentials));
-			_streamingTransportClient = streamingTransportClient;
-		}
+            _streamingTransportClient = streamingTransportClient;
+        }
 
         public async Task<bool> ForwardToSkillAsync(ITurnContext turnContext, Activity activity, Action<Activity> tokenRequestHandler = null)
         {
@@ -44,8 +44,8 @@ namespace Microsoft.Bot.Builder.Skills
                 var headers = new Dictionary<string, string>();
                 headers.Add("Authorization", $"Bearer {token}");
 
-				// establish websocket connection
-				_streamingTransportClient = new WebSocketClient(
+                // establish websocket connection
+                _streamingTransportClient = new WebSocketClient(
                     EnsureWebSocketUrl(_skillManifest.Endpoint.ToString()),
                     new SkillCallingRequestHandler(
                         turnContext,
@@ -55,14 +55,18 @@ namespace Microsoft.Bot.Builder.Skills
 
                 await _streamingTransportClient.ConnectAsync();
             }
+            else
+            {
+                await _streamingTransportClient.ConnectAsync();
+            }
 
-			// set recipient to the skill
-			if (activity.Recipient == null)
-			{
-				activity.Recipient = new ChannelAccount();
-			}
+            // set recipient to the skill
+            if (activity.Recipient == null)
+            {
+                activity.Recipient = new ChannelAccount();
+            }
 
-			activity.Recipient.Id = _skillManifest.MSAappId;
+            activity.Recipient.Id = _skillManifest.MSAappId;
 
             // Serialize the activity and POST to the Skill endpoint
             var body = new StringContent(JsonConvert.SerializeObject(activity, SerializationSettings.BotSchemaSerializationSettings), Encoding.UTF8, SerializationSettings.ApplicationJson);
@@ -86,7 +90,8 @@ namespace Microsoft.Bot.Builder.Skills
         {
             if (_streamingTransportClient != null)
             {
-				_streamingTransportClient.Disconnect();
+                _streamingTransportClient.Disconnect();
+                endOfConversation = false;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->
Close #1420 [VA websocket] Skill invocation fail to work in Directline Speech Client

As Skill dialog won't be recreated in each of conversation, SkillWebSocketTransport need to add state management logic to ensure reenter able.
### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
