### PR TITLE
[Botskills] Add --noTrain flag for connect/disconnect commands

### DIFF
--- a/lib/typescript/botskills/docs/connect-disconnect.md
+++ b/lib/typescript/botskills/docs/connect-disconnect.md
@@ -18,7 +18,8 @@ botskills connect [options]
 | -l, --localManifest \<path>   | Path to local Skill Manifest file                                                                                                                           |
 | -r, --remoteManifest \<url>   | URL to remote Skill Manifest                                                                                                                                |
 | --cs                          | Determine your assistant project structure to be a csharp-like structure                                                                                    |
-| --ts                          | Determine your assistant project structure to be a TypeScript-like structure                                                                                |
+| --ts                          | Determine your assistant project structure to be a TypeScript-like structure   
+| --noTrain                          | (OPTIONAL) Determine whether the skills connected are not going to be trained (by default they are trained)                                                                              |
 | --dispatchName [name]         | (OPTIONAL) Name of your assistant's '.dispatch' file (defaults to the name displayed in your Cognitive Models file)                                         |
 | --language [language]         | (OPTIONAL) Locale used for LUIS culture (defaults to 'en-us')                                                                                               |
 | --luisFolder [path]           | (OPTIONAL) Path to the folder containing your Skills' '.lu' files (defaults to './deployment/resources/skills/en' inside your assistant folder)             |
@@ -64,7 +65,8 @@ botskills disconnect [option]
 |-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | -i, --skillId \<id>           | Id of the skill to remove from your assistant (case sensitive)                                                                                              |
 | --cs                          | Determine your assistant project structure to be a csharp-like structure                                                                                    |
