### PR TITLE
[Typescript]Normalize use of asserts in tests 

### DIFF
--- a/lib/typescript/botbuilder-skills/test/manifestTest.js
+++ b/lib/typescript/botbuilder-skills/test/manifestTest.js
@@ -29,7 +29,7 @@ describe("manifest", function() {
             skillManifests.push(skillManifest);
             assert.ok(SkillRouter.isSkill(skillManifests, "calendarSkill/createEvent"));
             assert.ok(SkillRouter.isSkill(skillManifests, "calendarSkill/updateEvent"));
-            assert.deepEqual(undefined, SkillRouter.isSkill(skillManifests, "calendarSkill/MISSINGEVENT"));
+            assert.deepStrictEqual(undefined, SkillRouter.isSkill(skillManifests, "calendarSkill/MISSINGEVENT"));
         });
     });
 })

--- a/lib/typescript/botbuilder-skills/test/skillDialogInvocationTest.js
+++ b/lib/typescript/botbuilder-skills/test/skillDialogInvocationTest.js
@@ -58,7 +58,7 @@ describe("skill dialog invocation", function() {
             await testAdapter.send("hello");
 
             // Check if a request was sent to the mock, if not the test has failed (skill wasn't invoked).
-            assert.deepEqual(true, mockSkillTransport.checkIfSkillInvoked());
+            assert.deepStrictEqual(true, mockSkillTransport.checkIfSkillInvoked());
         })
     });
 });

--- a/lib/typescript/botbuilder-skills/test/skillDialogSlotFillingTest.js
+++ b/lib/typescript/botbuilder-skills/test/skillDialogSlotFillingTest.js
@@ -109,7 +109,7 @@ describe("skill dialog invocation", function() {
                 undefined);
             await testAdapter.send("hello");
 
-            assert.deepEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
+            assert.deepStrictEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
         });
     });
 
@@ -131,7 +131,7 @@ describe("skill dialog invocation", function() {
                 slots);
             await testAdapter.send("hello");
     
-            assert.deepEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
+            assert.deepStrictEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
         });
     });
 
@@ -161,7 +161,7 @@ describe("skill dialog invocation", function() {
                 slots);
             await testAdapter.send("hello");
     
-            assert.deepEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
+            assert.deepStrictEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
         });
     });
 
@@ -187,7 +187,7 @@ describe("skill dialog invocation", function() {
                 slots);
             await testAdapter.send("hello");
     
-            assert.deepEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
+            assert.deepStrictEqual(true, mockSkillTransport.verifyActivityForwardedCorrectly(eventToMatch));
         });        
     });
 });

--- a/lib/typescript/botbuilder-skills/test/skillMiddlewareTest.js
+++ b/lib/typescript/botbuilder-skills/test/skillMiddlewareTest.js
@@ -126,5 +126,5 @@ describe("skill middleware", function() {
 
 async function validateSkillContextData(context, skillTestDataToValidate){
     const skillContext = await skillContextAccessor.get(context, new SkillContext());
-    assert.deepEqual(JSON.stringify(skillContext), JSON.stringify(skillTestDataToValidate));
+    assert.deepStrictEqual(JSON.stringify(skillContext), JSON.stringify(skillTestDataToValidate));
 }

--- a/lib/typescript/botbuilder-solutions/test/dateTimeExtensionsTest.js
+++ b/lib/typescript/botbuilder-solutions/test/dateTimeExtensionsTest.js
@@ -144,10 +144,10 @@ describe("date time extensions", function() {
             
             testData.forEach(data => {
                 i18next.changeLanguage(data.culture.substring(0, 2));
-                assert.equal(data.expectedDateSpeech, DateTimeExtensions.toSpeechDateString(data.inputDateTime));
-                assert.equal(data.expectedDateSpeechWithSuffix, DateTimeExtensions.toSpeechDateString(data.inputDateTime, true));
-                assert.equal(data.expectedTimeSpeech , DateTimeExtensions.toSpeechTimeString(data.inputDateTime));
-                assert.equal(data.expectedTimeSpeechWithSuffix, DateTimeExtensions.toSpeechTimeString(data.inputDateTime, true));
+                assert.strictEqual(data.expectedDateSpeech, DateTimeExtensions.toSpeechDateString(data.inputDateTime));
+                assert.strictEqual(data.expectedDateSpeechWithSuffix, DateTimeExtensions.toSpeechDateString(data.inputDateTime, true));
+                assert.strictEqual(data.expectedTimeSpeech , DateTimeExtensions.toSpeechTimeString(data.inputDateTime));
+                assert.strictEqual(data.expectedTimeSpeechWithSuffix, DateTimeExtensions.toSpeechTimeString(data.inputDateTime, true));
             });
         });
     });    
