### PR TITLE
Correct language for deployment

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/deployment/scripts/publish.ps1
@@ -19,7 +19,7 @@ else {
 if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 
 	# Add needed deployment files for az
-	az bot prepare-deploy --code-dir $projFolder --lang Typescript
+	az bot prepare-deploy --code-dir $projFolder --lang Node
 }
 
 # Check for existing deployment configuration


### PR DESCRIPTION
Per help docs recommended after this script throws message re:TypeScript

>>> az bot prepare-deploy --help

Command
    az bot prepare-deploy : Add scripts and configuration files to your local source code directory
    to be able to publish back using `az webapp deployment source`.

Arguments
    --lang [Required] : The language or runtime of the bot.  Allowed values: Csharp, Node.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
