### PR TITLE
remove skill begin event

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Microsoft.Bot.Builder.Skills.Tests.csproj
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Microsoft.Bot.Builder.Skills.Tests.csproj
@@ -43,15 +43,6 @@
     <Content Include="manifestTemplate.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestData\skillBeginEvent.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestData\skillBeginEventWithOneParam.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestData\skillBeginEventWithTwoParams.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillTransport.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Bot.Protocol;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
 {
 	public class MockSkillTransport : ISkillTransport
 	{
-		private string _activityForwarded = string.Empty;
+		private Activity _activityForwarded;
 
 		public Task CancelRemoteDialogsAsync(ITurnContext turnContext)
 		{
@@ -22,19 +19,19 @@ namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
 
 		public Task<bool> ForwardToSkillAsync(ITurnContext dialogContext, Activity activity, Action<Activity> tokenRequestHandler = null)
 		{
-			_activityForwarded = JsonConvert.SerializeObject(activity, SerializationSettings.BotSchemaSerializationSettings);
+			_activityForwarded = activity;
 
 			return Task.FromResult(true);
 		}
 
 		public bool CheckIfSkillInvoked()
 		{
-			return !string.IsNullOrWhiteSpace(_activityForwarded);
+			return _activityForwarded != null;
 		}
 
-		public void VerifyActivityForwardedCorrectly(Func<string, bool> assertion)
+		public void VerifyActivityForwardedCorrectly(Action<Activity> assertion)
 		{
-			Assert.IsTrue(assertion(_activityForwarded));
+			assertion(_activityForwarded);
 		}
 	}
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogSlotFillingTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogSlotFillingTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -9,6 +8,7 @@ using Microsoft.Bot.Builder.Skills.Tests.Mocks;
 using Microsoft.Bot.Builder.Skills.Tests.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills.Tests
 {
@@ -68,108 +68,84 @@ namespace Microsoft.Bot.Builder.Skills.Tests
         }
 
         /// <summary>
-        /// Ensure the SkillBegin event activity is sent to the Skill when starting a skill conversation.
+        /// Ensure the activity received on the skill side includes the slots that were configured in the manifest.
         /// </summary>
         /// <returns>Task.</returns>
         [TestMethod]
-        public async Task SkilllBeginEventTest()
+        public async Task SkillInvocationWithSlotsTest()
         {
-            string eventToMatch = await File.ReadAllTextAsync(@".\TestData\skillBeginEvent.json");
-
             var sp = Services.BuildServiceProvider();
             var adapter = sp.GetService<TestAdapter>();
 
-            await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskill"), "testSkill/testAction", null)
+			var slots = new SkillContext();
+			dynamic entity = new { key1 = "TEST1", key2 = "TEST2" };
+			slots.Add("param1", JObject.FromObject(entity));
+
+			await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskillwithslots"), "testSkill/testActionWithSlots", slots)
                   .Send("hello")
                   .StartTestAsync();
 
-			_mockSkillTransport.VerifyActivityForwardedCorrectly(activity => ValidateActivity(activity, eventToMatch));
-        }
-
-        /// <summary>
-        /// Ensure the skillBegin event is sent and includes the slots that were configured in the manifest
-        /// and present in State.
-        /// </summary>
-        /// <returns>Task.</returns>
-        [TestMethod]
-        public async Task SkilllBeginEventWithSlotsTest()
-        {
-            string eventToMatch = await File.ReadAllTextAsync(@".\TestData\skillBeginEventWithOneParam.json");
-
-            var sp = Services.BuildServiceProvider();
-            var adapter = sp.GetService<TestAdapter>();
-
-            // Data to add to the UserState managed SkillContext made available for slot filling
-            // within SkillDialog
-            Dictionary<string, object> slots = new Dictionary<string, object>();
-            slots.Add("param1", "TEST");
-
-            await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskillwithslots"), "testSkill/testActionWithSlots", slots)
-                  .Send("hello")
-                  .StartTestAsync();
-
-			_mockSkillTransport.VerifyActivityForwardedCorrectly(activity => ValidateActivity(activity, eventToMatch));
+			_mockSkillTransport.VerifyActivityForwardedCorrectly(activity =>
+			{
+				var semanticAction = activity.SemanticAction;
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key1"], "TEST1");
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key2"], "TEST2");
+			});
 		}
 
 		/// <summary>
-		/// Ensure the skillBegin event is sent and includes the slots that were configured in the manifest
-		/// This test has extra data in the SkillContext "memory" which should not be sent across
-		/// and present in State.
+		/// Ensure the activity received on the skill side includes the slots that were configured in the manifest
+		/// This test has extra data in the SkillContext "memory" which should not be sent across.
 		/// </summary>
 		/// <returns>Task.</returns>
 		[TestMethod]
-        public async Task SkilllBeginEventWithSlotsTestExtraItems()
+        public async Task SkillInvocationWithSlotsTestExtraItems()
         {
-            string eventToMatch = await File.ReadAllTextAsync(@".\TestData\skillBeginEventWithOneParam.json");
-
             var sp = Services.BuildServiceProvider();
             var adapter = sp.GetService<TestAdapter>();
 
-            // Data to add to the UserState managed SkillContext made available for slot filling
-            // within SkillDialog
-            Dictionary<string, object> slots = new Dictionary<string, object>();
-            slots.Add("param1", "TEST");
-            slots.Add("param2", "TEST");
-            slots.Add("param3", "TEST");
-            slots.Add("param4", "TEST");
+			var slots = new SkillContext();
+			dynamic entity = new { key1 = "TEST1", key2 = "TEST2" };
+			slots.Add("param1", JObject.FromObject(entity));
 
-            await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskillwithslots"), "testSkill/testActionWithSlots", slots)
+			await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskillwithslots"), "testSkill/testActionWithSlots", slots)
                   .Send("hello")
                   .StartTestAsync();
 
-			_mockSkillTransport.VerifyActivityForwardedCorrectly(activity => ValidateActivity(activity, eventToMatch));
+			_mockSkillTransport.VerifyActivityForwardedCorrectly(activity =>
+			{
+				var semanticAction = activity.SemanticAction;
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key1"], "TEST1");
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key2"], "TEST2");
+			});
 		}
 
-        /// <summary>
-        /// Ensure the skillBegin event is sent and includes the slots that were configured in the manifest
-        /// and present in State. This doesn't pass an action so "global" slot filling is used
-        /// </summary>
-        /// <returns>Task.</returns>
-        [TestMethod]
-        public async Task SkilllBeginEventNoActionPassed()
+		/// <summary>
+		/// Ensure the activity received on the skill side includes the slots that were configured in the manifest
+		/// This doesn't pass an action so "global" slot filling is used.
+		/// </summary>
+		/// <returns>Task.</returns>
+		[TestMethod]
+        public async Task SkillInvocationNoActionPassed()
         {
-            string eventToMatch = await File.ReadAllTextAsync(@".\TestData\skillBeginEventWithTwoParams.json");
-
             var sp = Services.BuildServiceProvider();
             var adapter = sp.GetService<TestAdapter>();
 
-            // Data to add to the UserState managed SkillContext made available for slot filling
-            // within SkillDialog
-            Dictionary<string, object> slots = new Dictionary<string, object>();
-            slots.Add("param1", "TEST");
-            slots.Add("param2", "TEST2");
+			var slots = new SkillContext();
+			dynamic entity = new { key1 = "TEST1", key2 = "TEST2" };
+			slots.Add("param1", JObject.FromObject(entity));
 
             // Not passing action to test the "global" slot filling behaviour
             await this.GetTestFlow(_skillManifests.Single(s => s.Name == "testskillwithmultipleactionsandslots"), null, slots)
                   .Send("hello")
                   .StartTestAsync();
 
-            _mockSkillTransport.VerifyActivityForwardedCorrectly(activity => ValidateActivity(activity, eventToMatch));
-        }
-
-        private bool ValidateActivity(string activitySent, string activityToMatch)
-        {
-            return string.Equals(activitySent, activityToMatch);
+            _mockSkillTransport.VerifyActivityForwardedCorrectly(activity =>
+			{
+				var semanticAction = activity.SemanticAction;
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key1"], "TEST1");
+				Assert.AreEqual(semanticAction.Entities["param1"].Properties["key2"], "TEST2");
+			});
         }
     }
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogTestBase.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/SkillDialogTestBase.cs
@@ -6,6 +6,7 @@ using Microsoft.Bot.Builder.Solutions;
 using Microsoft.Bot.Builder.Solutions.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills.Tests
 {
@@ -47,7 +48,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 			Services.AddSingleton<ISkillTransport, SkillWebSocketTransport>();
         }
 
-        public TestFlow GetTestFlow(SkillManifest skillManifest, string actionId, Dictionary<string, object> slots)
+        public TestFlow GetTestFlow(SkillManifest skillManifest, string actionId, Dictionary<string, JObject> slots)
         {
             var sp = Services.BuildServiceProvider();
             var adapter = sp.GetService<TestAdapter>();

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEvent.json
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEvent.json
@@ -1,1 +1,0 @@
-﻿{"type":"event","channelId":"test","from":{"id":"user1","name":"User1"},"conversation":{"id":"Conversation1"},"recipient":{"id":"bot","name":"Bot"},"value":{},"name":"skill/begin"}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEventWithOneParam.json
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEventWithOneParam.json
@@ -1,1 +1,0 @@
-﻿{"type":"event","channelId":"test","from":{"id":"user1","name":"User1"},"conversation":{"id":"Conversation1"},"recipient":{"id":"bot","name":"Bot"},"value":{"param1":"TEST"},"name":"skill/begin"}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEventWithTwoParams.json
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/TestData/skillBeginEventWithTwoParams.json
@@ -1,1 +1,0 @@
-﻿{"type":"event","channelId":"test","from":{"id":"user1","name":"User1"},"conversation":{"id":"Conversation1"},"recipient":{"id":"bot","name":"Bot"},"value":{"param1":"TEST","param2":"TEST2"},"name":"skill/begin"}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/SkillEvents.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/SkillEvents.cs
@@ -2,7 +2,6 @@
 {
     public class SkillEvents
     {
-        public const string SkillBeginEventName = "skill/begin";
         public const string CancelAllSkillDialogsEventName = "skill/cancelallskilldialogs";
     }
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillContext.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillContext.cs
@@ -1,17 +1,18 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills
 {
     /// <summary>
     ///  Context to share state between Bots and Skills.
     /// </summary>
-    public class SkillContext : Dictionary<string, object>
+    public class SkillContext : Dictionary<string, JObject>
     {
         public SkillContext()
         {
         }
 
-        public SkillContext(IDictionary<string, object> collection)
+        public SkillContext(IDictionary<string, JObject> collection)
             : base(collection)
         {
         }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Skills.Auth;
-using Microsoft.Bot.Builder.Skills.Models;
 using Microsoft.Bot.Builder.Skills.Models.Manifest;
 using Microsoft.Bot.Builder.Solutions;
 using Microsoft.Bot.Builder.Solutions.Authentication;
@@ -86,7 +85,7 @@ namespace Microsoft.Bot.Builder.Skills
         /// <returns>dialog turn result.</returns>
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var slots = new Dictionary<string, object>();
+            var slots = new Dictionary<string, JObject>();
 
             // Retrieve the SkillContext state object to identify slots (parameters) that can be used to slot-fill when invoking the skill
             var accessor = _userState.CreateProperty<SkillContext>(nameof(SkillContext));
@@ -136,7 +135,7 @@ namespace Microsoft.Bot.Builder.Skills
 
 			foreach (var slot in slots)
 			{
-				semanticAction.Entities.Add(slot.Key, new Entity { Properties = JObject.FromObject(slot.Value) });
+				semanticAction.Entities.Add(slot.Key, new Entity { Properties = slot.Value });
 			}
 
 			activity.SemanticAction = semanticAction;
@@ -194,7 +193,7 @@ namespace Microsoft.Bot.Builder.Skills
                 foreach (Slot slot in actionSlots)
                 {
                     // For each slot we check to see if there is an exact match, if so we pass this slot across to the skill
-                    if (skillContext.TryGetValue(slot.Name, out object slotValue))
+                    if (skillContext.TryGetValue(slot.Name, out JObject slotValue))
                     {
                         slots.Add(slot.Name, slotValue);
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Skills.Models;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Skills
 {
@@ -25,20 +24,10 @@ namespace Microsoft.Bot.Builder.Skills
 
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // The skillBegin event signals the start of a skill conversation to a Bot.
             var activity = turnContext.Activity;
             if (activity != null && activity.Type == ActivityTypes.Event)
             {
-                if (activity.Name == SkillEvents.SkillBeginEventName && activity.Value != null && !string.IsNullOrWhiteSpace(activity.Value.ToString()))
-				{
-					var skillContext = JsonConvert.DeserializeObject<SkillContext>(activity.Value.ToString());
-					if (skillContext != null)
-                    {
-                        var accessor = _userState.CreateProperty<SkillContext>(nameof(SkillContext));
-                        await accessor.SetAsync(turnContext, skillContext);
-                    }
-                }
-                else if (activity.Name == SkillEvents.CancelAllSkillDialogsEventName)
+                if (activity.Name == SkillEvents.CancelAllSkillDialogsEventName)
                 {
                     // when skill receives a CancelAllSkillDialogsEvent, clear the dialog stack and short-circuit
                     var currentConversation = await _dialogState.GetAsync(turnContext);

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillMiddleware.cs
@@ -30,10 +30,13 @@ namespace Microsoft.Bot.Builder.Skills
                 if (activity.Name == SkillEvents.CancelAllSkillDialogsEventName)
                 {
                     // when skill receives a CancelAllSkillDialogsEvent, clear the dialog stack and short-circuit
-                    var currentConversation = await _dialogState.GetAsync(turnContext);
-                    currentConversation.DialogStack.Clear();
-                    await _dialogState.SetAsync(turnContext, currentConversation);
-                    await _conversationState.SaveChangesAsync(turnContext, true);
+                    var currentConversation = await _dialogState.GetAsync(turnContext, () => new DialogState());
+					if (currentConversation.DialogStack != null)
+					{
+						currentConversation.DialogStack.Clear();
+						await _dialogState.SetAsync(turnContext, currentConversation);
+						await _conversationState.SaveChangesAsync(turnContext, true);
+					}
 
                     return;
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

SemanticAction field on the Activity schema is the one we should use to hang semantic action entities off of. If we use this approach we also don't need the extra skill begin event so on every turn the calling bot and the skill bot can just put entities on the semanticAction field and expect the counterpart to use that for context related information. 

Making this as draft for now because it's pending testing. 

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