@@ -171,13 +171,13 @@ describe("date time extensions", function() {
                 tomorrow.setDate(today.getDate() + 1);
                 const otherDate = new Date();
                 otherDate.setDate(today.getDate() + 3);
-                assert.equal(i18next.t("common:today"), DateTimeExtensions.toSpeechDateString(today));
-                assert.equal(i18next.t("common:tomorrow"), DateTimeExtensions.toSpeechDateString(tomorrow));
-                assert.equal(dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat")), DateTimeExtensions.toSpeechDateString(otherDate));
+                assert.strictEqual(i18next.t("common:today"), DateTimeExtensions.toSpeechDateString(today));
+                assert.strictEqual(i18next.t("common:tomorrow"), DateTimeExtensions.toSpeechDateString(tomorrow));
+                assert.strictEqual(dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat")), DateTimeExtensions.toSpeechDateString(otherDate));
                 if(i18next.t("common:spokenDatePrefix") === ""){
-                    assert.equal(`${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
+                    assert.strictEqual(`${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
                 } else {
-                    assert.equal(`${i18next.t("common:spokenDatePrefix")} ${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
+                    assert.strictEqual(`${i18next.t("common:spokenDatePrefix")} ${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
                 }
             });
         });

--- a/lib/typescript/botbuilder-solutions/test/listExtensionsTest.js
+++ b/lib/typescript/botbuilder-solutions/test/listExtensionsTest.js
@@ -19,7 +19,7 @@ describe("list extensions", function() {
             // Default is ToString and final separator is "and"
             const testList = ["One", "Two", "Three"];
 
-            assert.deepEqual("One, Two and Three", ListExtensions.toSpeechString(testList, andOperator));
+            assert.deepStrictEqual("One, Two and Three", ListExtensions.toSpeechString(testList, andOperator));
         });
     });
 
@@ -27,19 +27,19 @@ describe("list extensions", function() {
         it("verify the speech string of multiple complex type objects", function(){
             const testList = [];
 
-            assert.equal("", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
+            assert.strictEqual("", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
             
             testList.push(new SomeComplexType("One", "Don't care"));
-            assert.equal("One", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
+            assert.strictEqual("One", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
 
             testList.push(new SomeComplexType("Two", "Don't care"));
-            assert.equal("One or Two", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
+            assert.strictEqual("One or Two", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
 
             testList.push(new SomeComplexType("Three", "Don't care"));
-            assert.equal("One, Two or Three", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
+            assert.strictEqual("One, Two or Three", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
 
             testList.push(new SomeComplexType("Four", "Don't care"));
-            assert.equal("One, Two, Three or Four", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
+            assert.strictEqual("One, Two, Three or Four", ListExtensions.toSpeechString(testList, orOperator, (li) => { return li.number }));
         });
     });
 });

--- a/lib/typescript/botbuilder-solutions/test/responseGenerationTest.js
+++ b/lib/typescript/botbuilder-solutions/test/responseGenerationTest.js
@@ -17,14 +17,14 @@ describe("response generation", function() {
             );
 
             const response = responseManager.getResponseTemplate(TestResponses.getResponseText, "en");
-            assert.deepEqual(InputHints.ExpectingInput, response.inputHint);
-            assert.deepEqual("Suggestion 1", response.suggestedActions[0]);
-            assert.deepEqual("Suggestion 2", response.suggestedActions[1]);
+            assert.deepStrictEqual(InputHints.ExpectingInput, response.inputHint);
+            assert.deepStrictEqual("Suggestion 1", response.suggestedActions[0]);
+            assert.deepStrictEqual("Suggestion 2", response.suggestedActions[1]);
 
             const reply = response.reply;
-            assert.deepEqual("The text", reply.text);
-            assert.deepEqual("The speak", reply.speak);
-            assert.deepEqual("The card text", reply.cardText);
+            assert.deepStrictEqual("The text", reply.text);
+            assert.deepStrictEqual("The speak", reply.speak);
+            assert.deepStrictEqual("The card text", reply.cardText);
         });
     });
 });

--- a/lib/typescript/botbuilder-solutions/test/speechUtilityTest.js
+++ b/lib/typescript/botbuilder-solutions/test/speechUtilityTest.js
@@ -48,7 +48,7 @@ describe("speech utility", function() {
 
             const response = SpeechUtility.listToSpeechReadyString(promptOptions);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${listItemSpeakProperty}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${listItemSpeakProperty}`);
         });
     });
 
@@ -68,7 +68,7 @@ describe("speech utility", function() {
             const item1 = i18next.t("common:latestItem").replace("{0}", listItemSpeakProperty);
             const item2 = i18next.t("common:lastItem").replace("{0}", listItemSpeakProperty);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1} ${andOperator} ${item2}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1} ${andOperator} ${item2}`);
         });
     });
 
@@ -80,7 +80,7 @@ describe("speech utility", function() {
 
             const response = SpeechUtility.listToSpeechReadyString(activity);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${listItemSpeakProperty}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${listItemSpeakProperty}`);
         });
     });
 
@@ -98,7 +98,7 @@ describe("speech utility", function() {
             const item2 = i18next.t("common:lastItem")
                 .replace("{0}", listItemSpeakProperty);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1} ${andOperator} ${item2}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1} ${andOperator} ${item2}`);
         });
     });
 