-| --ts                          | Determine your assistant project structure to be a TypeScript-like structure                                                                                |
+| --ts                          | Determine your assistant project structure to be a TypeScript-like structure         
+| --noTrain                          | (OPTIONAL) Determine whether the skills connected are not going to be trained (by default they are trained)                                                                         |
 | --dispatchName [name]         | (OPTIONAL) Name of your assistant's '.dispatch' file (defaults to the name displayed in your Cognitive Models file)                                         |
 | --dispatchFolder [path]       | (OPTIONAL) Path to the folder containing your assistant's '.dispatch' file (defaults to './deployment/resources/dispatch/en' inside your assistant folder)  |
 | --outFolder [path]            | (OPTIONAL) Path for any output file that may be generated (defaults to your assistant's root folder)                                                        |

--- a/lib/typescript/botskills/src/botskills-connect.ts
+++ b/lib/typescript/botskills/src/botskills-connect.ts
@@ -36,6 +36,7 @@ program
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
+    .option('--noTrain', '[OPTIONAL] Determine whether the skills connected are not going to be trained (by default they are trained)')
     .option('--dispatchName [name]', '[OPTIONAL] Name of your assistant\'s \'.dispatch\' file (defaults to the name displayed in your Cognitive Models file)')
     .option('--language [language]', '[OPTIONAL] Locale used for LUIS culture (defaults to \'en-us\')')
     .option('--luisFolder [path]', '[OPTIONAL] Path to the folder containing your Skills\' .lu files (defaults to \'./deployment/resources/skills/en\' inside your assistant folder)')
@@ -57,8 +58,9 @@ if (process.argv.length < 3) {
 }
 
 logger.isVerbose = args.verbose;
-let projectLanguage: string = '';
+let noTrain: boolean = false;
 
+// Validation of arguments
 // cs and ts validation
 const csAndTsValidationResult: string = validatePairOfArgs(args.cs, args.ts);
 if (csAndTsValidationResult) {
@@ -68,9 +70,14 @@ if (csAndTsValidationResult) {
     );
     process.exit(1);
 }
-projectLanguage = args.cs ? 'cs' : 'ts';
 
-// Validation of arguments
+const projectLanguage: string = args.cs ? 'cs' : 'ts';
+
+// noTrain validation
+if (args.noTrain) {
+    noTrain = true;
+}
+
 // botName validation
 if (!args.botName) {
     logger.error(`The 'botName' argument should be provided.`);
@@ -96,6 +103,7 @@ const configuration: Partial<IConnectConfiguration> = {
     botName: args.botName,
     localManifest: args.localManifest,
     remoteManifest: args.remoteManifest,
+    noTrain: noTrain,
     lgLanguage: projectLanguage
 };
 

--- a/lib/typescript/botskills/src/botskills-disconnect.ts
+++ b/lib/typescript/botskills/src/botskills-disconnect.ts
@@ -34,6 +34,7 @@ program
     .option('-i, --skillId <id>', 'Id of the skill to remove from your assistant (case sensitive)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
+    .option('--noTrain', '[OPTIONAL] Determine whether the skills connected are not going to be trained (by default they are trained)')
     .option('--dispatchName [name]', '[OPTIONAL] Name of your assistant\'s \'.dispatch\' file (defaults to the name displayed in your Cognitive Models file)')
     .option('--dispatchFolder [path]', '[OPTIONAL] Path to the folder containing your assistant\'s \'.dispatch\' file (defaults to \'./deployment/resources/dispatch/en\' inside your assistant folder)')
     .option('--outFolder [path]', '[OPTIONAL] Path for any output file that may be generated (defaults to your assistant\'s root folder)')
@@ -50,6 +51,7 @@ if (process.argv.length < 3) {
 }
 
 logger.isVerbose = args.verbose;
+let noTrain: boolean = false;
 
 // Validation of arguments
 // cs and ts validation
@@ -63,6 +65,11 @@ if (csAndTsValidationResult) {
 }
 const projectLanguage: string = args.cs ? 'cs' : 'ts';
 
+// noTrain validation
+if (args.noTrain) {
+    noTrain = true;
+}
+
 // skillId validation
 if (!args.skillId) {
     logger.error(`The 'skillId' argument should be provided.`);
@@ -72,6 +79,7 @@ if (!args.skillId) {
 const configuration: Partial<IDisconnectConfiguration> = {
     skillId: args.skillId,
     lgLanguage: projectLanguage,
+    noTrain: noTrain,
     logger: logger
 };
 

--- a/lib/typescript/botskills/src/models/connectConfiguration.ts
+++ b/lib/typescript/botskills/src/models/connectConfiguration.ts
@@ -9,6 +9,7 @@ export interface IConnectConfiguration {
     botName: string;
     localManifest: string;
     remoteManifest: string;
+    noTrain: boolean;
     dispatchName: string;
     language: string;
     luisFolder: string;

--- a/lib/typescript/botskills/src/models/disconnectConfiguration.ts
+++ b/lib/typescript/botskills/src/models/disconnectConfiguration.ts
@@ -9,6 +9,7 @@ export interface IDisconnectConfiguration {
     skillId: string;
     skillsFile: string;
     outFolder: string;
+    noTrain: boolean;
     cognitiveModelsFile: string;
     language: string;
     luisFolder: string;


### PR DESCRIPTION
## Description

- Add `noTrain` flag for `connect`/`disconnect` commands
- Update `READMEs`

## Testing Steps
Using `botskills`
1. Follow these [steps](https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/skills/addingskills.md#adding-skills-to-your-virtual-assistant) to connect a skill.
1. Add the `--noTrain` flag during the **connection** to skip the training of your connected skills.
1. Follow these [steps](https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/skills/addingskills.md#remove-a-skill-from-your-virtual-assistant) for `disconnect` command
1. Add the `--noTrain` flag during the **disconnection** to skip the training of your connected skills.

Examples:
Connect command with `--noTrain`
```
botskills connect --botName YOUR_BOT_NAME --remoteManifest "http://<YOUR_SKILL_MANIFEST>.azurewebsites.net/api/skill/manifest" --luisFolder [path] --cs --noTrain
```

Disconnect command with `--noTrain`
```
botskills disconnect --skillId SKILL_ID --noTrain
```

## Checklist
- [X] I have updated related documentation
