### PR TITLE
[Botskills] Add language argument back to disconnect command

### DIFF
--- a/lib/typescript/botskills/docs/connect-disconnect.md
+++ b/lib/typescript/botskills/docs/connect-disconnect.md
@@ -68,6 +68,7 @@ botskills disconnect [option]
 | --ts                          | Determine your assistant project structure to be a TypeScript-like structure         
 | --noTrain                          | (OPTIONAL) Determine whether the skills connected are not going to be trained (by default they are trained)                                                                         |
 | --dispatchName [name]         | (OPTIONAL) Name of your assistant's '.dispatch' file (defaults to the name displayed in your Cognitive Models file)                                         |
+| --language [language]         | (OPTIONAL) Locale used for LUIS culture (defaults to 'en-us')                                                                                               |
 | --dispatchFolder [path]       | (OPTIONAL) Path to the folder containing your assistant's '.dispatch' file (defaults to './deployment/resources/dispatch/en' inside your assistant folder)  |
 | --outFolder [path]            | (OPTIONAL) Path for any output file that may be generated (defaults to your assistant's root folder)                                                        |
 | --lgOutFolder [path]          | (OPTIONAL) Path for the LuisGen output (defaults to a 'service' folder inside your assistant's folder)                                                      |

--- a/lib/typescript/botskills/src/botskills-disconnect.ts
+++ b/lib/typescript/botskills/src/botskills-disconnect.ts
@@ -36,6 +36,7 @@ program
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noTrain', '[OPTIONAL] Determine whether the skills connected are not going to be trained (by default they are trained)')
     .option('--dispatchName [name]', '[OPTIONAL] Name of your assistant\'s \'.dispatch\' file (defaults to the name displayed in your Cognitive Models file)')
+    .option('--language [language]', '[OPTIONAL] Locale used for LUIS culture (defaults to \'en-us\')')
     .option('--dispatchFolder [path]', '[OPTIONAL] Path to the folder containing your assistant\'s \'.dispatch\' file (defaults to \'./deployment/resources/dispatch/en\' inside your assistant folder)')
     .option('--outFolder [path]', '[OPTIONAL] Path for any output file that may be generated (defaults to your assistant\'s root folder)')
     .option('--lgOutFolder [path]', '[OPTIONAL] Path for the LuisGen output (defaults to a \'service\' folder inside your assistant\'s folder)')
@@ -112,9 +113,6 @@ configuration.cognitiveModelsFile = cognitiveModelsFilePath;
 const language: string = args.language || 'en-us';
 configuration.language = language;
 const languageCode: string = (language.split('-'))[0];
-
-// luisFolder validation
-configuration.luisFolder = args.luisFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
 
 // dispatchFolder validation
 configuration.dispatchFolder = args.dispatchFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix #1503 

- Add `language` argument to `disconnect` command.
- Remove unused `luisFolder` argument from `disconnect` command.
- Update documentation with the `language` argument.

## Testing Steps
1. Go to `AI\lib\typescript\botskills\`.
1. Open a terminal in that location.
1. Run the command `npm install` to install dependencies.
1. Run the command `npm run build` to build the project.
1. Run the command `npm link` to symlink the package folder.
1. Run the command `botskills disconnect` with the proper arguments, making sure to include the `language` argument and exclude the `dispatchFolder` argument, and checking the Dispatch subfolder with the language as name is successfully used.

## Checklist
- [x] I have updated related documentation