@@ -119,7 +119,7 @@ describe("speech utility", function() {
             const item3 = i18next.t("common:lastItem")
                 .replace("{0}", listItemSpeakProperty);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1}, ${item2} ${andOperator} ${item3}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1}, ${item2} ${andOperator} ${item3}`);
         });
     });
 
@@ -143,7 +143,7 @@ describe("speech utility", function() {
             const item4 = i18next.t("common:lastItem")
                 .replace("{0}", listItemSpeakProperty);
 
-            assert.deepEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1}, ${item2}, ${item3} ${andOperator} ${item4}`);
+            assert.deepStrictEqual(response, `${parentSpeakProperty}${SpeechUtility.breakString}${item1}, ${item2}, ${item3} ${andOperator} ${item4}`);
         });
     });
 });

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/localization.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/localization.test.js
@@ -33,8 +33,8 @@ describe("Localization", function() {
                     locale: "de"
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonDe);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonDe);
                 });
 
                 return testNock.resolveWithMocks('localization_response_de', done, flow);
@@ -60,8 +60,8 @@ describe("Localization", function() {
                     locale: 'es-es'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonEs);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonEs);
                 });
 
                 return testNock.resolveWithMocks('localization_response_es', done, flow);
@@ -87,8 +87,8 @@ describe("Localization", function() {
                     locale: 'fr'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonFr);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonFr);
                 });
 
                 return testNock.resolveWithMocks('localization_response_fr', done, flow);
@@ -114,8 +114,8 @@ describe("Localization", function() {
                     locale: 'it'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonIt);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonIt);
                 });
 
                 return testNock.resolveWithMocks('localization_response_it', done, flow);
@@ -141,8 +141,8 @@ describe("Localization", function() {
                     locale: 'en'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJson);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJson);
                 });
 
                 return testNock.resolveWithMocks('localization_response_en', done, flow);
