### PR TITLE
Sync dispatch model with new cognitive models

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -4,7 +4,7 @@ Param(
     [string] $configFile = $(Join-Path (Get-Location) 'cognitivemodels.json'),
     [switch] $RemoteToLocal,
     [string] $dispatchFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'Dispatch'),
-	[string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
+    [string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
     [string] $qnaFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'QnA'),
     [string] $lgOutFolder = $(Join-Path (Get-Location) 'Services'),
     [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt")
@@ -28,7 +28,8 @@ $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.N
 
 foreach ($langCode in $languageMap.Keys) {
     $models = $languageMap[$langCode]
-
+    $dispatch = $models.dispatchModel
+    
     if($RemoteToLocal)
     {
         # Update local LU files based on hosted models
@@ -42,6 +43,17 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($luisApp.id).lu" `
                 -o $(Join-Path $luisFolder $langCode)
+		
+            # Add the LUIS application to the dispatch model. 
+            # If the LUIS application id already exists within the model no action will be taken
+            Write-Host "> Adding $($luisApp.id) app to dispatch model ... "
+			(dispatch add `
+				--type "luis" `
+				--name $luisApp.name `
+				--id $luisApp.appid  `
+				--intentName "l_$($luisApp.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -55,6 +67,18 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($kb.id).lu" `
                 -o $(Join-Path $qnaFolder $langCode)
+		
+            # Add the knowledge base to the dispatch model. 
+            # If the knowledge base id already exists within the model no action will be taken
+            Write-Host "> Adding $($kb.id) kb to dispatch model ..."   
+            (dispatch add `
+				--type "qna" `
+				--name $kb.name `
+				--id $kb.kbId  `
+				--key $kb.subscriptionKey  `
+				--intentName "q_$($kb.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
     }
     else
@@ -85,7 +109,6 @@ foreach ($langCode in $languageMap.Keys) {
 
 # Update dispatch model
 Write-Host "> Updating dispatch model ..."
-$dispatch = $models.dispatchModel
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
     --dataFolder $dispatchFolder 2>> $logFile | Out-Null

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
@@ -4,7 +4,7 @@ Param(
     [string] $configFile = $(Join-Path (Get-Location) 'cognitivemodels.json'),
     [switch] $RemoteToLocal,
     [string] $dispatchFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'Dispatch'),
-	[string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
+    [string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
     [string] $qnaFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'QnA'),
     [string] $lgOutFolder = $(Join-Path (Get-Location) 'Services'),
     [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt")
@@ -28,7 +28,8 @@ $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.N
 
 foreach ($langCode in $languageMap.Keys) {
     $models = $languageMap[$langCode]
-
+    $dispatch = $models.dispatchModel
+    
     if($RemoteToLocal)
     {
         # Update local LU files based on hosted models
@@ -42,6 +43,17 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($luisApp.id).lu" `
                 -o $(Join-Path $luisFolder $langCode)
+		
+            # Add the LUIS application to the dispatch model. 
+            # If the LUIS application id already exists within the model no action will be taken
+            Write-Host "> Adding $($luisApp.id) app to dispatch model ... "
+			(dispatch add `
+				--type "luis" `
+				--name $luisApp.name `
+				--id $luisApp.appid  `
+				--intentName "l_$($luisApp.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -55,6 +67,18 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($kb.id).lu" `
                 -o $(Join-Path $qnaFolder $langCode)
+		
+            # Add the knowledge base to the dispatch model. 
+            # If the knowledge base id already exists within the model no action will be taken
+            Write-Host "> Adding $($kb.id) kb to dispatch model ..."   
+            (dispatch add `
+				--type "qna" `
+				--name $kb.name `
+				--id $kb.kbId  `
+				--key $kb.subscriptionKey  `
+				--intentName "q_$($kb.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
     }
     else
@@ -85,7 +109,6 @@ foreach ($langCode in $languageMap.Keys) {
 
 # Update dispatch model
 Write-Host "> Updating dispatch model ..."
-$dispatch = $models.dispatchModel
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
     --dataFolder $dispatchFolder 2>> $logFile | Out-Null

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -4,7 +4,7 @@ Param(
     [string] $configFile = $(Join-Path (Get-Location) 'cognitivemodels.json'),
     [switch] $RemoteToLocal,
     [string] $dispatchFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'Dispatch'),
-	[string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
+    [string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
     [string] $qnaFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'QnA'),
     [string] $lgOutFolder = $(Join-Path (Get-Location) 'Services'),
     [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt")
@@ -28,7 +28,8 @@ $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.N
 
 foreach ($langCode in $languageMap.Keys) {
     $models = $languageMap[$langCode]
-
+    $dispatch = $models.dispatchModel
+    
     if($RemoteToLocal)
     {
         # Update local LU files based on hosted models
@@ -42,6 +43,17 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($luisApp.id).lu" `
                 -o $(Join-Path $luisFolder $langCode)
+		
+            # Add the LUIS application to the dispatch model. 
+            # If the LUIS application id already exists within the model no action will be taken
+            Write-Host "> Adding $($luisApp.id) app to dispatch model ... "
+			(dispatch add `
+				--type "luis" `
+				--name $luisApp.name `
+				--id $luisApp.appid  `
+				--intentName "l_$($luisApp.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -55,6 +67,18 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($kb.id).lu" `
                 -o $(Join-Path $qnaFolder $langCode)
+		
+            # Add the knowledge base to the dispatch model. 
+            # If the knowledge base id already exists within the model no action will be taken
+            Write-Host "> Adding $($kb.id) kb to dispatch model ..."   
+            (dispatch add `
+				--type "qna" `
+				--name $kb.name `
+				--id $kb.kbId  `
+				--key $kb.subscriptionKey  `
+				--intentName "q_$($kb.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
     }
     else
@@ -85,7 +109,6 @@ foreach ($langCode in $languageMap.Keys) {
 
 # Update dispatch model
 Write-Host "> Updating dispatch model ..."
-$dispatch = $models.dispatchModel
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
     --dataFolder $dispatchFolder 2>> $logFile | Out-Null

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
@@ -4,7 +4,7 @@ Param(
     [string] $configFile = $(Join-Path (Get-Location) 'cognitivemodels.json'),
     [switch] $RemoteToLocal,
     [string] $dispatchFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'Dispatch'),
-	[string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
+    [string] $luisFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'LU'),
     [string] $qnaFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'QnA'),
     [string] $lgOutFolder = $(Join-Path (Get-Location) 'Services'),
     [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt")
@@ -28,7 +28,8 @@ $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.N
 
 foreach ($langCode in $languageMap.Keys) {
     $models = $languageMap[$langCode]
-
+    $dispatch = $models.dispatchModel
+    
     if($RemoteToLocal)
     {
         # Update local LU files based on hosted models
@@ -42,6 +43,17 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($luisApp.id).lu" `
                 -o $(Join-Path $luisFolder $langCode)
+		
+            # Add the LUIS application to the dispatch model. 
+            # If the LUIS application id already exists within the model no action will be taken
+            Write-Host "> Adding $($luisApp.id) app to dispatch model ... "
+			(dispatch add `
+				--type "luis" `
+				--name $luisApp.name `
+				--id $luisApp.appid  `
+				--intentName "l_$($luisApp.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -55,6 +67,18 @@ foreach ($langCode in $languageMap.Keys) {
                 --stdin `
                 -n "$($kb.id).lu" `
                 -o $(Join-Path $qnaFolder $langCode)
+		
+            # Add the knowledge base to the dispatch model. 
+            # If the knowledge base id already exists within the model no action will be taken
+            Write-Host "> Adding $($kb.id) kb to dispatch model ..."   
+            (dispatch add `
+				--type "qna" `
+				--name $kb.name `
+				--id $kb.kbId  `
+				--key $kb.subscriptionKey  `
+				--intentName "q_$($kb.id)" `
+                --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
+                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
         }
     }
     else
@@ -85,7 +109,6 @@ foreach ($langCode in $languageMap.Keys) {
 
 # Update dispatch model
 Write-Host "> Updating dispatch model ..."
-$dispatch = $models.dispatchModel
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
     --dataFolder $dispatchFolder 2>> $logFile | Out-Null


### PR DESCRIPTION
## Description
When running the following command:
  `update_cognitive_models.ps1 -RemoteToLocal` 

Any new cognitive models should be added to the existing dispatch model, this allows users to refer to the new endpoint in the resulting luisgen'd class file.

### Bug Fixes
Closes #1431 

## Testing Steps
Follow the documention for adding [another QnA endpoint](https://github.com/microsoft/botframework-solutions/blob/master/docs/tutorials/csharp/customizeassistant.md#add-an-additional-knowledgebase).

The new endpoint should show in the LuisGen'ed dispatch model.

## Checklist
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have updated related documentation _(no documentation needs to be updated as this fixes the existing documentation)_
