### PR TITLE
Enable Linked Accounts to work with Azure AD and personal Microsoft accounts

### DIFF
--- a/solutions/linkedaccounts/LinkedAccounts.sln
+++ b/solutions/linkedaccounts/LinkedAccounts.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.452
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinkedAccounts.Web", "linkedaccounts.web\LinkedAccounts.Web.csproj", "{C2C15C6D-720B-46B7-B1B1-F1B015487A9E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Web", "Microsoft.Identity.Web\Microsoft.Identity.Web.csproj", "{8B15534C-586F-42C8-ACCD-0B300CF83815}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{C2C15C6D-720B-46B7-B1B1-F1B015487A9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2C15C6D-720B-46B7-B1B1-F1B015487A9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2C15C6D-720B-46B7-B1B1-F1B015487A9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B15534C-586F-42C8-ACCD-0B300CF83815}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B15534C-586F-42C8-ACCD-0B300CF83815}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B15534C-586F-42C8-ACCD-0B300CF83815}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B15534C-586F-42C8-ACCD-0B300CF83815}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/ClaimConstants.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/ClaimConstants.cs
@@ -1,0 +1,39 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Constants for claim types.
+    /// </summary>
+    public static class ClaimConstants
+    {
+        public const string Name = "name";
+        public const string ObjectId = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+        public const string Oid = "oid";
+        public const string PreferredUserName = "preferred_username";
+        public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
+        public const string Tid = "tid";
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/ClaimPrincipalExtension.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/ClaimPrincipalExtension.cs
@@ -1,0 +1,183 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.Identity.Client;
+using System.Security.Claims;
+
+namespace Microsoft.Identity.Web
+{
+    public static class ClaimsPrincipalExtension
+    {
+        /// <summary>
+        /// Gets the Account identifier for an MSAL.NET account from a <see cref="ClaimsPrincipal"/>
+        /// </summary>
+        /// <param name="claimsPrincipal">Claims principal</param>
+        /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></returns>
+        public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
+        {
+            string userObjectId = GetObjectId(claimsPrincipal);
+            string tenantId = GetTenantId(claimsPrincipal);
+            if (!string.IsNullOrWhiteSpace(userObjectId) && !string.IsNullOrWhiteSpace(tenantId))
+            {
+                return $"{userObjectId}.{tenantId}";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the unique object ID associated with the <see cref="ClaimsPrincipal"/>
+        /// </summary>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the unique object id</param>
+        /// <returns>Unique object ID of the identity, or <c>null</c> if it cannot be found</returns>
+        public static string GetObjectId(this ClaimsPrincipal claimsPrincipal)
+        {
+            string userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.Oid);
+            if (string.IsNullOrEmpty(userObjectId))
+                userObjectId = claimsPrincipal.FindFirstValue(ClaimConstants.ObjectId);
+
+            return userObjectId;
+        }
+
+        /// <summary>
+        /// Gets the Tenant ID associated with the <see cref="ClaimsPrincipal"/>
+        /// </summary>
+        /// <param name="claimsPrincipal">the <see cref="ClaimsPrincipal"/> from which to retrieve the tenant id</param>
+        /// <returns>Tenant ID of the identity, or <c>null</c> if it cannot be found</returns>
+        public static string GetTenantId(this ClaimsPrincipal claimsPrincipal)
+        {
+            string tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.Tid);
+            if (string.IsNullOrEmpty(tenantId))
+                tenantId = claimsPrincipal.FindFirstValue(ClaimConstants.TenantId);
+
+            return tenantId;
+        }
+
+        /// <summary>
+        /// Gets the login-hint associated with a <see cref="ClaimsPrincipal"/>
+        /// </summary>
+        /// <param name="claimsPrincipal">Identity for which to complete the login-hint</param>
+        /// <returns>login-hint for the identity, or <c>null</c> if it cannot be found</returns>
+        public static string GetLoginHint(this ClaimsPrincipal claimsPrincipal)
+        {
+            return GetDisplayName(claimsPrincipal);
+        }
+
+        /// <summary>
+        /// Gets the domain-hint associated with an identity
+        /// </summary>
+        /// <param name="claimsPrincipal">Identity for which to compte the domain-hint</param>
+        /// <returns>domain-hint for the identity, or <c>null</c> if it cannot be found</returns>
+        public static string GetDomainHint(this ClaimsPrincipal claimsPrincipal)
+        {
+            // Tenant for MSA accounts
+            const string msaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+            var tenantId = GetTenantId(claimsPrincipal);
+            return string.IsNullOrWhiteSpace(tenantId) ? null : tenantId == msaTenantId ? "consumers" : "organizations";
+        }
+
+        /// <summary>
+        /// Get the display name for the signed-in user, from the <see cref="ClaimsPrincipal"/>
+        /// </summary>
+        /// <param name="claimsPrincipal">Claims about the user/account</param>
+        /// <returns>A string containing the display name for the user, as brought by Azure AD v1.0 and v2.0 tokens,
+        /// or <c>null</c> if the claims cannot be found</returns>
+        /// <remarks>See https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#payload-claims </remarks>
+        public static string GetDisplayName(this ClaimsPrincipal claimsPrincipal)
+        {
+            // Attempting the claims brought by an Azure AD v2.0 token first
+            string displayName = claimsPrincipal.FindFirstValue(ClaimConstants.PreferredUserName);
+
+            // Otherwise falling back to the claims brought by an Azure AD v1.0 token
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = claimsPrincipal.FindFirstValue(ClaimsIdentity.DefaultNameClaimType);
+            }
+
+            // Finally falling back to name
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = claimsPrincipal.FindFirstValue(ClaimConstants.Name);
+            }
+
+            return displayName;
+        }
+
+        /// <summary>
+        /// Instantiate a ClaimsPrincipal from an account objectId and tenantId. This can
+        /// we useful when the Web app subscribes to another service on behalf of the user
+        /// and then is called back by a notification where the user is identified by his tenant
+        /// id and object id (like in Microsoft Graph Web Hooks)
+        /// </summary>
+        /// <param name="tenantId">Tenant Id of the account</param>
+        /// <param name="objectId">Object Id of the account in this tenant ID</param>
+        /// <returns>A ClaimsPrincipal containing these two claims</returns>
+        /// <example>
+        /// <code>
+        /// private async Task GetChangedMessagesAsync(IEnumerable<Notification> notifications)
+        /// {
+        ///  foreach (var notification in notifications)
+        ///  {
+        ///   SubscriptionStore subscription =
+        ///           subscriptionStore.GetSubscriptionInfo(notification.SubscriptionId);
+        ///  HttpContext.User = ClaimsPrincipalExtension.FromTenantIdAndObjectId(subscription.TenantId,
+        ///                                                                      subscription.UserId);
+        ///  string accessToken = await tokenAcquisition.GetAccessTokenOnBehalfOfUser(HttpContext, scopes);,
+        /// </code>
+        /// </example>
+        public static ClaimsPrincipal FromTenantIdAndObjectId(string tenantId, string objectId)
+        {
+            return new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[]
+                {
+                    new Claim(ClaimConstants.Tid, tenantId),
+                    new Claim(ClaimConstants.Oid, objectId)
+                })
+            );
+        }
+
+        /// <summary>
+        /// Creates the <see cref="ClaimsPrincipal"/> from the values found in an <see cref="IAccount"/>
+        /// </summary>
+        /// <param name="account">The IAccount instance</param>
+        /// <returns>A <see cref="ClaimsPrincipal"/> built from IAccount</returns>
+        public static ClaimsPrincipal ToClaimsPrincipal(this IAccount account)
+        {
+            if (account != null)
+            {
+                return new ClaimsPrincipal(
+                    new ClaimsIdentity(new Claim[]
+                    {
+                        new Claim(ClaimConstants.Oid, account.HomeAccountId.ObjectId),
+                        new Claim(ClaimConstants.Tid, account.HomeAccountId.TenantId),
+                        new Claim(ClaimTypes.Upn, account.Username)
+                    })
+                );
+            }
+
+            return null;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/ITokenAcquisition.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/ITokenAcquisition.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.Client
+{
+    public interface ITokenAcquisition
+    {
+        /// <summary>
+        /// In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
+        /// signed-in and consented)
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>OpenIdConnectOptions options;</code>
+        /// 
+        /// Subscribe to the authorization code recieved event:
+        /// <code>
+        ///  options.Events = new OpenIdConnectEvents();
+        ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        /// }
+        /// </code>
+        /// 
+        /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCode"/>:
+        /// <code>
+        /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+        /// }
+        /// </code>
+        /// </example>
+        Task AddAccountToCacheFromAuthorizationCode(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes);
+
+        /// <summary>
+        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token 
+        /// for a downstream API on behalf of the user account which claims are provided in the <see cref="HttpContext.User"/>
+        /// member of the <paramref name="context"/> parameter
+        /// </summary>
+        /// <param name="context">HttpContext associated with the Controller or auth operation</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the 
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        Task<string> GetAccessTokenOnBehalfOfUser(HttpContext context, IEnumerable<string> scopes, string tenantId=null);
+
+        /// <summary>
+        /// In a Web API, adds to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
+        /// An access token and a refresh token are added to the cache, so that they can then be used to acquire another token on-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the JwtBearer middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API (for example in the Startup.cs file)
+        /// <code>JwtBearerOptions option;</code>
+        /// 
+        /// Subscribe to the token validated event:
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = async context =>
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///   tokenAcquisition.AddAccountToCacheFromJwt(context);
+        /// };
+        /// </code>
+        /// </example>
+        void AddAccountToCacheFromJwt(AspNetCore.Authentication.JwtBearer.TokenValidatedContext tokenValidationContext, IEnumerable<string> scopes = null);
+
+        /// <summary>
+        /// [not recommended] In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App.
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// same user in order for the Web App to call a Web APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event 
+        /// for the OpenIdConnect middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <remarks>In a Web App, it's preferable to not request an access token, but only a code, and use the <see cref="AddAccountToCacheFromAuthorizationCode"/></remarks>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>OpenIdConnectOptions options;</code>
+        /// 
+        /// Subscribe to the token validated event:
+        /// <code>
+        ///  options.Events.OnAuthorizationCodeReceived = OnTokenValidated;
+        /// </code>
+        /// 
+        /// And then in the OnTokenValidated method, call <see cref="AddAccountToCacheFromJwt(OpenIdConnect.TokenValidatedContext)"/>:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///  _tokenAcquisition.AddAccountToCache(tokenValidationContext);
+        /// }
+        /// </code>
+        /// </example>
+        void AddAccountToCacheFromJwt(TokenValidatedContext tokenValidationContext, IEnumerable<string> scopes = null);
+
+        /// <summary>
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// </summary>
+        /// <param name="context">RedirectContext passed-in to a <see cref="OnRedirectToIdentityProviderForSignOut"/> 
+        /// Openidconnect event</param>
+        /// <returns></returns>
+        Task RemoveAccount(RedirectContext context);
+
+        /// <summary>
+        /// Used in Web APIs (which therefore cannot have an interaction with the user). 
+        /// Replies to the client through the HttpReponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+        /// the client can trigger an iteraction with the user so that the user consents to more scopes
+        /// </summary>
+        /// <param name="httpContext">HttpContext</param>
+        /// <param name="scopes">Scopes to consent to</param>
+        /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+        void ReplyForbiddenWithWwwAuthenticateHeader(HttpContext httpContext, IEnumerable<string> scopes, MsalUiRequiredException msalSeviceException);
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/MsalUiRequiredExceptionFilterAttribute.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/MsalUiRequiredExceptionFilterAttribute.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Identity.Client;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.Identity.Web.Client
+{
+    /// <summary>
+    /// Filter used on a controller action to trigger an incremental consent.
+    /// </summary>
+    /// <example>
+    /// The following controller action will trigger 
+    /// <code>
+    /// [MsalUiRequiredExceptionFilter(Scopes = new[] {"Mail.Send"})]
+    /// public async Task<IActionResult> SendEmail()
+    /// {
+    /// }
+    /// </code>
+    /// </example>
+    public class MsalUiRequiredExceptionFilterAttribute : ExceptionFilterAttribute
+    {
+        public string[] Scopes { get; set; }
+        
+        public override void OnException(ExceptionContext context)
+        {
+            MsalUiRequiredException msalUiRequiredException = context.Exception as MsalUiRequiredException;
+            if (msalUiRequiredException == null)
+            {
+                msalUiRequiredException = context.Exception?.InnerException as MsalUiRequiredException;
+            }
+
+            if (msalUiRequiredException!=null)
+            {
+                if (CanBeSolvedByReSignInUser(msalUiRequiredException))
+                {
+                    var properties =
+                        BuildAuthenticationPropertiesForIncrementalConsent(Scopes, msalUiRequiredException, context.HttpContext);
+                    context.Result = new ChallengeResult(properties);
+                }
+            }
+            
+            base.OnException(context);
+        }
+        
+        private bool CanBeSolvedByReSignInUser(MsalUiRequiredException ex)
+        {
+            // ex.ErrorCode != MsalUiRequiredException.UserNullError indicates a cache problem.
+            // When calling an [Authenticate]-decorated controller we expect an authenticated
+            // user and therefore its account should be in the cache. However in the case of an
+            // InMemoryCache, the cache could be empty if the server was restarted. This is why
+            // the null_user exception is thrown.
+
+            return ex.ErrorCode == MsalError.UserNullError;
+        }
+
+        /// <summary>
+        /// Build Authentication properties needed for an incremental consent.
+        /// </summary>
+        /// <param name="scopes">Scopes to request</param>
+        /// <param name="ex">ui is present</param>
+        /// <param name="context">current http context in the pipeline</param>
+        /// <returns>AuthenticationProperties</returns>
+        private AuthenticationProperties BuildAuthenticationPropertiesForIncrementalConsent(
+            string[] scopes, MsalUiRequiredException ex, HttpContext context)
+        {
+            var properties = new AuthenticationProperties();
+
+            // Set the scopes, including the scopes that ADAL.NET / MASL.NET need for the Token cache
+            string[] additionalBuildInScopes =
+                {OidcConstants.ScopeOpenId, OidcConstants.ScopeOfflineAccess, OidcConstants.ScopeProfile};
+            properties.SetParameter<ICollection<string>>(OpenIdConnectParameterNames.Scope,
+                                                         scopes.Union(additionalBuildInScopes).ToList());
+
+            // Attempts to set the login_hint to avoid the logged-in user to be presented with an account selection dialog
+            var loginHint = context.User.GetLoginHint();
+            if (!string.IsNullOrWhiteSpace(loginHint))
+            {
+                properties.SetParameter(OpenIdConnectParameterNames.LoginHint, loginHint);
+
+                var domainHint = context.User.GetDomainHint();
+                properties.SetParameter(OpenIdConnectParameterNames.DomainHint, domainHint);
+            }
+
+            // Additional claims required (for instance MFA)
+            if (!string.IsNullOrEmpty(ex.Claims))
+            {
+                properties.Items.Add(OidcConstants.AdditionalClaims, ex.Claims);
+            }
+
+            return properties;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/OidcConstants.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/OidcConstants.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.Identity.Web.Client
+{
+    public static class OidcConstants
+    {
+        public const string AdditionalClaims = "claims";
+        public const string ScopeOfflineAccess = "offline_access";
+        public const string ScopeProfile = "profile";
+        public const string ScopeOpenId = "openid";
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenAcquisition.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenAcquisition.cs
@@ -1,0 +1,456 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web.Client.TokenCacheProviders;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.Client
+{
+    /// <summary>
+    /// Token acquisition service
+    /// </summary>
+    public class TokenAcquisition : ITokenAcquisition
+    {
+        private readonly AzureADOptions azureAdOptions;
+        private ConfidentialClientApplicationOptions _applicationOptions;
+
+        private readonly IMSALAppTokenCacheProvider AppTokenCacheProvider;
+        private readonly IMSALUserTokenCacheProvider UserTokenCacheProvider;
+
+        /// <summary>
+        /// Constructor of the TokenAcquisition service. This requires the Azure AD Options to
+        /// configure the confidential client application and a token cache provider.
+        /// This constructor is called by ASP.NET Core dependency injection
+        /// </summary>
+        /// <param name="appTokenCacheProvider">The App token cache provider</param>
+        /// <param name="userTokenCacheProvider">The User token cache provider</param>
+        /// <param name="configuration"></param>
+        public TokenAcquisition(IConfiguration configuration, IMSALAppTokenCacheProvider appTokenCacheProvider, IMSALUserTokenCacheProvider userTokenCacheProvider)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+
+            azureAdOptions = new AzureADOptions();
+            configuration.Bind("AzureAD", azureAdOptions);
+
+            _applicationOptions = new ConfidentialClientApplicationOptions();
+            configuration.Bind("AzureAD", _applicationOptions);
+
+            this.AppTokenCacheProvider = appTokenCacheProvider;
+            this.UserTokenCacheProvider = userTokenCacheProvider;
+        }
+
+        /// <summary>
+        /// Scopes which are already requested by MSAL.NET. they should not be re-requested;
+        /// </summary>
+        private readonly string[] scopesRequestedByMsalNet = new string[]
+        {
+            OidcConstants.ScopeOpenId,
+            OidcConstants.ScopeProfile,
+            OidcConstants.ScopeOfflineAccess
+        };
+
+        /// <summary>
+        /// In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
+        /// signed-in and consented)
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API:
+        /// <code>OpenIdConnectOptions options;</code>
+        ///
+        /// Subscribe to the authorization code recieved event:
+        /// <code>
+        ///  options.Events = new OpenIdConnectEvents();
+        ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        /// }
+        /// </code>
+        ///
+        /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCode"/>:
+        /// <code>
+        /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+        /// }
+        /// </code>
+        /// </example>
+        public async Task AddAccountToCacheFromAuthorizationCode(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            if (scopes == null)
+                throw new ArgumentNullException(nameof(scopes));
+
+            try
+            {
+                // As AcquireTokenByAuthorizationCodeAsync is asynchronous we want to tell ASP.NET core that we are handing the code
+                // even if it's not done yet, so that it does not concurrently call the Token endpoint.
+                context.HandleCodeRedemption();
+
+                var application = BuildConfidentialClientApplication(context.HttpContext, context.Principal);
+
+                // Do not share the access token with ASP.NET Core otherwise ASP.NET will cache it and will not send the OAuth 2.0 request in
+                // case a further call to AcquireTokenByAuthorizationCodeAsync in the future for incremental consent (getting a code requesting more scopes)
+                // Share the ID Token
+                var result = await application.AcquireTokenByAuthorizationCode(scopes.Except(scopesRequestedByMsalNet), context.ProtocolMessage.Code)
+                                              .ExecuteAsync();
+                context.HandleCodeRedemption(null, result.IdToken);
+            }
+            catch (MsalException ex)
+            {
+                // brentsch - todo, write to a log
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token
+        /// for a downstream API on behalf of the user account which claims are provided in the <see cref="HttpContext.User"/>
+        /// member of the <paramref name="context"/> parameter
+        /// </summary>
+        /// <param name="context">HttpContext associated with the Controller or auth operation</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        public async Task<string> GetAccessTokenOnBehalfOfUser(HttpContext context, IEnumerable<string> scopes, string tenant = null)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            if (scopes == null)
+                throw new ArgumentNullException(nameof(scopes));
+
+            // Use MSAL to get the right token to call the API
+            var application = BuildConfidentialClientApplication(context, context.User);
+
+            // Case of a lazy OBO
+            Claim jwtClaim = context.User.FindFirst("jwt");
+            if (jwtClaim != null)
+            {
+                (context.User.Identity as ClaimsIdentity).RemoveClaim(jwtClaim);
+                var result = await application.AcquireTokenOnBehalfOf(scopes.Except(scopesRequestedByMsalNet), new UserAssertion(jwtClaim.Value))
+                                        .ExecuteAsync();
+                return result.AccessToken;
+            }
+            else
+            {
+                return await GetAccessTokenOnBehalfOfUser(application, context.User, scopes, tenant);
+            }
+        }
+
+        /// <summary>
+        /// In a Web API, adds to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
+        /// An access token and a refresh token are added to the cache, so that they can then be used to acquire another token on-behalf-of the
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the JwtBearer middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API (for example in the Startup.cs file)
+        /// <code>JwtBearerOptions option;</code>
+        ///
+        /// Subscribe to the token validated event:
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = async context =>
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///   tokenAcquisition.AddAccountToCacheFromJwt(context);
+        /// };
+        /// </code>
+        /// </example>
+        public void AddAccountToCacheFromJwt(Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext tokenValidatedContext,
+            IEnumerable<string> scopes)
+        {
+            if (tokenValidatedContext == null)
+                throw new ArgumentNullException(nameof(tokenValidatedContext));
+
+            AddAccountToCacheFromJwt(scopes,
+                                     tokenValidatedContext.SecurityToken as JwtSecurityToken,
+                                     tokenValidatedContext.Principal,
+                                     tokenValidatedContext.HttpContext);
+        }
+
+        /// <summary>
+        /// [not recommended] In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App.
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on-behalf-of the
+        /// same user in order for the Web App to call a Web APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the OpenIdConnect middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <remarks>In a Web App, it's preferable to not request an access token, but only a code, and use the <see cref="AddAccountToCacheFromAuthorizationCode"/></remarks>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API:
+        /// <code>OpenIdConnectOptions options;</code>
+        ///
+        /// Subscribe to the token validated event:
+        /// <code>
+        ///  options.Events.OnAuthorizationCodeReceived = OnTokenValidated;
+        /// </code>
+        ///
+        /// And then in the OnTokenValidated method, call <see cref="AddAccountToCacheFromJwt(OpenIdConnect.TokenValidatedContext)"/>:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+        ///  _tokenAcquisition.AddAccountToCache(tokenValidationContext);
+        /// }
+        /// </code>
+        /// </example>
+        public void AddAccountToCacheFromJwt(AspNetCore.Authentication.OpenIdConnect.TokenValidatedContext tokenValidatedContext, IEnumerable<string> scopes = null)
+        {
+            if (tokenValidatedContext == null)
+                throw new ArgumentNullException(nameof(tokenValidatedContext));
+
+            AddAccountToCacheFromJwt(scopes,
+                                           tokenValidatedContext.SecurityToken,
+                                           tokenValidatedContext.Principal,
+                                           tokenValidatedContext.HttpContext);
+        }
+
+        /// <summary>
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// </summary>
+        /// <param name="context">RedirectContext passed-in to a <see cref="OnRedirectToIdentityProviderForSignOut"/>
+        /// Openidconnect event</param>
+        /// <returns></returns>
+        public async Task RemoveAccount(RedirectContext context)
+        {
+            ClaimsPrincipal user = context.HttpContext.User;
+            IConfidentialClientApplication app = BuildConfidentialClientApplication(context.HttpContext, user);
+            IAccount account = await app.GetAccountAsync(context.HttpContext.User.GetMsalAccountId());
+
+            // Workaround for the guest account
+            if (account == null)
+            {
+                var accounts = await app.GetAccountsAsync();
+                account = accounts.FirstOrDefault(a => a.Username == user.GetLoginHint());
+            }
+
+            if (account!=null)
+            {
+                this.UserTokenCacheProvider?.Clear(account.HomeAccountId.Identifier);
+
+                await app.RemoveAsync(account);
+            }
+        }
+
+        /// <summary>
+        /// Creates an MSAL Confidential client application
+        /// </summary>
+        /// <param name="httpContext"></param>
+        /// <param name="claimsPrincipal"></param>
+        /// <param name="authenticationProperties"></param>
+        /// <param name="signInScheme"></param>
+        /// <returns></returns>
+        private IConfidentialClientApplication BuildConfidentialClientApplication(HttpContext httpContext, ClaimsPrincipal claimsPrincipal)
+        {
+            var request = httpContext.Request;
+            string currentUri = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase, azureAdOptions.CallbackPath ?? string.Empty);
+            string authority = $"{azureAdOptions.Instance}{azureAdOptions.TenantId}/";
+
+            var app = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(_applicationOptions)
+               .WithRedirectUri(currentUri)
+               .WithAuthority(authority)
+               .Build();
+
+            // Initialize token cache providers
+            if (this.AppTokenCacheProvider != null)
+            {
+                this.AppTokenCacheProvider.Initialize(app.AppTokenCache, httpContext);
+            }
+
+            if (this.UserTokenCacheProvider != null)
+            {
+                this.UserTokenCacheProvider.Initialize(app.UserTokenCache, httpContext, claimsPrincipal);
+            }
+
+            return app;
+        }
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal
+        /// </summary>
+        /// <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        private async Task<string> GetAccessTokenOnBehalfOfUser(IConfidentialClientApplication application, ClaimsPrincipal claimsPrincipal, IEnumerable<string> scopes, string tenant)
+        {
+            string accountIdentifier = claimsPrincipal.GetMsalAccountId();
+            string loginHint = claimsPrincipal.GetLoginHint();
+            return await GetAccessTokenOnBehalfOfUser(application, accountIdentifier, scopes, loginHint, tenant);
+        }
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user which account ID is passed as an argument
+        /// </summary>
+        /// <param name="accountIdentifier">User account identifier for which to acquire a token.
+        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></param>
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        private async Task<string> GetAccessTokenOnBehalfOfUser(IConfidentialClientApplication application, string accountIdentifier, IEnumerable<string> scopes, string loginHint, string tenant)
+        {
+            if (accountIdentifier == null)
+                throw new ArgumentNullException(nameof(accountIdentifier));
+
+            if (scopes == null)
+                throw new ArgumentNullException(nameof(scopes));
+
+            // Get the account
+            IAccount account = await application.GetAccountAsync(accountIdentifier);
+
+            // Special case for guest users as the Guest iod / tenant id are not surfaced.
+            if (account == null)
+            {
+                var accounts = await application.GetAccountsAsync();
+                account = accounts.FirstOrDefault(a => a.Username == loginHint);
+            }
+
+            AuthenticationResult result;
+            if (string.IsNullOrWhiteSpace(tenant))
+            {
+                result = await application.AcquireTokenSilent(scopes.Except(scopesRequestedByMsalNet), account)
+                                           .ExecuteAsync();
+            }
+            else
+            {
+                string authority = application.Authority.Replace(new Uri(application.Authority).PathAndQuery, $"/{tenant}/");
+                result = await application.AcquireTokenSilent(scopes.Except(scopesRequestedByMsalNet), account)
+                                          .WithAuthority(authority)
+                                          .ExecuteAsync();
+            }
+            return result.AccessToken;
+        }
+
+        /// <summary>
+        /// Adds an account to the token cache from a JWT token and other parameters related to the token cache implementation
+        /// </summary>
+        private void AddAccountToCacheFromJwt(IEnumerable<string> scopes, JwtSecurityToken jwtToken, ClaimsPrincipal principal, HttpContext httpContext)
+        {
+            try
+            {
+                UserAssertion userAssertion;
+                IEnumerable<string> requestedScopes;
+                if (jwtToken != null)
+                {
+                    userAssertion = new UserAssertion(jwtToken.RawData, "urn:ietf:params:oauth:grant-type:jwt-bearer");
+                    requestedScopes = scopes ?? jwtToken.Audiences.Select(a => $"{a}/.default");
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException("tokenValidationContext.SecurityToken should be a JWT Token");
+                    // TODO: Understand if we could support other kind of client assertions (SAML);
+                }
+
+                var application = BuildConfidentialClientApplication(httpContext, principal);
+
+                // .Result to make sure that the cache is filled-in before the controller tries to get access tokens
+                var result = application.AcquireTokenOnBehalfOf(requestedScopes.Except(scopesRequestedByMsalNet), userAssertion)
+                                        .ExecuteAsync()
+                                        .GetAwaiter().GetResult();
+            }
+            catch (MsalException ex)
+            {
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+
+        /// <summary>
+        /// Used in Web APIs (which therefore cannot have an interaction with the user). 
+        /// Replies to the client through the HttpReponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+        /// the client can trigger an iteraction with the user so that the user consents to more scopes
+        /// </summary>
+        /// <param name="httpContext">HttpContext</param>
+        /// <param name="scopes">Scopes to consent to</param>
+        /// <param name="msalServiceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+
+        public void ReplyForbiddenWithWwwAuthenticateHeader(HttpContext httpContext, IEnumerable<string> scopes, MsalUiRequiredException msalServiceException)
+        {
+            // A user interaction is required, but we are in a Web API, and therefore, we need to report back to the client through an wwww-Authenticate header https://tools.ietf.org/html/rfc6750#section-3.1
+            string proposedAction = "consent";
+            if (msalServiceException.ErrorCode == MsalError.InvalidGrantError)
+            {
+                if (AcceptedTokenVersionIsNotTheSameAsTokenVersion(msalServiceException))
+                {
+                    throw msalServiceException;
+                }
+            }
+
+            IDictionary<string, string> parameters = new Dictionary<string, string>()
+                {
+                    { "clientId", azureAdOptions.ClientId },
+                    { "claims", msalServiceException.Claims },
+                    { "scopes", string.Join(",", scopes) },
+                    { "proposedAction", proposedAction }
+                };
+
+            string parameterString = string.Join(", ", parameters.Select(p => $"{p.Key}=\"{p.Value}\""));
+            string scheme = "Bearer";
+            StringValues v = new StringValues($"{scheme} {parameterString}");
+
+            //  StringValues v = new StringValues(new string[] { $"Bearer clientId=\"{jwtToken.Audiences.First()}\", claims=\"{ex.Claims}\", scopes=\" {string.Join(",", scopes)}\"" });
+            var httpResponse = httpContext.Response;
+            var headers = httpResponse.Headers;
+            httpResponse.StatusCode = (int)HttpStatusCode.Forbidden;
+            if (headers.ContainsKey(HeaderNames.WWWAuthenticate))
+            {
+                headers.Remove(HeaderNames.WWWAuthenticate);
+            }
+            headers.Add(HeaderNames.WWWAuthenticate, v);
+        }
+
+        private static bool AcceptedTokenVersionIsNotTheSameAsTokenVersion(MsalUiRequiredException msalSeviceException)
+        {
+            // Normally app developers should not make decisions based on the internal AAD code
+            // however until the STS sends sub-error codes for this error, this is the only
+            // way to distinguish the case. 
+            // This is subject to change in the future
+            return (msalSeviceException.Message.Contains("AADSTS50013"));
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenAcquisitionExtension.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenAcquisitionExtension.cs
@@ -1,0 +1,73 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web.Client;
+using Microsoft.Identity.Web.Client.TokenCacheProviders;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TokenCache.Tests.Core")]
+
+namespace Microsoft.Identity.Web
+{
+    /// <summary>
+    /// Extension methods
+    /// </summary>
+    public static class TokenAcquisitionExtension
+    {
+        /// <summary>
+        /// Add the token acquisition service.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <returns>the service collection</returns>
+        /// <example>
+        /// This method is typically called from the Startup.ConfigureServices(IServiceCollection services)
+        /// Note that the implementation of the token cache can be chosen separately.
+        ///
+        /// <code>
+        /// // Token acquisition service and its cache implementation as a session cache
+        /// services.AddTokenAcquisition()
+        /// .AddDistributedMemoryCache()
+        /// .AddSession()
+        /// .AddSessionBasedTokenCache()
+        ///  ;
+        /// </code>
+        /// </example>
+        public static IServiceCollection AddTokenAcquisition(this IServiceCollection services)
+        {
+            // Token acquisition service
+            services.AddScoped<ITokenAcquisition>(factory =>
+            {
+                var config = factory.GetRequiredService<IConfiguration>();
+                var apptokencacheprovider = factory.GetService<IMSALAppTokenCacheProvider>();
+                var usertokencacheprovider = factory.GetService<IMSALUserTokenCacheProvider>();
+
+                return new TokenAcquisition(config, apptokencacheprovider, usertokencacheprovider);
+            });
+
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/IMSALAppTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/IMSALAppTokenCacheProvider.cs
@@ -1,0 +1,48 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Identity.Client;
+using System.Security.Claims;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL token cache provider interface for application cache
+    /// </summary>
+    public interface IMSALAppTokenCacheProvider
+    {
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        void Initialize(ITokenCache tokenCache, HttpContext httpcontext);
+
+        /// <summary>
+        /// Clears the token cache for this app
+        /// </summary>
+        void Clear();
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/IMSALUserTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/IMSALUserTokenCacheProvider.cs
@@ -1,0 +1,47 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
+using System.Security.Claims;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL token cache provider interface for user accounts
+    /// </summary>
+    public interface IMSALUserTokenCacheProvider
+    {
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user);
+
+        /// <summary>
+        /// Clears the token cache for this user
+        /// </summary>
+        void Clear(string accountId);
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALAppMemoryTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALAppMemoryTokenCacheProvider.cs
@@ -1,0 +1,135 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using System;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by MemoryCache.
+    /// MemoryCache is useful in Api scenarios where there is no HttpContext to cache data.
+    /// </summary>
+    /// <seealso cref="https://aka.ms/msal-net-token-cache-serialization"/>
+    public class MSALAppMemoryTokenCacheProvider : IMSALAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The application cache key
+        /// </summary>
+        internal string AppCacheId;
+
+        /// <summary>
+        /// The backing MemoryCache instance
+        /// </summary>
+        internal IMemoryCache memoryCache;
+
+        private readonly MSALMemoryTokenCacheOptions CacheOptions;
+
+        /// <summary>
+        /// The App's whose cache we are maintaining.
+        /// </summary>
+        private readonly string AppId;
+
+        public MSALAppMemoryTokenCacheProvider(IMemoryCache cache,
+            MSALMemoryTokenCacheOptions option,
+            IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor)
+        {
+            if (option != null)
+            {
+                this.CacheOptions = new MSALMemoryTokenCacheOptions();
+            }
+            else
+            {
+                this.CacheOptions = option;
+            }
+
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(AzureADOptions), $"The app token cache needs {nameof(AzureADOptions)}, populated with clientId to initialize.");
+            }
+
+            this.AppId = azureAdOptionsAccessor.CurrentValue.ClientId;
+            this.memoryCache = cache;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            this.AppCacheId = this.AppId + "_AppTokenCache";
+
+            tokenCache.SetBeforeAccess(this.AppTokenCacheBeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.AppTokenCacheAfterAccessNotification);
+            tokenCache.SetBeforeWrite(this.AppTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a MemoryCache ,whose methods are threads safe, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Clears the token cache for this app
+        /// </summary>
+        public void Clear()
+        {
+            this.memoryCache.Remove(this.AppCacheId);
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // Load the token cache from memory
+            byte[] tokenCacheBytes = (byte[])this.memoryCache.Get(this.AppCacheId);
+            args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache: true);
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                // Reflect changes in the persistence store
+                this.memoryCache.Set(this.AppCacheId, args.TokenCache.SerializeMsalV3(), CacheOptions.SlidingExpiration);
+            }
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALAppMemoryTokenCacheProviderExtension.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALAppMemoryTokenCacheProviderExtension.cs
@@ -1,0 +1,87 @@
+﻿/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    public static class MSALAppMemoryTokenCacheProviderExtension
+    {
+        /// <summary>Adds both the app and per-user in-memory token caches.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddInMemoryTokenCaches(this IServiceCollection services, MSALMemoryTokenCacheOptions cacheOptions = null)
+        {
+            var memoryCacheoptions = (cacheOptions == null) ? new MSALMemoryTokenCacheOptions { SlidingExpiration = TimeSpan.FromDays(14) }
+            : cacheOptions;
+
+            AddInMemoryAppTokenCache(services, memoryCacheoptions);
+            AddInMemoryPerUserTokenCache(services, memoryCacheoptions);
+            return services;
+        }
+
+
+        /// <summary>Adds the in-memory based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        public static IServiceCollection AddInMemoryAppTokenCache(this IServiceCollection services, MSALMemoryTokenCacheOptions cacheOptions)
+        {
+            services.AddMemoryCache();
+
+            services.AddSingleton<IMSALAppTokenCacheProvider>(factory =>
+            {
+                var memoryCache = factory.GetRequiredService<IMemoryCache>();
+                var optionsMonitor = factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>();
+
+                return new MSALAppMemoryTokenCacheProvider(memoryCache, cacheOptions, optionsMonitor);
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the in-memory based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddInMemoryPerUserTokenCache(this IServiceCollection services, MSALMemoryTokenCacheOptions cacheOptions)
+        {
+            services.AddMemoryCache();
+            services.AddHttpContextAccessor();
+            services.AddSingleton<IMSALUserTokenCacheProvider>(factory =>
+            {
+                var memoryCache = factory.GetRequiredService<IMemoryCache>();
+                IHttpContextAccessor httpContextAccessor = factory.GetRequiredService<IHttpContextAccessor>();
+                return new MSALPerUserMemoryTokenCacheProvider(memoryCache, cacheOptions, httpContextAccessor);
+            });
+
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALMemoryTokenCacheOptions.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALMemoryTokenCacheOptions.cs
@@ -1,0 +1,52 @@
+/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL's memory token cache options
+    /// </summary>
+    public class MSALMemoryTokenCacheOptions
+    {
+        /// <summary>
+        /// Gets or sets the value of The fixed date and time at which the cache entry will expire..
+        /// The duration till the tokens are kept in memory cache. In production, a higher value , upto 90 days is recommended.
+        /// </summary>
+        /// <value>
+        /// The AbsoluteExpiration value.
+        /// </value>
+        public TimeSpan SlidingExpiration
+        {
+            get;
+            set;
+        }
+
+        public MSALMemoryTokenCacheOptions()
+        {
+            this.SlidingExpiration = TimeSpan.FromHours(12);
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALPerUserMemoryTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/InMemory/MSALPerUserMemoryTokenCacheProvider.cs
@@ -1,0 +1,140 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Identity.Client;
+using System.Security.Claims;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// An implementation of token cache for both Confidential and Public clients backed by MemoryCache.
+    /// MemoryCache is useful in Api scenarios where there is no HttpContext.Session to cache data.
+    /// </summary>
+    /// <seealso cref="https://aka.ms/msal-net-token-cache-serialization"/>
+    public class MSALPerUserMemoryTokenCacheProvider : IMSALUserTokenCacheProvider
+    {
+        /// <summary>
+        /// The backing MemoryCache instance
+        /// </summary>
+        internal IMemoryCache memoryCache;
+
+        private readonly MSALMemoryTokenCacheOptions CacheOptions;
+
+        /// <summary>
+        /// Enables the singleton object to access the right HttpContext
+        /// </summary>
+        private IHttpContextAccessor httpContextAccessor;
+
+        /// <summary>Initializes a new instance of the <see cref="MSALPerUserMemoryTokenCache"/> class.</summary>
+        /// <param name="cache">The memory cache instance</param>
+        public MSALPerUserMemoryTokenCacheProvider(IMemoryCache cache, MSALMemoryTokenCacheOptions option, IHttpContextAccessor httpContextAccessor)
+        {
+            this.memoryCache = cache;
+            this.httpContextAccessor = httpContextAccessor;
+
+            if (option != null)
+            {
+                this.CacheOptions = new MSALMemoryTokenCacheOptions();
+            }
+            else
+            {
+                this.CacheOptions = option;
+            }
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            tokenCache.SetBeforeAccess(this.UserTokenCacheBeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.UserTokenCacheAfterAccessNotification);
+            tokenCache.SetBeforeWrite(this.UserTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear(string accountId)
+        {
+            this.memoryCache.Remove(accountId);
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                string cacheKey = args.Account?.HomeAccountId?.Identifier;
+                if (string.IsNullOrEmpty(cacheKey))
+                {
+                    cacheKey = httpContextAccessor.HttpContext.User.GetMsalAccountId();
+                }
+
+                if (string.IsNullOrWhiteSpace(cacheKey))
+                    return;
+
+                // Ideally, methods that load and persist should be thread safe.MemoryCache.Get() is thread safe.
+                this.memoryCache.Set(cacheKey, args.TokenCache.SerializeMsalV3(), this.CacheOptions.SlidingExpiration);
+
+            }
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it
+        /// changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            string cacheKey = args.Account?.HomeAccountId?.Identifier;
+            if (string.IsNullOrEmpty(cacheKey))
+            {
+                cacheKey = httpContextAccessor.HttpContext.User.GetMsalAccountId();
+            }
+
+            if (string.IsNullOrWhiteSpace(cacheKey))
+                return;
+
+            byte[] tokenCacheBytes = (byte[])this.memoryCache.Get(cacheKey);
+            args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache:true);
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALAppSessionTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALAppSessionTokenCacheProvider.cs
@@ -1,0 +1,178 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by Http session.
+    /// </summary>
+    /// <seealso cref="https://aka.ms/msal-net-token-cache-serialization"/>
+    public class MSALAppSessionTokenCacheProvider : IMSALAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The application cache key
+        /// </summary>
+        internal string AppCacheId;
+
+        /// <summary>
+        /// The HTTP context being used by this app
+        /// </summary>
+        internal HttpContext HttpContext { get { return httpContextAccessor.HttpContext; } }
+
+        /// <summary>
+        /// HTTP context accessor
+        /// </summary>
+        internal IHttpContextAccessor httpContextAccessor;
+
+        /// <summary>
+        /// The duration till the tokens are kept in memory cache. In production, a higher value , upto 90 days is recommended.
+        /// </summary>
+        private readonly DateTimeOffset cacheDuration = DateTimeOffset.Now.AddHours(12);
+
+        private static ReaderWriterLockSlim SessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        /// <summary>
+        /// The App's whose cache we are maintaining.
+        /// </summary>
+        private string AppId;
+
+        /// <summary>Initializes a new instance of the <see cref="MSALAppSessionTokenCacheProvider"/> class.</summary>
+        /// <param name="azureAdOptionsAccessor">The azure ad options accessor.</param>
+        /// <exception cref="ArgumentNullException">AzureADOptions - The app token cache needs {nameof(AzureADOptions)}</exception>
+        public MSALAppSessionTokenCacheProvider(IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor, IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(AzureADOptions), $"The app token cache needs {nameof(AzureADOptions)}, populated with clientId to initialize.");
+            }
+
+            AppId = azureAdOptionsAccessor.CurrentValue.ClientId;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            AppCacheId = this.AppId + "_AppTokenCache";
+
+            tokenCache.SetBeforeAccessAsync(this.AppTokenCacheBeforeAccessNotificationAsync);
+            tokenCache.SetAfterAccessAsync(this.AppTokenCacheAfterAccessNotificationAsync);
+            tokenCache.SetBeforeWrite(this.AppTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a SessionCache ,whose methods are threads safe, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear()
+        {
+            SessionLock.EnterWriteLock();
+            try
+            {
+                Debug.WriteLine($"INFO: Clearing session {this.HttpContext.Session.Id}, cacheId {this.AppCacheId}");
+
+                // Reflect changes in the persistent store
+                this.HttpContext.Session.Remove(this.AppCacheId);
+                this.HttpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                SessionLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private async Task AppTokenCacheBeforeAccessNotificationAsync(TokenCacheNotificationArgs args)
+        {
+            await this.HttpContext.Session.LoadAsync();
+
+            SessionLock.EnterReadLock();
+            try
+            {
+                byte[] blob;
+                if (this.HttpContext.Session.TryGetValue(this.AppCacheId, out blob))
+                {
+                    Debug.WriteLine($"INFO: Deserializing session {this.HttpContext.Session.Id}, cacheId {this.AppCacheId}");
+                    args.TokenCache.DeserializeMsalV3(blob, shouldClearExistingCache: true);
+                }
+                else
+                {
+                    Debug.WriteLine($"INFO: cacheId {this.AppCacheId} not found in session {this.HttpContext.Session.Id}");
+                }
+            }
+            finally
+            {
+                SessionLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private async Task AppTokenCacheAfterAccessNotificationAsync(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                SessionLock.EnterWriteLock();
+                try
+                {
+                    Debug.WriteLine($"INFO: Serializing session {this.HttpContext.Session.Id}, cacheId {this.AppCacheId}");
+
+                    // Reflect changes in the persistent store
+                    byte[] blob = args.TokenCache.SerializeMsalV3();
+                    HttpContext.Session.Set(this.AppCacheId, blob);
+                    await HttpContext.Session.CommitAsync();
+                }
+                finally
+                {
+                    SessionLock.ExitWriteLock();
+                }
+            }
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALAppSessionTokenCacheProviderExtension.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALAppSessionTokenCacheProviderExtension.cs
@@ -1,0 +1,70 @@
+﻿/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    public static class MSALAppSessionTokenCacheProviderExtension
+    {
+        /// <summary>Adds both App and per-user session token caches.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionTokenCaches(this IServiceCollection services)
+        {
+            AddSessionAppTokenCache(services);
+            AddSessionPerUserTokenCache(services);
+
+            return services;
+        }
+
+        /// <summary>Adds the Http session based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionAppTokenCache(this IServiceCollection services)
+        {
+            services.AddHttpContextAccessor();
+            services.AddScoped<IMSALAppTokenCacheProvider>(factory =>
+            {
+                return new MSALAppSessionTokenCacheProvider(factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>(),
+                                                            factory.GetRequiredService<IHttpContextAccessor>());
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the http session based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionPerUserTokenCache(this IServiceCollection services)
+        {
+            services.AddHttpContextAccessor();
+            services.AddScoped<IMSALUserTokenCacheProvider, MSALPerUserSessionTokenCacheProvider>();
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALPerUserSessionTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Session/MSALPerUserSessionTokenCacheProvider.cs
@@ -1,0 +1,170 @@
+﻿/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Identity.Client;
+using System;
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Threading;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// This is a MSAL's TokenCache implementation for one user. It uses Http session as a back end store
+    /// </summary>
+    public class MSALPerUserSessionTokenCacheProvider : IMSALUserTokenCacheProvider
+    {
+        private static ReaderWriterLockSlim SessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        /// <summary>
+        /// The HTTP context being used by this app
+        /// </summary>
+        internal HttpContext HttpContext { get { return httpContextAccessor.HttpContext; } }
+
+        IHttpContextAccessor httpContextAccessor;
+
+        /// <summary>Initializes a new instance of the <see cref="MSALPerUserSessionTokenCache"/> class.</summary>
+        public MSALPerUserSessionTokenCacheProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <summary>Initializes the cache instance</summary>
+        /// <param name="tokenCache">The <see cref="ITokenCache"/> passed through the constructor</param>
+        /// <param name="httpcontext">The current <see cref="HttpContext" /></param>
+        /// <param name="user">The signed in user's ClaimPrincipal, could be null.
+        /// If the calling app has it available, then it should pass it themselves.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            if (tokenCache == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCache));
+            }
+            tokenCache.SetBeforeAccess(this.UserTokenCacheBeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.UserTokenCacheAfterAccessNotification);
+            tokenCache.SetBeforeWrite(this.UserTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear(string accountId)
+        {
+            string cacheKey = accountId;
+
+            SessionLock.EnterWriteLock();
+            try
+            {
+                Debug.WriteLine($"INFO: Clearing session {this.HttpContext.Session.Id}, cacheId {cacheKey}");
+
+                // Reflect changes in the persistent store
+                this.HttpContext.Session.Remove(cacheKey);
+                this.HttpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                SessionLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we obtain and release lock right before and after we read the Http session, we need not do anything here.
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                string cacheKey = args.Account?.HomeAccountId?.Identifier;
+                if (string.IsNullOrEmpty(cacheKey))
+                {
+                    cacheKey = httpContextAccessor.HttpContext.User.GetMsalAccountId();
+                }
+
+                if (string.IsNullOrWhiteSpace(cacheKey))
+                    return;
+
+                SessionLock.EnterWriteLock();
+                try
+                {
+                    Debug.WriteLine($"INFO: Serializing session {this.HttpContext.Session.Id}, cacheId {cacheKey}");
+
+                    // Reflect changes in the persistent store
+                    byte[] blob = args.TokenCache.SerializeMsalV3();
+                    this.HttpContext.Session.Set(cacheKey, blob);
+                    this.HttpContext.Session.CommitAsync().Wait();
+                }
+                finally
+                {
+                    SessionLock.ExitWriteLock();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            this.HttpContext.Session.LoadAsync().Wait();
+            string cacheKey = args.Account?.HomeAccountId?.Identifier;
+            if (string.IsNullOrEmpty(cacheKey))
+            {
+                cacheKey = httpContextAccessor.HttpContext.User.GetMsalAccountId();
+            }
+            if (string.IsNullOrWhiteSpace(cacheKey))
+                return;
+
+            SessionLock.EnterReadLock();
+            try
+            {
+                if (this.HttpContext.Session.TryGetValue(cacheKey, out byte[] blob))
+                {
+                    Debug.WriteLine($"INFO: Deserializing session {this.HttpContext.Session.Id}, cacheId {cacheKey}");
+                    args.TokenCache.DeserializeMsalV3(blob, shouldClearExistingCache: true);
+                }
+                else
+                {
+                    Debug.WriteLine($"INFO: cacheId {cacheKey} not found in session {this.HttpContext.Session.Id}");
+                }
+            }
+            finally
+            {
+                SessionLock.ExitReadLock();
+            }
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProvider.cs
@@ -1,0 +1,215 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by Sql server and Entity Framework
+    /// </summary>
+    /// <seealso cref="https://aka.ms/msal-net-token-cache-serialization"/>
+    public class MSALAppSqlTokenCacheProvider : IMSALAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The EF's DBContext object to be used to read and write from the Sql server database.
+        /// </summary>
+        private TokenCacheDbContext TokenCacheDb;
+
+        /// <summary>
+        /// This keeps the latest copy of the token in memory to save calls to DB, if possible.
+        /// </summary>
+        private AppTokenCache InMemoryCache;
+
+        /// <summary>
+        /// The data protector
+        /// </summary>
+        private IDataProtector DataProtector;
+
+        /// <summary>
+        /// Once a app obtains a token, this is populated and used for caching queries et al. Contains the App's AppId/ClientID as obtained from the Azure AD portal
+        /// </summary>
+        internal string ActiveClientId;
+
+        /// <summary>Initializes a new instance of the <see cref="EFMSALAppTokenCache"/> class.</summary>
+        /// <param name="tokenCacheDbContext">The TokenCacheDbContext DbContext to read and write from Sql server.</param>
+        /// <param name="azureAdOptionsAccessor"></param>
+        /// <param name="protectionProvider">The data protection provider. Requires the caller to have used serviceCollection.AddDataProtection();</param>
+        public MSALAppSqlTokenCacheProvider(TokenCacheDbContext tokenCacheDbContext, IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor, IDataProtectionProvider protectionProvider)
+        {
+            if (protectionProvider == null)
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs an {nameof(IDataProtectionProvider)} to operate. Please use 'serviceCollection.AddDataProtection();' to add the data protection provider to the service collection");
+            }
+
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs {nameof(AzureADOptions)}, populated with both Sql connection string and clientId to initialize.");
+            }
+
+            this.DataProtector = protectionProvider.CreateProtector("MSAL");
+            this.TokenCacheDb = tokenCacheDbContext;
+            this.ActiveClientId = azureAdOptionsAccessor.CurrentValue.ClientId;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            tokenCache.SetBeforeAccess(this.AppTokenCacheBeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.AppTokenCacheAfterAccessNotification);
+            tokenCache.SetBeforeWrite(this.AppTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a Rowversion for concurrency, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Raised AFTER MSAL added the new token in its in-memory copy of the cache.
+        /// This notification is called every time MSAL accessed the cache, not just when a write took place:
+        /// If MSAL's current operation resulted in a cache change, the property TokenCacheNotificationArgs.HasStateChanged will be set to true.
+        /// If that is the case, we call the TokenCache.Serialize() to get a binary blob representing the latest cache content – and persist it.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if state changed, i.e. new token obtained
+            if (args.HasStateChanged && !string.IsNullOrWhiteSpace(this.ActiveClientId))
+            {
+                if (this.InMemoryCache == null)
+                {
+                    this.InMemoryCache = new AppTokenCache
+                    {
+                        ClientID = this.ActiveClientId
+                    };
+                }
+
+                this.InMemoryCache.CacheBits = this.DataProtector.Protect(args.TokenCache.SerializeMsalV3());
+                this.InMemoryCache.LastWrite = DateTime.Now;
+
+                try
+                {
+                    // Update the DB and the lastwrite
+                    this.TokenCacheDb.Entry(InMemoryCache).State = InMemoryCache.AppTokenCacheId == 0 ? EntityState.Added : EntityState.Modified;
+                    this.TokenCacheDb.SaveChanges();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    // Record already updated on a different thread, so just read the updated record
+                    this.ReadCacheForSignedInApp(args);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all tokens belonging to the currently signed-in client Id from database
+        /// </summary>
+        public void Clear()
+        {
+            var cacheEntries = this.TokenCacheDb.AppTokenCache.Where(c => c.ClientID == this.ActiveClientId);
+            this.TokenCacheDb.AppTokenCache.RemoveRange(cacheEntries);
+            this.TokenCacheDb.SaveChanges();
+        }
+
+        /// <summary>
+        /// Right before it reads the cache, a call is made to BeforeAccess notification. Here, you have the opportunity of retrieving your persisted cache blob
+        /// from the Sql database. We pick it from the database, save it in the in-memory copy, and pass it to the base class by calling the Deserialize().
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            this.ReadCacheForSignedInApp(args);
+        }
+
+        /// <summary>
+        /// Reads the cache data from the backend database.
+        /// </summary>
+        private void ReadCacheForSignedInApp(TokenCacheNotificationArgs args)
+        {
+            if (this.InMemoryCache == null) // first time access
+            {
+                this.InMemoryCache = GetLatestAppRecordQuery().FirstOrDefault();
+            }
+            else
+            {
+                // retrieve last written record from the DB
+                var lastwriteInDb = GetLatestAppRecordQuery().Select(n => n.LastWrite).FirstOrDefault();
+
+                // if the persisted copy is newer than the in-memory copy
+                if (lastwriteInDb > this.InMemoryCache.LastWrite)
+                {
+                    // read from from storage, update in-memory copy
+                    this.InMemoryCache = GetLatestAppRecordQuery().FirstOrDefault();
+                }
+            }
+
+            // Send data to the TokenCache instance
+            args.TokenCache.DeserializeMsalV3((this.InMemoryCache == null) ? null : this.DataProtector.Unprotect(this.InMemoryCache.CacheBits), shouldClearExistingCache: true);
+        }
+
+        private IOrderedQueryable<AppTokenCache> GetLatestAppRecordQuery()
+        {
+            return this.TokenCacheDb.AppTokenCache.Where(c => c.ClientID == this.ActiveClientId).OrderByDescending(d => d.LastWrite);
+        }
+    }
+
+    /// <summary>
+    /// Represents an app's token cache entry in database
+    /// </summary>
+    public class AppTokenCache
+    {
+        [Key]
+        public int AppTokenCacheId { get; set; }
+
+        /// <summary>
+        /// The Appid or ClientId of the app
+        /// </summary>
+        public string ClientID { get; set; }
+
+        public byte[] CacheBits { get; set; }
+
+        public DateTime LastWrite { get; set; }
+
+        /// <summary>
+        /// Provided here as a precaution against concurrent updates by multiple threads.
+        /// </summary>
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALAppSqlTokenCacheProviderExtension.cs
@@ -1,0 +1,112 @@
+﻿/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    public static class MSALAppSqlTokenCacheProviderExtension
+    {
+        /// <summary>Adds the app and per user SQL token caches.</summary>
+        /// <param name="configuration">The configuration instance from where this method pulls the connection string to the Sql database.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlTokenCaches(this IServiceCollection services, MSALSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            AddSqlAppTokenCache(services, sqlTokenCacheOptions);
+            AddSqlPerUserTokenCache(services, sqlTokenCacheOptions);
+            return services;
+        }
+
+        /// <summary>Adds the Sql Server based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlAppTokenCache(this IServiceCollection services, MSALSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            // Uncomment the following lines to create the database. In production scenarios, the database
+            // will most probably be already present.
+/*
+            var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
+            tokenCacheDbContextBuilder.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString);
+
+            var tokenCacheDbContextForCreation = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
+            tokenCacheDbContextForCreation.Database.EnsureCreated();
+*/
+            services.AddDataProtection();
+
+            services.AddDbContext<TokenCacheDbContext>(options =>
+                options.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString));
+
+            services.AddScoped<IMSALAppTokenCacheProvider>(factory =>
+            {
+                var dpprovider = factory.GetRequiredService<IDataProtectionProvider>();
+                var tokenCacheDbContext = factory.GetRequiredService<TokenCacheDbContext>();
+                var optionsMonitor = factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>();
+
+                return new MSALAppSqlTokenCacheProvider(tokenCacheDbContext, optionsMonitor, dpprovider);
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the Sql Server based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlPerUserTokenCache(this IServiceCollection services, MSALSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            // Uncomment the following lines to create the database. In production scenarios, the database
+            // will most probably be already present.
+            //var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
+            //tokenCacheDbContextBuilder.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString);
+
+            //var tokenCacheDbContext = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
+            //tokenCacheDbContext.Database.EnsureCreated();
+
+            services.AddDataProtection();
+
+            services.AddDbContext<TokenCacheDbContext>(options =>
+                options.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString));
+
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            services.AddScoped<IMSALUserTokenCacheProvider>(factory =>
+            {
+                var dpprovider = factory.GetRequiredService<IDataProtectionProvider>();
+                var tokenCacheDbContext = factory.GetRequiredService<TokenCacheDbContext>();
+                var httpcontext = factory.GetRequiredService<IHttpContextAccessor>();
+
+                return new MSALPerUserSqlTokenCacheProvider(tokenCacheDbContext, dpprovider, httpcontext);
+            });
+
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALPerUserSqlTokenCacheProvider.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALPerUserSqlTokenCacheProvider.cs
@@ -1,0 +1,231 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Identity.Client;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// This is a MSAL's TokenCache implementation for one user. It uses Sql server as a backend store and uses the Entity Framework to read and write to that database.
+    /// </summary>
+    /// <seealso cref="https://aka.ms/msal-net-token-cache-serialization"/>
+    public class MSALPerUserSqlTokenCacheProvider : IMSALUserTokenCacheProvider
+    {
+        /// <summary>
+        /// The EF's DBContext object to be used to read and write from the Sql server database.
+        /// </summary>
+        private TokenCacheDbContext TokenCacheDb;
+
+        /// <summary>
+        /// This keeps the latest copy of the token in memory to save calls to DB, if possible.
+        /// </summary>
+        private UserTokenCache InMemoryCache;
+
+        /// <summary>
+        /// The data protector
+        /// </summary>
+        private IDataProtector DataProtector;
+
+        private IHttpContextAccessor httpContextAccesssor;
+
+        /// <summary>Initializes a new instance of the <see cref="EFMSALPerUserTokenCache"/> class.</summary>
+        /// <param name="protectionProvider">The data protection provider. Requires the caller to have used serviceCollection.AddDataProtection();</param>
+        /// <param name="tokenCacheDbContext">The DbContext to the database where tokens will be cached.</param>
+        /// <param name="httpContext">The current HttpContext that has a user signed-in</param>
+        public MSALPerUserSqlTokenCacheProvider(TokenCacheDbContext tokenCacheDbContext, IDataProtectionProvider protectionProvider, IHttpContextAccessor httpContext)
+            : this(tokenCacheDbContext, protectionProvider, httpContext?.HttpContext?.User)
+        {
+            this.httpContextAccesssor = httpContext;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MSALPerUserSqlTokenCacheProvider"/> class.</summary>
+        /// <param name="tokenCacheDbContext">The token cache database context.</param>
+        /// <param name="protectionProvider">The protection provider.</param>
+        /// <param name="user">The current user .</param>
+        /// <exception cref="ArgumentNullException">protectionProvider - The app token cache needs an {nameof(IDataProtectionProvider)}</exception>
+        public MSALPerUserSqlTokenCacheProvider(TokenCacheDbContext tokenCacheDbContext, IDataProtectionProvider protectionProvider, ClaimsPrincipal user)
+        {
+            if (protectionProvider == null)
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs an {nameof(IDataProtectionProvider)} to operate. Please use 'serviceCollection.AddDataProtection();' to add the data protection provider to the service collection");
+            }
+
+            this.DataProtector = protectionProvider.CreateProtector("MSAL");
+            this.TokenCacheDb = tokenCacheDbContext;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            tokenCache.SetBeforeAccess(this.UserTokenCacheBeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.UserTokenCacheAfterAccessNotification);
+            tokenCache.SetBeforeWrite(this.UserTokenCacheBeforeWriteNotification);
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a Rowversion for concurrency, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Right before it reads the cache, a call is made to BeforeAccess notification. Here, you have the opportunity of retrieving your persisted cache blob
+        /// from the Sql database. We pick it from the database, save it in the in-memory copy, and pass it to the base class by calling the Deserialize().
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            this.ReadCacheForSignedInUser(args);
+        }
+
+        /// <summary>
+        /// Raised AFTER MSAL added the new token in its in-memory copy of the cache.
+        /// This notification is called every time MSAL accessed the cache, not just when a write took place:
+        /// If MSAL's current operation resulted in a cache change, the property TokenCacheNotificationArgs.HasStateChanged will be set to true.
+        /// If that is the case, we call the TokenCache.Serialize() to get a binary blob representing the latest cache content – and persist it.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            string accountId = args.Account?.HomeAccountId?.Identifier;
+            if (string.IsNullOrEmpty(accountId))
+            {
+                accountId = httpContextAccesssor.HttpContext.User.GetMsalAccountId();
+            }
+
+            // if state changed, i.e. new token obtained
+            if (args.HasStateChanged && !string.IsNullOrWhiteSpace(accountId))
+            {
+                if (this.InMemoryCache == null)
+                {
+                    this.InMemoryCache = new UserTokenCache
+                    {
+                        WebUserUniqueId = accountId
+                    };
+                }
+
+                this.InMemoryCache.CacheBits = this.DataProtector.Protect(args.TokenCache.SerializeMsalV3());
+                this.InMemoryCache.LastWrite = DateTime.Now;
+
+                try
+                {
+                    // Update the DB and the lastwrite
+                    this.TokenCacheDb.Entry(InMemoryCache).State = InMemoryCache.UserTokenCacheId == 0 ? EntityState.Added : EntityState.Modified;
+                    this.TokenCacheDb.SaveChanges();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    // Record already updated on a different thread, so just read the updated record
+                    this.ReadCacheForSignedInUser(args);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads the cache data from the backend database.
+        /// </summary>
+        private void ReadCacheForSignedInUser(TokenCacheNotificationArgs args)
+        {
+            string accountId = args.Account?.HomeAccountId?.Identifier;
+            if (string.IsNullOrEmpty(accountId))
+            {
+                accountId = httpContextAccesssor.HttpContext.User.GetMsalAccountId();
+            }
+            if (this.InMemoryCache == null) // first time access
+            {
+                this.InMemoryCache = GetLatestUserRecordQuery(accountId).FirstOrDefault();
+            }
+            else
+            {
+                // retrieve last written record from the DB
+                var lastwriteInDb = GetLatestUserRecordQuery(accountId).Select(n => n.LastWrite).FirstOrDefault();
+
+                // if the persisted copy is newer than the in-memory copy
+                if (lastwriteInDb > InMemoryCache.LastWrite)
+                {
+                    // read from from storage, update in-memory copy
+                    this.InMemoryCache = GetLatestUserRecordQuery(accountId).FirstOrDefault();
+                }
+            }
+
+            // Send data to the TokenCache instance
+            args.TokenCache.DeserializeMsalV3((InMemoryCache == null) ? null : this.DataProtector.Unprotect(InMemoryCache.CacheBits), shouldClearExistingCache: true);
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy and the database copy of this user's cache.
+        /// </summary>
+        public void Clear(string accountId)
+        {
+            // Delete from DB
+            var cacheEntries = this.TokenCacheDb.UserTokenCache.Where(c => c.WebUserUniqueId == accountId);
+            this.TokenCacheDb.UserTokenCache.RemoveRange(cacheEntries);
+            this.TokenCacheDb.SaveChanges();
+        }
+
+        private IOrderedQueryable<UserTokenCache> GetLatestUserRecordQuery(string accountId)
+        {
+            return this.TokenCacheDb.UserTokenCache
+                                    .Where(c => c.WebUserUniqueId == accountId)
+                                    .OrderByDescending(d => d.LastWrite);
+        }
+    }
+
+    /// <summary>
+    /// Represents a user's token cache entry in database
+    /// </summary>
+    public class UserTokenCache
+    {
+        [Key]
+        public int UserTokenCacheId { get; set; }
+
+        /// <summary>
+        /// The objectId of the signed-in user's object in Azure AD
+        /// </summary>
+        public string WebUserUniqueId { get; set; }
+
+        public byte[] CacheBits { get; set; }
+
+        public DateTime LastWrite { get; set; }
+
+        /// <summary>
+        /// Provided here as a precaution against concurrent updates by multiple threads.
+        /// </summary>
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALSqlTokenCacheOptions.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/MSALSqlTokenCacheOptions.cs
@@ -1,0 +1,65 @@
+﻿/*
+ The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL's Sql token cache options
+    /// </summary>
+    public class MSALSqlTokenCacheOptions
+    {
+        /// <summary>
+        /// Gets or sets the SQL connection string to the token cache database.
+        /// </summary>
+        public string SqlConnectionString
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets or sets the clientId of the application for whom this token cache instance is being created. (Optional)
+        /// </summary>
+        public string ClientId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MSALSqlTokenCacheOptions"/> class.</summary>
+        /// <param name="sqlConnectionString">the SQL connection string to the token cache database.</param>
+        public MSALSqlTokenCacheOptions(string sqlConnectionString) :
+            this(sqlConnectionString, string.Empty)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MSALSqlTokenCacheOptions"/> class.</summary>
+        /// <param name="sqlConnectionString">The SQL connection string.</param>
+        /// <param name="clientId">The the clientId of the application for whom this token cache instance is being created. (Optional for User cache).</param>
+        public MSALSqlTokenCacheOptions(string sqlConnectionString, string clientId)
+        {
+            this.SqlConnectionString = sqlConnectionString;
+            this.ClientId = clientId;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/TokenCacheDbContext.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Client/TokenCacheProviders/Sql/TokenCacheDbContext.cs
@@ -1,0 +1,48 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.Identity.Web.Client.TokenCacheProviders
+{
+    /// <summary>
+    /// The DBContext that is used by the TokenCache providers to read and write to a Sql database.
+    /// </summary>
+    public class TokenCacheDbContext : DbContext
+    {
+        public TokenCacheDbContext(DbContextOptions<TokenCacheDbContext> options)
+        : base(options)
+        { }
+
+        /// <summary>
+        /// The app token cache table
+        /// </summary>
+        public DbSet<AppTokenCache> AppTokenCache { get; set; }
+
+        /// <summary>
+        /// The user token cache table
+        /// </summary>
+        public DbSet<UserTokenCache> UserTokenCache { get; set; }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Diagrams.cd
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Diagrams.cd
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
+  <Class Name="Microsoft.Identity.Web.Resource.AadIssuerValidator">
+    <Position X="0.5" Y="6.25" Width="7.5" />
+    <Members>
+      <Method Name="AadIssuerValidator" Hidden="true" />
+      <Field Name="IssuerAliases" Hidden="true" />
+      <Field Name="issuerValidators" Hidden="true" />
+      <Method Name="TenantedIssuer" Hidden="true" />
+    </Members>
+    <TypeIdentifier>
+      <HashCode>BAAAAEAAAAAAAAAAAAAAAAAAAAAQAAAAAgAAAEAAAAI=</HashCode>
+      <FileName>Resource\AadIssuerValidator.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.Resource.IssuerConfigurationRetriever" BaseTypeListCollapsed="true">
+    <Position X="12.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Resource\AadIssuerValidator.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" Collapsed="true" />
+  </Class>
+  <Class Name="Microsoft.Identity.Web.Resource.IssuerMetadata" Collapsed="true">
+    <Position X="10.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEEAA=</HashCode>
+      <FileName>Resource\AadIssuerValidator.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.Resource.Metadata">
+    <Position X="12.25" Y="1.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAEAAAAAABAAAAAAAACAAAAAAAA=</HashCode>
+      <FileName>Resource\AadIssuerValidator.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.Resource.OpenIdConnectMiddlewareDiagnostics">
+    <Position X="0.5" Y="0.5" Width="5.5" />
+    <Members>
+      <Field Name="onAuthenticationFailed" Hidden="true" />
+      <Field Name="onAuthorizationCodeReceived" Hidden="true" />
+      <Field Name="onMessageReceived" Hidden="true" />
+      <Field Name="onRedirectToIdentityProvider" Hidden="true" />
+      <Field Name="onRedirectToIdentityProviderForSignOut" Hidden="true" />
+      <Field Name="onRemoteSignOut" Hidden="true" />
+      <Field Name="onSignedOutCallbackRedirect" Hidden="true" />
+      <Field Name="onTokenResponseReceived" Hidden="true" />
+      <Field Name="onTokenValidated" Hidden="true" />
+      <Field Name="onUserInformationReceived" Hidden="true" />
+    </Members>
+    <TypeIdentifier>
+      <HashCode>AABAAABAAIIAAAQCAIAEAIBEAICCAAAAwgBAAEAAAgA=</HashCode>
+      <FileName>Resource\OpenIdConnectMiddlewareDiagnostics.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.ClaimsPrincipalExtension">
+    <Position X="10" Y="3.75" Width="7.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAkAAAAAAAAABAAAAAAAAAAAAAAAAAAIAAEAGAAA=</HashCode>
+      <FileName>ClaimPrincipalExtension.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Microsoft.Identity.Web.StartupHelpers">
+    <Position X="0.5" Y="4.5" Width="7" />
+    <Members>
+      <Field Name="emptyScopes" Hidden="true" />
+    </Members>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAgAAAAAAAAAgAAAAAACAAAAAAAAAAAA=</HashCode>
+      <FileName>StartupHelpers.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
+  </ItemGroup>
+</Project>

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/NuGet.Config
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/README.md
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/README.md
@@ -1,0 +1,46 @@
+# Microsoft Identity Web
+
+This library contains a set of reusable classes useful in Web Applications and Web APIs (collectively referred to as Web resources) that sign-in users and call Web APIs
+
+The library contains helper classes to:
+
+- **Bootstrap the web resource from the Startup.cs file** in your web application by just calling a few methods
+  - `AddAzureAdV2Authentication` to add authentication with the Microsoft Identity platform (AAD v2.0), including managing the authority validation, and the sign-out.
+  
+    ```CSharp
+    services.AddAzureAdV2Authentication();
+    ```    
+    
+  - `AddMsal` to add support for token acquistion with MSAL.NET. This should be followed by one of the AddXXXTokenCache methods to express the token cache technology to use
+  
+      ```CSharp
+    services.AddAzureAdV2Authentication() 
+            .AddMsal()
+            .AddInMemoryTokenCache();
+    ```    
+  
+    ![image](https://user-images.githubusercontent.com/13203188/53899064-a100ab80-4039-11e9-8869-fa9cffcd345a.png)
+  
+- Protect Web resources (in the `Resources` folder)
+  - `AadIssuerValidator` is used to validate the issuer in multi-tenant applications, taking into account the aliases for authorities exising in Azure AD. This class works both for Azure AD v1.0 and Microsoft Identity platform v2.0 web resources. You should not need to use it directly, as it's used by `AddAzureAdV2Authentication`
+  - `OpenIdConnectMiddlewareDiagnostics` helps you understand what happens in the Open Id Connect Middleware. This is a diagnostics class that can help you troubleshooting your Web apps.
+  - `ClaimsPrincipalExtensions` provides a set of extension methods on `ClaimsPrincipal` helping getting information from the signed-in user. It's used in the other classes of the libraries.
+
+- **Acquire a token to call protected APIs** (in the `Client` folder)
+  -  `ITokenAcquisition` is an interface implemented by a wrapper to MSAL.NET in confidential client applications, enabling you to simply get a token from the controllers, after adding them to the cache from OpenIDConnect events (in Web Apps), or JwtBearerMiddleware events (in the case of Web APIs)
+  - Extensions methods allow you to choose the token cache implementation you want to have in your web resource (`AddSessionBasedTokenCache`, or `AddInMemoryTokenCache` for the moment)
+  - `MsalUiRequiredExceptionFilterAttribute` allows for incremental consent by declaratively adding the attribute with the required scopes, on a controller action.
+  
+## Learn more:
+You can learn more about the tokens by looking at the following articles in MSAL.NET's conceptual documentation:
+
+- The [Authorization code flow](https://aka.ms/msal-net-authorization-code), which is used, after the user signed-in with Open ID Connect, in order to get a token and cache it for a later use. See [TokenAcquisition L 107](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L107) for details of this code
+- [AcquireTokenSilent](https://aka.ms/msal-net-acquiretokensilent ), which is used by the controller to get an access token for the downstream API. See [TokenAcquisition L 168](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/f99e913cc032e16c59b748241111e97108e87918/Extensions/TokenAcquisition.cs#L168) for details of this code
+- [Token cache serialization](msal-net-token-cache-serialization)
+
+
+The token validation is performed by the classes of the [Identity Model Extensions for DotNet](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet) library. Learn about customizing
+token validation by reading:
+
+- [Validating Tokens](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/ValidatingTokens) in that library's conceptual documentation
+- [TokenValidationParameters](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters?view=azure-dotnet)'s reference documentation.

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
@@ -1,0 +1,237 @@
+﻿/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+
+namespace Microsoft.Identity.Web.Resource
+{
+    /// <summary>
+    /// Generic class that validates token issuer from the provided Azure AD authority
+    /// </summary>
+    public class AadIssuerValidator
+    {
+        /// <summary>
+        /// A list of all Issuers across the various Azure AD instances
+        /// </summary>
+        private readonly SortedSet<string> _issuerAliases;
+        private const string _fallBackAuthority = "https://login.microsoftonline.com/";
+        private static IDictionary<string, AadIssuerValidator> _issuerValidators = new ConcurrentDictionary<string, AadIssuerValidator>();
+        private static string _azureADIssuerMetadataUrl = "https://login.microsoftonline.com/common/discovery/instance?authorization_endpoint=https://login.microsoftonline.com/common/oauth2/v2.0/authorize&api-version=1.1";
+        private static ConfigurationManager<IssuerMetadata> _configManager = new ConfigurationManager<IssuerMetadata>(_azureADIssuerMetadataUrl, new IssuerConfigurationRetriever());
+
+        private AadIssuerValidator(IEnumerable<string> aliases)
+        {
+            _issuerAliases = new SortedSet<string>(aliases);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="AadIssuerValidator"/> for an authority.
+        /// </summary>
+        /// <param name="aadAuthority">the authority to create the validator for.</param>
+        /// <returns>a <see cref="AadIssuerValidator"/> for the aadAuthority.</returns>
+        /// <exception cref="ArgumentNullException">if <paramref name="aadAuthority"/> is null or empty.</exception>
+        public static AadIssuerValidator GetIssuerValidator(string aadAuthority)
+        {
+            if (string.IsNullOrEmpty(aadAuthority))
+                throw new ArgumentNullException(nameof(aadAuthority));
+
+            if (_issuerValidators.TryGetValue(aadAuthority, out AadIssuerValidator aadIssuerValidator))
+            {
+                return aadIssuerValidator;
+            }
+            else
+            {
+                // In the constructor, we hit the Azure AD issuer metadata endpoint and cache the aliases. The data is cached for 24 hrs.
+                var issuerMetadata = _configManager.GetConfigurationAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                string authorityHost;
+                try
+                {
+                     authorityHost = new Uri(aadAuthority).Authority;
+                }
+                catch
+                {
+                    authorityHost = null;
+                }
+
+                // Add issuer aliases of the chosen authority
+                string authority = authorityHost ?? _fallBackAuthority;
+                var aliases = issuerMetadata.Metadata.Where(m => m.Aliases.Any(a => a == authority)).SelectMany(m => m.Aliases).Distinct();
+                _issuerValidators[authority] = new AadIssuerValidator(aliases);
+                return _issuerValidators[authority];
+            }
+        }
+
+        /// <summary>
+        /// Validate the issuer for multi-tenant applications of various audience (Work and School account, or Work and School accounts +
+        /// Personal accounts)
+        /// </summary>
+        /// <param name="issuer">Issuer to validate (will be tenanted)</param>
+        /// <param name="securityToken">Received Security Token</param>
+        /// <param name="validationParameters">Token Validation parameters</param>
+        /// <remarks>The issuer is considered as valid if it has the same http scheme and authority as the
+        /// authority from the configuration file, has a tenant Id, and optionally v2.0 (this web api
+        /// accepts both V1 and V2 tokens).
+        /// Authority aliasing is also taken into account</remarks>
+        /// <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown</returns>
+        /// <exception cref="ArgumentNullException"> if <paramref name="securityToken"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"> if <paramref name="validationParameters"/> is null.</exception>
+        /// <exception cref="SecurityTokenInvalidIssuerException">if the issuer </exception>
+        public string ValidateAadIssuer(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            if (securityToken == null)
+                throw new ArgumentNullException(nameof(securityToken));
+
+            if (validationParameters == null)
+                throw new ArgumentNullException(nameof(validationParameters));
+
+
+            string tenantId = GetTenantIdFromToken(securityToken);
+            if (string.IsNullOrWhiteSpace(tenantId))
+                throw new SecurityTokenInvalidIssuerException("Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft Identity Platform.");
+
+            if (validationParameters.ValidIssuers != null)
+                foreach (var validIssuer in validationParameters.ValidIssuers)
+                    if (IsValidIssuer(validIssuer, tenantId))
+                        return issuer;
+
+            if (IsValidIssuer(validationParameters.ValidIssuer, tenantId))
+                return issuer;
+
+            // If a valid issuer is not found, throw
+            // brentsch - todo, create a list of all the possible valid issuers in TokenValidationParameters
+            throw new SecurityTokenInvalidIssuerException($"Issuer: '{issuer}', does not match any of the valid issuers provided for this application.");
+        }
+
+        private bool IsValidIssuer(string validIssuer, string tenantId)
+        {
+            if (string.IsNullOrEmpty(validIssuer))
+                return false;
+
+            try
+            {
+                var uri = new Uri(validIssuer.Replace("{tenantid}", tenantId));
+                if (_issuerAliases.Contains(uri.Authority))
+                {
+                    string trimmedLocalPath = uri.LocalPath.Trim('/');
+                    return (trimmedLocalPath == tenantId || trimmedLocalPath == $"{tenantId}/v2.0");
+                }
+            }
+            catch
+            {
+                // if something faults, ignore
+            }
+
+            return false;
+        }
+
+        /// <summary>Gets the tenant id from a token.</summary>
+        /// <param name="securityToken">A JWT token.</param>
+        /// <returns>A string containing tenantId, if found or <see cref="string.Empty"/>.</returns>
+        /// <remarks>Only <see cref="JwtSecurityToken"/> and <see cref="JsonWebToken"/> are acceptable types.</remarks>
+        private static string GetTenantIdFromToken(SecurityToken securityToken)
+        {
+            if (securityToken is JwtSecurityToken jwtSecurityToken)
+            {
+                if (jwtSecurityToken.Payload.TryGetValue(ClaimConstants.Tid, out object tenantId))
+                    return tenantId as string;
+            }
+
+            // brentsch - todo, TryGetPayloadValue is available in 5.5.0
+            if (securityToken is JsonWebToken  jsonWebToken)
+            {
+                var tid = jsonWebToken.GetPayloadValue<string>(ClaimConstants.Tid);
+                if (tid != null)
+                    return tid;
+            }
+
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />
+    /// </summary>
+    public class IssuerConfigurationRetriever : IConfigurationRetriever<IssuerMetadata>
+    {
+        /// <summary>Retrieves a populated configuration given an address and an <see cref="T:Microsoft.IdentityModel.Protocols.IDocumentRetriever"/>.</summary>
+        /// <param name="address">Address of the discovery document.</param>
+        /// <param name="retriever">The <see cref="T:Microsoft.IdentityModel.Protocols.IDocumentRetriever"/> to use to read the discovery document.</param>
+        /// <param name="cancel">A cancellation token that can be used by other objects or threads to receive notice of cancellation. <see cref="T:System.Threading.CancellationToken"/>.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">if <paramref name="address"/> is null or empty.
+        /// or
+        /// retriever - No metadata document retriever is provided</exception>
+        public async Task<IssuerMetadata> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
+        {
+            if (string.IsNullOrEmpty(address))
+                throw new ArgumentNullException(nameof(address), $"Azure AD Issuer metadata address url is required");
+
+            if (retriever == null)
+                throw new ArgumentNullException(nameof(retriever), $"No metadata document retriever is provided");
+
+            string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<IssuerMetadata>(doc);
+        }
+    }
+
+    /// <summary>
+    /// Model class to hold information parsed from the Azure AD issuer endpoint
+    /// </summary>
+    public class IssuerMetadata
+    {
+        [JsonProperty(PropertyName = "tenant_discovery_endpoint")]
+        public string TenantDiscoveryEndpoint { get; set; }
+
+        [JsonProperty(PropertyName = "api-version")]
+        public string ApiVersion { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public List<Metadata> Metadata { get; set; }
+    }
+
+    /// <summary>
+    /// Model child class to hold alias information parsed from the Azure AD issuer endpoint.
+    /// </summary>
+    public class Metadata
+    {
+        [JsonProperty(PropertyName = "preferred_network")]
+        public string PreferredNetwork { get; set; }
+
+        [JsonProperty(PropertyName = "preferred_cache")]
+        public string PreferredCache { get; set; }
+
+        [JsonProperty(PropertyName = "aliases")]
+        public List<string> Aliases { get; set; }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web.Resource
+{
+    /// <summary>
+    /// Diagnostics for the JwtBearer middleware (used in Web APIs)
+    /// </summary>
+    public class JwtBearerMiddlewareDiagnostics
+    {
+        /// <summary>
+        /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
+        /// </summary>
+        static Func<AuthenticationFailedContext, Task> onAuthenticationFailed;
+
+        /// <summary>
+        /// Invoked when a protocol message is first received.
+        /// </summary>
+        static Func<MessageReceivedContext, Task> onMessageReceived;
+
+        /// <summary>
+        /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
+        /// </summary>
+        static Func<TokenValidatedContext, Task> onTokenValidated;
+
+        /// <summary>
+        /// Invoked before a challenge is sent back to the caller.
+        /// </summary>
+        static Func<JwtBearerChallengeContext, Task> onChallenge;
+
+        /// <summary>
+        /// Subscribes to all the JwtBearer events, to help debugging, while
+        /// preserving the previous handlers (which are called)
+        /// </summary>
+        /// <param name="events">Events to subscribe to</param>
+        public static JwtBearerEvents Subscribe(JwtBearerEvents events)
+        {
+            if (events == null)
+            {
+                events = new JwtBearerEvents();
+            }
+
+            onAuthenticationFailed = events.OnAuthenticationFailed;
+            events.OnAuthenticationFailed = OnAuthenticationFailed;
+
+            onMessageReceived = events.OnMessageReceived;
+            events.OnMessageReceived = OnMessageReceived;
+
+            onTokenValidated = events.OnTokenValidated;
+            events.OnTokenValidated = OnTokenValidated;
+
+            onChallenge = events.OnChallenge;
+            events.OnChallenge = OnChallenge;
+
+            return events;
+        }
+
+        static async Task OnMessageReceived(MessageReceivedContext context)
+        {
+            Debug.WriteLine($"1. Begin {nameof(OnMessageReceived)}");
+            // Place a breakpoint here and examine the bearer token (context.Request.Headers.HeaderAuthorization / context.Request.Headers["Authorization"])
+            // Use https://jwt.ms to decode the token and observe claims
+            await onMessageReceived(context);
+            Debug.WriteLine($"1. End - {nameof(OnMessageReceived)}");
+        }
+
+        static async Task OnAuthenticationFailed(AuthenticationFailedContext context)
+        {
+            Debug.WriteLine($"99. Begin {nameof(OnAuthenticationFailed)}");
+            // Place a breakpoint here and examine context.Exception
+            await onAuthenticationFailed(context);
+            Debug.WriteLine($"99. End - {nameof(OnAuthenticationFailed)}");
+        }
+
+        static async Task OnTokenValidated(TokenValidatedContext context)
+        {
+            Debug.WriteLine($"2. Begin {nameof(OnTokenValidated)}");
+            await onTokenValidated(context);
+            Debug.WriteLine($"2. End - {nameof(OnTokenValidated)}");
+        }
+
+        static async Task OnChallenge(JwtBearerChallengeContext context)
+        {
+            Debug.WriteLine($"55. Begin {nameof(OnChallenge)}");
+            await onChallenge(context);
+            Debug.WriteLine($"55. End - {nameof(OnChallenge)}");
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.Identity.Web.Resource
+{
+    /// <summary>
+    /// Diagnostics used in the Open Id Connect middleware
+    /// (used in Web Apps)
+    /// </summary>
+    public class OpenIdConnectMiddlewareDiagnostics
+    {
+        //
+        // Summary:
+        //     Invoked before redirecting to the identity provider to authenticate. This can
+        //     be used to set ProtocolMessage.State that will be persisted through the authentication
+        //     process. The ProtocolMessage can also be used to add or customize parameters
+        //     sent to the identity provider.
+        static Func<RedirectContext, Task> onRedirectToIdentityProvider;
+        //
+        // Summary:
+        //     Invoked when a protocol message is first received.
+        static Func<MessageReceivedContext, Task> onMessageReceived;
+        //
+        // Summary:
+        //     Invoked after security token validation if an authorization code is present in
+        //     the protocol message.
+        static Func<AuthorizationCodeReceivedContext, Task> onAuthorizationCodeReceived;
+        //
+        // Summary:
+        //     Invoked after "authorization code" is redeemed for tokens at the token endpoint.
+        static Func<TokenResponseReceivedContext, Task> onTokenResponseReceived;
+        //
+        // Summary:
+        //     Invoked when an IdToken has been validated and produced an AuthenticationTicket.
+        static Func<TokenValidatedContext, Task> onTokenValidated;
+        //
+        // Summary:
+        //     Invoked when user information is retrieved from the UserInfoEndpoint.
+        static Func<UserInformationReceivedContext, Task> onUserInformationReceived;
+        //
+        // Summary:
+        //     Invoked if exceptions are thrown during request processing. The exceptions will
+        //     be re-thrown after this event unless suppressed.
+        static Func<AuthenticationFailedContext, Task> onAuthenticationFailed;
+        //
+        // Summary:
+        //     Invoked when a request is received on the RemoteSignOutPath.
+        static Func<RemoteSignOutContext, Task> onRemoteSignOut;
+        //
+        // Summary:
+        //     Invoked before redirecting to the identity provider to sign out.
+        static Func<RedirectContext, Task> onRedirectToIdentityProviderForSignOut;
+        //
+        // Summary:
+        //     Invoked before redirecting to the Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.SignedOutRedirectUri
+        //     at the end of a remote sign-out flow.
+        static Func<RemoteSignOutContext, Task> onSignedOutCallbackRedirect;
+ 
+
+        /// <summary>
+        /// Subscribes to all the OpenIdConnect events, to help debugging, while
+        /// preserving the previous handlers (which are called)
+        /// </summary>
+        /// <param name="events">Events to subscribe to</param>
+        public static void Subscribe(OpenIdConnectEvents events)
+        {
+            onRedirectToIdentityProvider = events.OnRedirectToIdentityProvider;
+            events.OnRedirectToIdentityProvider = OnRedirectToIdentityProvider;
+
+            onMessageReceived = events.OnMessageReceived;
+            events.OnMessageReceived = OnMessageReceived;
+
+            onAuthorizationCodeReceived = events.OnAuthorizationCodeReceived;
+            events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+
+            onTokenResponseReceived = events.OnTokenResponseReceived;
+            events.OnTokenResponseReceived = OnTokenResponseReceived;
+
+            onTokenValidated = events.OnTokenValidated;
+            events.OnTokenValidated = OnTokenValidated;
+
+            onUserInformationReceived = events.OnUserInformationReceived;
+            events.OnUserInformationReceived = OnUserInformationReceived;
+
+            onAuthenticationFailed = events.OnAuthenticationFailed;
+            events.OnAuthenticationFailed = OnAuthenticationFailed;
+
+            onRemoteSignOut = events.OnRemoteSignOut;
+            events.OnRemoteSignOut = OnRemoteSignOut;
+
+            onRedirectToIdentityProviderForSignOut = events.OnRedirectToIdentityProviderForSignOut;
+            events.OnRedirectToIdentityProviderForSignOut = OnRedirectToIdentityProviderForSignOut;
+
+            onSignedOutCallbackRedirect = events.OnSignedOutCallbackRedirect;
+            events.OnSignedOutCallbackRedirect = OnSignedOutCallbackRedirect;
+        }
+
+        static async Task OnRedirectToIdentityProvider(RedirectContext context)
+        {
+            Debug.WriteLine($"1. Begin {nameof(OnRedirectToIdentityProvider)}");
+
+            await onRedirectToIdentityProvider(context);
+
+            Debug.WriteLine("   Sending OpenIdConnect message:");
+            DisplayProtocolMessage(context.ProtocolMessage);
+            Debug.WriteLine($"1. End - {nameof(OnRedirectToIdentityProvider)}");
+        }
+
+        private static void DisplayProtocolMessage(OpenIdConnectMessage message)
+        {
+            foreach (var property in message.GetType().GetProperties())
+            {
+                object value = property.GetValue(message);
+                if (value != null)
+                {
+                    Debug.WriteLine($"   - {property.Name}={value}");
+                }
+            }
+        }
+
+        static async Task OnMessageReceived(MessageReceivedContext context)
+        {
+            Debug.WriteLine($"2. Begin {nameof(OnMessageReceived)}");
+            Debug.WriteLine("   Received from STS the OpenIdConnect message:");
+            DisplayProtocolMessage(context.ProtocolMessage);
+            await onMessageReceived(context);
+            Debug.WriteLine($"2. End - {nameof(OnMessageReceived)}");
+        }
+
+        static async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        {
+            Debug.WriteLine($"4. Begin {nameof(OnAuthorizationCodeReceived)}");
+            await onAuthorizationCodeReceived(context);
+            Debug.WriteLine($"4. End - {nameof(OnAuthorizationCodeReceived)}");
+        }
+
+        static async Task OnTokenResponseReceived(TokenResponseReceivedContext context)
+        {
+            Debug.WriteLine($"5. Begin {nameof(OnTokenResponseReceived)}");
+            await onTokenResponseReceived(context);
+            Debug.WriteLine($"5. End - {nameof(OnTokenResponseReceived)}");
+
+        }
+        static async Task OnTokenValidated(TokenValidatedContext context)
+        {
+            Debug.WriteLine($"3. Begin {nameof(OnTokenValidated)}");
+            await onTokenValidated(context);
+            Debug.WriteLine($"3. End - {nameof(OnTokenValidated)}");
+        }
+        static async Task OnUserInformationReceived(UserInformationReceivedContext context)
+        {
+            Debug.WriteLine($"6. Begin {nameof(OnUserInformationReceived)}");
+            await onUserInformationReceived(context);
+            Debug.WriteLine($"6. End - {nameof(OnUserInformationReceived)}");
+        }
+
+        static async Task OnAuthenticationFailed(AuthenticationFailedContext context)
+        {
+            Debug.WriteLine($"99. Begin {nameof(OnAuthenticationFailed)}");
+            await onAuthenticationFailed(context);
+            Debug.WriteLine($"99. End - {nameof(OnAuthenticationFailed)}");
+        }
+
+        static async Task OnRedirectToIdentityProviderForSignOut(RedirectContext context)
+        {
+            Debug.WriteLine($"10. Begin {nameof(OnRedirectToIdentityProviderForSignOut)}");
+            await onRedirectToIdentityProviderForSignOut(context);
+            Debug.WriteLine($"10. End - {nameof(OnRedirectToIdentityProviderForSignOut)}");
+        }
+        static async Task OnRemoteSignOut(RemoteSignOutContext context)
+        {
+            Debug.WriteLine($"11. Begin {nameof(OnRemoteSignOut)}");
+            await onRemoteSignOut(context);
+            Debug.WriteLine($"11. End - {nameof(OnRemoteSignOut)}");
+        }
+        static async Task OnSignedOutCallbackRedirect(RemoteSignOutContext context)
+        {
+            Debug.WriteLine($"12. Begin {nameof(OnSignedOutCallbackRedirect)}");
+            await onSignedOutCallbackRedirect(context);
+            Debug.WriteLine($"12. End {nameof(OnSignedOutCallbackRedirect)}");
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/StartupHelpers.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/StartupHelpers.cs
@@ -1,0 +1,174 @@
+/************************************************************************************************
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+***********************************************************************************************/
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web.Client;
+using Microsoft.Identity.Web.Resource;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web
+{
+    public static class StartupHelpers
+    {
+        /// <summary>
+        /// Add authentication with Microsoft identity platform v2.0 (AAD v2.0).
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddAzureAdV2Authentication(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
+                .AddAzureAD(options => configuration.Bind("AzureAd", options));
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                // Per the code below, this application signs in users in any Work and School
+                // accounts and any Microsoft Personal Accounts.
+                // If you want to direct Azure AD to restrict the users that can sign-in, change
+                // the tenant value of the appsettings.json file in the following way:
+                // - only Work and School accounts => 'organizations'
+                // - only Microsoft Personal accounts => 'consumers'
+                // - Work and School and Personal accounts => 'common'
+                // If you want to restrict the users that can sign-in to only one tenant
+                // set the tenant value in the appsettings.json file to the tenant ID
+                // or domain of this organization
+                options.Authority = options.Authority + "/v2.0/";
+
+                // If you want to restrict the users that can sign-in to several organizations
+                // Set the tenant value in the appsettings.json file to 'organizations', and add the
+                // issuers you want to accept to options.TokenValidationParameters.ValidIssuers collection
+                options.TokenValidationParameters.IssuerValidator = AadIssuerValidator.GetIssuerValidator(options.Authority).ValidateAadIssuer;
+
+                // Set the nameClaimType to be preferred_username.
+                // This change is needed because certain token claims from Azure AD V1 endpoint
+                // (on which the original .NET core template is based) are different than Azure AD V2 endpoint.
+                // For more details see [ID Tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens)
+                // and [Access Tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
+                options.TokenValidationParameters.NameClaimType = "preferred_username";
+
+                // Handling the sign-out
+                options.Events.OnRedirectToIdentityProviderForSignOut = async context =>
+                {
+                    var user = context.HttpContext.User;
+
+                    // Avoid displaying the select account dialog
+                    context.ProtocolMessage.LoginHint = user.GetLoginHint();
+                    context.ProtocolMessage.DomainHint = user.GetDomainHint();
+                    await Task.FromResult(0);
+                };
+
+                // Avoids having users being presented the select account dialog when they are already signed-in
+                // for instance when going through incremental consent
+                options.Events.OnRedirectToIdentityProvider = context =>
+                {
+                    var login = context.Properties.GetParameter<string>(OpenIdConnectParameterNames.LoginHint);
+                    if (!string.IsNullOrWhiteSpace(login))
+                    {
+                        context.ProtocolMessage.LoginHint = login;
+                        context.ProtocolMessage.DomainHint = context.Properties.GetParameter<string>(OpenIdConnectParameterNames.DomainHint);
+
+                        // delete the login_hint and domainHint from the Properties when we are done otherwise
+                        // it will take up extra space in the cookie.
+                        context.Properties.Parameters.Remove(OpenIdConnectParameterNames.LoginHint);
+                        context.Properties.Parameters.Remove(OpenIdConnectParameterNames.DomainHint);
+                    }
+
+                    // Additional claims
+                    if (context.Properties.Items.ContainsKey(OidcConstants.AdditionalClaims))
+                    {
+                        context.ProtocolMessage.SetParameter(
+                            OidcConstants.AdditionalClaims,
+                            context.Properties.Items[OidcConstants.AdditionalClaims]);
+                    }
+
+                    return Task.FromResult(0);
+                };
+
+                // If you want to debug, or just understand the OpenIdConnect events, just
+                // uncomment the following line of code
+                // OpenIdConnectMiddlewareDiagnostics.Subscribe(options.Events);
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Add MSAL support to the Web App or Web API
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="initialScopes">Initial scopes to request at sign-in</param>
+        /// <returns></returns>
+        public static IServiceCollection AddMsal(this IServiceCollection services, IEnumerable<string> initialScopes)
+        {
+            services.AddTokenAcquisition();
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                // Response type
+                options.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+
+                // This scope is needed to get a refresh token when users sign-in with their Microsoft personal accounts
+                // (it's required by MSAL.NET and automatically provided when users sign-in with work or school accounts)
+                options.Scope.Add(OidcConstants.ScopeOfflineAccess);
+                if (initialScopes != null)
+                {
+                    foreach (string scope in initialScopes)
+                    {
+                        if (!options.Scope.Contains(scope))
+                        {
+                            options.Scope.Add(scope);
+                        }
+                    }
+                }
+
+                // Handling the auth redemption by MSAL.NET so that a token is available in the token cache
+                // where it will be usable from Controllers later (through the TokenAcquisition service)
+                var handler = options.Events.OnAuthorizationCodeReceived;
+                options.Events.OnAuthorizationCodeReceived = async context =>
+                {
+                    var _tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, options.Scope);
+                    await handler(context);
+                };
+
+                // Handling the sign-out: removing the account from MSAL.NET cache
+                options.Events.OnRedirectToIdentityProviderForSignOut = async context =>
+                {
+                    // Remove the account from MSAL.NET token cache
+                    var _tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                    await _tokenAcquisition.RemoveAccount(context);
+                };
+            });
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/Microsoft.Identity.Web/WebApiStartupHelpers.cs
+++ b/solutions/linkedaccounts/Microsoft.Identity.Web/WebApiStartupHelpers.cs
@@ -1,0 +1,100 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web.Client;
+using Microsoft.Identity.Web.Resource;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Web
+{
+    public static class WebApiStartupHelpers
+    {
+        /// <summary>
+        /// Protects the Web API with Microsoft Identity Platform v2.0 (AAD v2.0)
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddProtectWebApiWithMicrosoftIdentityPlatformV2(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
+                    .AddAzureADBearer(options => configuration.Bind("AzureAd", options));
+
+            services.AddSession();
+
+            // Added
+            services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
+            {
+                // Reinitialize the options as this has changed to JwtBearerOptions to pick configuration values for attributes unique to JwtBearerOptions 
+                configuration.Bind("AzureAd", options);
+
+                // This is an Azure AD v2.0 Web API
+                options.Authority += "/v2.0";
+
+                // The valid audiences are both the Client ID (options.Audience) and api://{ClientID}
+                options.TokenValidationParameters.ValidAudiences = new string[] { options.Audience, $"api://{options.Audience}" };
+
+                // Instead of using the default validation (validating against a single tenant, as we do in line of business apps),
+                // we inject our own multitenant validation logic (which even accepts both V1 and V2 tokens)
+                options.TokenValidationParameters.IssuerValidator = AadIssuerValidator.GetIssuerValidator(options.Authority).ValidateAadIssuer;
+
+                // When an access token for our own Web API is validated, we add it to MSAL.NET's cache so that it can
+                // be used from the controllers.
+                options.Events = new JwtBearerEvents();
+
+                // If you want to debug, or just understand the JwtBearer events, uncomment the following line of code
+                // options.Events = JwtBearerMiddlewareDiagnostics.Subscribe(options.Events);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Protects the Web API with Microsoft Identity Platform v2.0 (AAD v2.0)
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="scopes">Optional parameters. If not specified, the token used to call the protected API
+        /// will be kept with the user's claims until the API calls a downstream API. Otherwise the account for the 
+        /// user is immediately added to the token cache</param>
+        /// <returns></returns>
+        public static IServiceCollection AddProtectedApiCallsWebApis(this IServiceCollection services, IConfiguration configuration, IEnumerable<string> scopes=null)
+        {
+            services.AddTokenAcquisition();
+            services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
+            {
+                // If you don't pre-provide scopes when adding calling AddProtectedApiCallsWebApis, the On behalf of
+                // flow will be delayed (lazy construction of MSAL's application
+
+                options.Events.OnTokenValidated = async context =>
+                {
+                    if (scopes != null && scopes.Any())
+                    {
+                        var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                        context.Success();
+                        tokenAcquisition.AddAccountToCacheFromJwt(context, scopes);
+                    }
+                    else
+                    {
+                        context.Success();
+
+                        // Todo : rather use options.SaveToken?
+                        (context.Principal.Identity as ClaimsIdentity).AddClaim(new Claim("jwt", (context.SecurityToken as JwtSecurityToken).RawData));
+                    }
+                    // Adds the token to the cache, and also handles the incremental consent and claim challenges
+                    await Task.FromResult(0);
+                };
+            });
+
+            return services;
+        }
+    }
+}

--- a/solutions/linkedaccounts/linkedaccounts.web/Controllers/AccountController.cs
+++ b/solutions/linkedaccounts/linkedaccounts.web/Controllers/AccountController.cs
@@ -13,7 +13,7 @@ namespace LinkedAccounts.Web.Controllers
     using Microsoft.AspNetCore.Mvc;
 
     /// <summary>
-    /// Controller for Account Linking
+    /// Controller used for account linked.
     /// </summary>
     [Route("[controller]/[action]")]
     public class AccountController : Controller

--- a/solutions/linkedaccounts/linkedaccounts.web/Controllers/HomeController.cs
+++ b/solutions/linkedaccounts/linkedaccounts.web/Controllers/HomeController.cs
@@ -33,9 +33,9 @@ namespace LinkedAccounts.Web.Controllers
         }
 
         /// <summary>
-        /// Initialisation work for the LinkedAccounts feature
+        /// Initialisation work for the LinkedAccounts feature.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>IActionResult.</returns>
         public async Task<IActionResult> LinkedAccounts()
         {
             this.ViewData["Message"] = "Your application description page.";
@@ -87,10 +87,10 @@ namespace LinkedAccounts.Web.Controllers
         }
 
         /// <summary>
-        /// Retrieve a URL for the user to link a given connection name to their Bot
+        /// Retrieve a URL for the user to link a given connection name to their Bot.
         /// </summary>
-        /// <param name="account"></param>
-        /// <returns></returns>
+        /// <param name="account">TokenStatus information.</param>
+        /// <returns>IActionResult.</returns>
         public async Task<IActionResult> SignIn(TokenStatus account)
         {
             var userId = UserId.GetUserId(HttpContext, this.User);
@@ -101,10 +101,10 @@ namespace LinkedAccounts.Web.Controllers
         }
 
         /// <summary>
-        /// Sign a user out of a given connection name previously linked to their Bot
+        /// Sign a user out of a given connection name previously linked to their Bot.
         /// </summary>
-        /// <param name="account"></param>
-        /// <returns></returns>
+        /// <param name="account">TokenStatus information.</param>
+        /// <returns>IActionResult.</returns>
         public async Task<IActionResult> SignOut(TokenStatus account)
         {
             var userId = UserId.GetUserId(HttpContext, this.User);
@@ -125,7 +125,9 @@ namespace LinkedAccounts.Web.Controllers
 
         
         [HttpPost]
+#pragma warning disable CS1998 // This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
         public async Task<IActionResult> ChangeUserId(LinkedAccountsViewModel model)
+#pragma warning restore CS1998 // This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
         {
             if (ModelState.IsValid)
             {                               

--- a/solutions/linkedaccounts/linkedaccounts.web/LinkedAccounts.Web.csproj
+++ b/solutions/linkedaccounts/linkedaccounts.web/LinkedAccounts.Web.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <UserSecretsId>aspnet-projects-2DBAF904-BA99-4B92-AC4E-82793D8EFF4F</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>0</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.4.4" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.4.4" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.4.4" />
@@ -20,6 +20,10 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Identity.Web\Microsoft.Identity.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solutions/linkedaccounts/linkedaccounts.web/Startup.cs
+++ b/solutions/linkedaccounts/linkedaccounts.web/Startup.cs
@@ -20,6 +20,7 @@ namespace LinkedAccounts.Web
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Identity.Web;
     using Microsoft.Net.Http.Headers;
 
     public class Startup
@@ -40,13 +41,7 @@ namespace LinkedAccounts.Web
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddAuthentication(sharedOptions =>
-            {
-                sharedOptions.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                sharedOptions.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
-            })
-            .AddAzureAd(options => Configuration.Bind("AzureAd", options))
-            .AddCookie();
+            services.AddAzureAdV2Authentication(Configuration);
 
             services.AddSingleton<ICredentialProvider>(new ConfigurationCredentialProvider(Configuration));
 

--- a/solutions/linkedaccounts/linkedaccounts.web/appsettings.json
+++ b/solutions/linkedaccounts/linkedaccounts.web/appsettings.json
@@ -2,9 +2,9 @@
 
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "",
-    "TenantId": "",
-    "ClientId": "",
+    "Domain": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com]",
+    "TenantId": "[Enter 'common', or 'organizations' or the Tenant Id (Obtained from the Azure portal. Select 'Endpoints' from the 'App registrations' blade and use the GUID in any of the URLs), e.g. da41245a5-11b3-996c-00a8-4d99re19f292]",
+    "ClientId": "[Enter the Client Id (Application ID obtained from the Azure portal), e.g. ba74781c2-53c2-442a-97c2-3d60re42f403]",
     "CallbackPath": "/signin-oidc"
   },
   "Logging": {


### PR DESCRIPTION
## Maintenance
* Updated LinkedAccounts with Microsoft.Identity.Web package that contains helper methods to enable users to authenticate with Azure AD & personal Microsoft accounts.
* Updated to .Net Core 2.2 framework.
* Addressing some stylecop issues with comments