@@ -168,8 +168,8 @@ describe("Localization", function() {
                     locale: 'zh'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonZh);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonZh);
                 });
 
                 return testNock.resolveWithMocks('localization_response_zh', done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mainDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mainDialog.test.js
@@ -67,8 +67,8 @@ describe("Main Dialog", function () {
 				const flow = testAdapter
 					.send('I want to talk to a human')	
 					.assertReply(function (activity, description) {
-						assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.hero');
-						assert.deepEqual(activity.attachments[0].content.title, 'Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.');
+						assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.hero');
+						assert.deepStrictEqual(activity.attachments[0].content.title, 'Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.');
 					});
 
 				testNock.resolveWithMocks('mainDialog_escalate_response', done, flow);
@@ -95,8 +95,8 @@ describe("Main Dialog", function () {
 					locale: 'es-es'
 				})
 				.assertReply(function (activity, description) {
-					assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, introJsonEs);
+					assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, introJsonEs);
 				});
 
 				return testNock.resolveWithMocks('mainDialog_localization_response', done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mainDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mainDialog.test.js
@@ -63,7 +63,7 @@ describe("main dialog", function() {
       const flow = testAdapter
         .send("blah blah")
         .assertReply(function(activity) {
-          assert.notEqual(-1, unhandledReplies.indexOf(activity.text));
+          assert.notStrictEqual(-1, unhandledReplies.indexOf(activity.text));
         });
 
       testNock.resolveWithMocks("mainDialog_unhandled_response", done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/sampleDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/sampleDialog.test.js
@@ -25,7 +25,7 @@ describe("sample dialog", function() {
         .assertReply("What is your name?")
         .send(nameInput)
         .assertReply(function(activity) {
-          assert.notEqual(-1, sampleDialogNameReplies.indexOf(activity.text));
+          assert.notStrictEqual(-1, sampleDialogNameReplies.indexOf(activity.text));
         });
 
       testNock.resolveWithMocks("sampleDialog_response", done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.skill.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.skill.test.suite.js
@@ -120,12 +120,12 @@ describe(`The generator-botbuilder-assistant skill tests`, function() {
         
         describe(`and have in the package.json`, function() {
             it(`a name property with the given name`, function(done) {
-                assert.equal(packageJSON.name, skillName);
+                assert.strictEqual(packageJSON.name, skillName);
                 done();
             });
 
             it(`a description property with given description`, function(done) {
-                assert.equal(packageJSON.description, skillDesc);
+                assert.strictEqual(packageJSON.description, skillDesc);
                 done();
             });
         });

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
@@ -113,12 +113,12 @@ describe(`The generator-botbuilder-assistant tests`, function() {
 
         describe(`and have in the package.json`, function() {
             it("a name property with the given name", function(done) {
-                assert.equal(packageJSON.name, assistantName);
+                assert.strictEqual(packageJSON.name, assistantName);
                 done();
             });
 
             it("a description property with given description", function(done) {
-                assert.equal(packageJSON.description, assistantDesc);
+                assert.strictEqual(packageJSON.description, assistantDesc);
                 done();
             });
         });

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/localization.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/localization.test.js
@@ -33,8 +33,8 @@ describe("Localization", function() {
                     locale: "de"
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonDe);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonDe);
                 });
 
                 return testNock.resolveWithMocks('localization_response_de', done, flow);
@@ -60,8 +60,8 @@ describe("Localization", function() {
                     locale: 'es-es'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonEs);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonEs);
                 });
 
                 return testNock.resolveWithMocks('localization_response_es', done, flow);
@@ -87,8 +87,8 @@ describe("Localization", function() {
                     locale: 'fr'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonFr);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonFr);
                 });
 
                 return testNock.resolveWithMocks('localization_response_fr', done, flow);
@@ -114,8 +114,8 @@ describe("Localization", function() {
                     locale: 'it'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonIt);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonIt);
                 });
 
                 return testNock.resolveWithMocks('localization_response_it', done, flow);
@@ -141,8 +141,8 @@ describe("Localization", function() {
                     locale: 'en'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJson);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJson);
                 });
 
                 return testNock.resolveWithMocks('localization_response_en', done, flow);
@@ -168,8 +168,8 @@ describe("Localization", function() {
                     locale: 'zh'
                 })
                 .assertReply(function (activity, description) {
-                    assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, localizationJsonZh);
+                    assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, localizationJsonZh);
                 });
 
                 return testNock.resolveWithMocks('localization_response_zh', done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mainDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mainDialog.test.js
@@ -67,8 +67,8 @@ describe("Main Dialog", function () {
 				const flow = testAdapter
 					.send('I want to talk to a human')	
 					.assertReply(function (activity, description) {
-						assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.hero');
-						assert.deepEqual(activity.attachments[0].content.title, 'Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.');
+						assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.hero');
+						assert.deepStrictEqual(activity.attachments[0].content.title, 'Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.');
 					});
 
 				testNock.resolveWithMocks('mainDialog_escalate_response', done, flow);
@@ -95,8 +95,8 @@ describe("Main Dialog", function () {
 					locale: 'es-es'
 				})
 				.assertReply(function (activity, description) {
-					assert.equal(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
-					assert.deepEqual(activity.attachments[0].content, introJsonEs);
+					assert.strictEqual(activity.attachments[0].contentType, 'application/vnd.microsoft.card.adaptive');
+					assert.deepStrictEqual(activity.attachments[0].content, introJsonEs);
 				});
 
 				return testNock.resolveWithMocks('mainDialog_localization_response', done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mainDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mainDialog.test.js
@@ -63,7 +63,7 @@ describe("main dialog", function() {
       const flow = testAdapter
         .send("blah blah")
         .assertReply(function(activity) {
-          assert.notEqual(-1, unhandledReplies.indexOf(activity.text));
+          assert.notStrictEqual(-1, unhandledReplies.indexOf(activity.text));
         });
 
       testNock.resolveWithMocks("mainDialog_unhandled_response", done, flow);

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/sampleDialog.test.js
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/sampleDialog.test.js
@@ -25,7 +25,7 @@ describe("sample dialog", function() {
         .assertReply("What is your name?")
         .send(nameInput)
         .assertReply(function(activity) {
-          assert.notEqual(-1, sampleDialogNameReplies.indexOf(activity.text));
+          assert.notStrictEqual(-1, sampleDialogNameReplies.indexOf(activity.text));
         });
 
       testNock.resolveWithMocks("sampleDialog_response", done, flow);


### PR DESCRIPTION
## Description 

### Normalize asserts in:
- Botbuilder-Solutions
- Botbuilder-skills
- Sample-Assistant
- Sample-Skill
- Generator-botbuilder-assistant

## Testing Steps

### Sample-assistant

1. Go to `botframework-solutions\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant`
1. Open a terminal in that location.
1. Execute `npm install` to install dependencies. 
1. Execute `npm run build` to build the project.
1. Execute `npm run test`
1. Check that all the test passed successfully.

### Sample-Skill

1. Go to `botframework-solutions\templates\Virtual-Assistant-Template\typescript\samples\sample-skill`
1. Open a terminal in that location.
1. Execute `npm install` to install dependencies. 
1. Execute `npm run build` to build the project.
1. Execute `npm run test`
1. Check that all the test passed successfully.

###  Generator-botbuilder-assistant

1. Go to `botframework-solutions\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant`
1. Open a terminal in that location.
1. Execute `npm install` to install dependencies. 
1. Execute `npm run build` to build the project.
1. Execute `npm run test`
1. Check that all the test passed successfully.

### Botbuilder-Solutions and Botbuilder-Skills

1. Go to botframework-solutions\lib\typescript\
1. Run `rush update`
1. Run `run rebuild`
1. Go to `botframework-solutions\lib\typescript\botbuilder-solutions`
1. Run `npm run test` and check the following output
1. Go to `botframework-solutions\lib\typescript\botbuilder-skills`
1. Run `npm run test` and check the following output

## Checklist
- [X] I have added or updated the appropriate unit tests