### PR TITLE
Fixes path issue with dispatch sync

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -53,7 +53,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--id $luisApp.appid  `
 				--intentName "l_$($luisApp.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -78,7 +78,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--key $kb.subscriptionKey  `
 				--intentName "q_$($kb.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
     }
     else
@@ -111,7 +111,7 @@ foreach ($langCode in $languageMap.Keys) {
 Write-Host "> Updating dispatch model ..."
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-    --dataFolder $dispatchFolder 2>> $logFile | Out-Null
+    --dataFolder $(Join-Path $dispatchFolder $langCode) 2>> $logFile | Out-Null
 
 # Update dispatch.cs file
 Write-Host "> Running LuisGen ..."

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
@@ -53,7 +53,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--id $luisApp.appid  `
 				--intentName "l_$($luisApp.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -78,7 +78,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--key $kb.subscriptionKey  `
 				--intentName "q_$($kb.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
     }
     else
@@ -111,7 +111,7 @@ foreach ($langCode in $languageMap.Keys) {
 Write-Host "> Updating dispatch model ..."
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-    --dataFolder $dispatchFolder 2>> $logFile | Out-Null
+    --dataFolder $(Join-Path $dispatchFolder $langCode) 2>> $logFile | Out-Null
 
 # Update dispatch.cs file
 Write-Host "> Running LuisGen ..."

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -54,7 +54,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--id $luisApp.appid  `
 				--intentName "l_$($luisApp.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -79,7 +79,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--key $kb.subscriptionKey  `
 				--intentName "q_$($kb.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
     }
     else
@@ -112,7 +112,7 @@ foreach ($langCode in $languageMap.Keys) {
 Write-Host "> Updating dispatch model ..."
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-    --dataFolder $dispatchFolder 2>> $logFile | Out-Null
+    --dataFolder $(Join-Path $dispatchFolder $langCode) 2>> $logFile | Out-Null
 
 # Update dispatch.cs file
 Write-Host "> Running LuisGen ..."

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
@@ -54,7 +54,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--id $luisApp.appid  `
 				--intentName "l_$($luisApp.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
 
         # Update local LU files based on hosted QnA KBs
@@ -79,7 +79,7 @@ foreach ($langCode in $languageMap.Keys) {
 				--key $kb.subscriptionKey  `
 				--intentName "q_$($kb.id)" `
                 --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-                --dataFolder $dispatchFolder)  2>> $logFile | Out-Null
+                --dataFolder $(Join-Path $dispatchFolder $langCode))  2>> $logFile | Out-Null
         }
     }
     else
@@ -112,7 +112,7 @@ foreach ($langCode in $languageMap.Keys) {
 Write-Host "> Updating dispatch model ..."
 dispatch refresh `
     --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
-    --dataFolder $dispatchFolder 2>> $logFile | Out-Null
+    --dataFolder $(Join-Path $dispatchFolder $langCode) 2>> $logFile | Out-Null
 
 # Update dispatch.cs file
 Write-Host "> Running LuisGen ..."


### PR DESCRIPTION
## Description
Fixes an issue introduced by https://github.com/microsoft/botframework-solutions/commit/6061da900dcf1bf60caacd487a763cadf50fa4bd where the dispatch file would be updated in the root of the dispatch directory, but the dispatch file used for dispatch refresh is located under dispatch/locale, meaning that running the `update_cognitive_models.ps1` script didn't work.

### Bug Fixes
As it stands the current script would create/update a .dispatch file in `Deployment\Resources\Dispatch` rather than `Deployment\Resources\Dispatch\locale-folder` which means that when the dispatch refresh command is run (and looks for a dispatch file inside the locale-folder) it won't be the file that was just updated. This change updates the behaviour so that we are both writing to, and reading from the locale-folder.

## Testing Steps
Tested against a KB and LUIS app that I created