### PR TITLE
[Skills] Add error handling for skills websocket transport

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -127,9 +127,18 @@ namespace Microsoft.Bot.Builder.Skills
                     _botTelemetryClient.TrackTrace($"Sending activity. ReplyToId: {activity.ReplyToId}", Severity.Information, null);
 
                     var stopWatch = new Diagnostics.Stopwatch();
-                    stopWatch.Start();
-                    response = await SendRequestAsync<ResourceResponse>(request).ConfigureAwait(false);
-                    stopWatch.Stop();
+
+					try
+					{
+						stopWatch.Start();
+						response = await SendRequestAsync<ResourceResponse>(request).ConfigureAwait(false);
+						stopWatch.Stop();
+					}
+					catch (Exception ex)
+					{
+						throw new SkillWebSocketCallbackException($"Callback failed. Verb: POST, Path: {requestPath}", ex);
+					}
+
                     _botTelemetryClient.TrackEvent("SkillWebSocketSendActivityLatency", null, new Dictionary<string, double>
                     {
                         { "Latency", stopWatch.ElapsedMilliseconds },
@@ -162,13 +171,24 @@ namespace Microsoft.Bot.Builder.Skills
             var request = Request.CreatePut(requestPath);
             request.SetBody(activity);
 
-            _botTelemetryClient.TrackTrace($"Updating activity. activity id: {activity.Id}", Severity.Information, null);
+			var response = default(ResourceResponse);
+
+			_botTelemetryClient.TrackTrace($"Updating activity. activity id: {activity.Id}", Severity.Information, null);
 
             var stopWatch = new Diagnostics.Stopwatch();
-            stopWatch.Start();
-            var response = await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
-            stopWatch.Stop();
-            _botTelemetryClient.TrackEvent("SkillWebSocketUpdateActivityLatency", null, new Dictionary<string, double>
+
+			try
+			{
+				stopWatch.Start();
+				response = await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
+				stopWatch.Stop();
+			}
+			catch (Exception ex)
+			{
+				throw new SkillWebSocketCallbackException($"Callback failed. Verb: PUT, Path: {requestPath}", ex);
+			}
+
+			_botTelemetryClient.TrackEvent("SkillWebSocketUpdateActivityLatency", null, new Dictionary<string, double>
             {
                 { "Latency", stopWatch.ElapsedMilliseconds },
             });
@@ -181,13 +201,23 @@ namespace Microsoft.Bot.Builder.Skills
             var requestPath = $"/activities/{reference.ActivityId}";
             var request = Request.CreateDelete(requestPath);
 
-            _botTelemetryClient.TrackTrace($"Updating activity. activity id: {reference.ActivityId}", Severity.Information, null);
+			var response = default(ResourceResponse);
+
+			_botTelemetryClient.TrackTrace($"Deleting activity. activity id: {reference.ActivityId}", Severity.Information, null);
 
             var stopWatch = new Diagnostics.Stopwatch();
-            stopWatch.Start();
-            await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
-            stopWatch.Stop();
-            _botTelemetryClient.TrackEvent("SkillWebSocketDeleteActivityLatency", null, new Dictionary<string, double>
+			try
+			{
+				stopWatch.Start();
+				await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
+				stopWatch.Stop();
+			}
+			catch (Exception ex)
+			{
+				throw new SkillWebSocketCallbackException($"Callback failed. Verb: DELETE, Path: {requestPath}", ex);
+			}
+
+			_botTelemetryClient.TrackEvent("SkillWebSocketDeleteActivityLatency", null, new Dictionary<string, double>
             {
                 { "Latency", stopWatch.ElapsedMilliseconds },
             });

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -128,16 +128,16 @@ namespace Microsoft.Bot.Builder.Skills
 
                     var stopWatch = new Diagnostics.Stopwatch();
 
-					try
-					{
-						stopWatch.Start();
-						response = await SendRequestAsync<ResourceResponse>(request).ConfigureAwait(false);
-						stopWatch.Stop();
-					}
-					catch (Exception ex)
-					{
-						throw new SkillWebSocketCallbackException($"Callback failed. Verb: POST, Path: {requestPath}", ex);
-					}
+                    try
+                    {
+                        stopWatch.Start();
+                        response = await SendRequestAsync<ResourceResponse>(request).ConfigureAwait(false);
+                        stopWatch.Stop();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new SkillWebSocketCallbackException($"Callback failed. Verb: POST, Path: {requestPath}", ex);
+                    }
 
                     _botTelemetryClient.TrackEvent("SkillWebSocketSendActivityLatency", null, new Dictionary<string, double>
                     {
@@ -171,24 +171,24 @@ namespace Microsoft.Bot.Builder.Skills
             var request = Request.CreatePut(requestPath);
             request.SetBody(activity);
 
-			var response = default(ResourceResponse);
+            var response = default(ResourceResponse);
 
-			_botTelemetryClient.TrackTrace($"Updating activity. activity id: {activity.Id}", Severity.Information, null);
+            _botTelemetryClient.TrackTrace($"Updating activity. activity id: {activity.Id}", Severity.Information, null);
 
             var stopWatch = new Diagnostics.Stopwatch();
 
-			try
-			{
-				stopWatch.Start();
-				response = await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
-				stopWatch.Stop();
-			}
-			catch (Exception ex)
-			{
-				throw new SkillWebSocketCallbackException($"Callback failed. Verb: PUT, Path: {requestPath}", ex);
-			}
+            try
+            {
+                stopWatch.Start();
+                response = await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
+                stopWatch.Stop();
+            }
+            catch (Exception ex)
+            {
+                throw new SkillWebSocketCallbackException($"Callback failed. Verb: PUT, Path: {requestPath}", ex);
+            }
 
-			_botTelemetryClient.TrackEvent("SkillWebSocketUpdateActivityLatency", null, new Dictionary<string, double>
+            _botTelemetryClient.TrackEvent("SkillWebSocketUpdateActivityLatency", null, new Dictionary<string, double>
             {
                 { "Latency", stopWatch.ElapsedMilliseconds },
             });
@@ -201,21 +201,21 @@ namespace Microsoft.Bot.Builder.Skills
             var requestPath = $"/activities/{reference.ActivityId}";
             var request = Request.CreateDelete(requestPath);
 
-			_botTelemetryClient.TrackTrace($"Deleting activity. activity id: {reference.ActivityId}", Severity.Information, null);
+            _botTelemetryClient.TrackTrace($"Deleting activity. activity id: {reference.ActivityId}", Severity.Information, null);
 
             var stopWatch = new Diagnostics.Stopwatch();
-			try
-			{
-				stopWatch.Start();
-				await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
-				stopWatch.Stop();
-			}
-			catch (Exception ex)
-			{
-				throw new SkillWebSocketCallbackException($"Callback failed. Verb: DELETE, Path: {requestPath}", ex);
-			}
+            try
+            {
+                stopWatch.Start();
+                await SendRequestAsync<ResourceResponse>(request, cancellationToken).ConfigureAwait(false);
+                stopWatch.Stop();
+            }
+            catch (Exception ex)
+            {
+                throw new SkillWebSocketCallbackException($"Callback failed. Verb: DELETE, Path: {requestPath}", ex);
+            }
 
-			_botTelemetryClient.TrackEvent("SkillWebSocketDeleteActivityLatency", null, new Dictionary<string, double>
+            _botTelemetryClient.TrackEvent("SkillWebSocketDeleteActivityLatency", null, new Dictionary<string, double>
             {
                 { "Latency", stopWatch.ElapsedMilliseconds },
             });

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -201,8 +201,6 @@ namespace Microsoft.Bot.Builder.Skills
             var requestPath = $"/activities/{reference.ActivityId}";
             var request = Request.CreateDelete(requestPath);
 
-			var response = default(ResourceResponse);
-
 			_botTelemetryClient.TrackTrace($"Deleting activity. activity id: {reference.ActivityId}", Severity.Information, null);
 
             var stopWatch = new Diagnostics.Stopwatch();

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketCallbackException.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketCallbackException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Microsoft.Bot.Builder.Skills
+{
+	public class SkillWebSocketCallbackException : Exception
+	{
+		public SkillWebSocketCallbackException(string message, Exception ex)
+			: base(message, ex)
+		{
+		}
+	}
+}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketRequestHandler.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketRequestHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Skills
             if (string.IsNullOrEmpty(body) || request.Streams?.Count == 0)
             {
                 response.StatusCode = (int)HttpStatusCode.BadRequest;
-				response.SetBody("Empty request body.");
+                response.SetBody("Empty request body.");
                 return response;
             }
 
@@ -57,64 +57,64 @@ namespace Microsoft.Bot.Builder.Skills
                 return response;
             }
 
-			Activity activity = null;
+            Activity activity = null;
 
-			try
-			{
-				activity = JsonConvert.DeserializeObject<Activity>(body, Serialization.Settings);
-			}
-			catch (Exception ex)
-			{
-				_botTelemetryClient.TrackException(ex);
+            try
+            {
+                activity = JsonConvert.DeserializeObject<Activity>(body, Serialization.Settings);
+            }
+            catch (Exception ex)
+            {
+                _botTelemetryClient.TrackException(ex);
 
-				response.StatusCode = (int)HttpStatusCode.BadRequest;
-				response.SetBody("Request body is not an Activity instance.");
-				return response;
-			}
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+                response.SetBody("Request body is not an Activity instance.");
+                return response;
+            }
 
-			try
-			{
-				var cancellationTokenSource = new CancellationTokenSource();
-				_stopWatch.Start();
-				var invokeResponse = await this.SkillWebSocketBotAdapter.ProcessActivityAsync(activity, new BotCallbackHandler(this.Bot.OnTurnAsync), cancellationTokenSource.Token).ConfigureAwait(false);
-				_stopWatch.Stop();
+            try
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+                _stopWatch.Start();
+                var invokeResponse = await this.SkillWebSocketBotAdapter.ProcessActivityAsync(activity, new BotCallbackHandler(this.Bot.OnTurnAsync), cancellationTokenSource.Token).ConfigureAwait(false);
+                _stopWatch.Stop();
 
-				_botTelemetryClient.TrackEvent("SkillWebSocketProcessRequestLatency", null, new Dictionary<string, double>
-				{
-					{ "Latency", _stopWatch.ElapsedMilliseconds },
-				});
+                _botTelemetryClient.TrackEvent("SkillWebSocketProcessRequestLatency", null, new Dictionary<string, double>
+                {
+                    { "Latency", _stopWatch.ElapsedMilliseconds },
+                });
 
-				// trigger cancel token after activity is handled. this will stop the typing indicator
-				cancellationTokenSource.Cancel();
+                // trigger cancel token after activity is handled. this will stop the typing indicator
+                cancellationTokenSource.Cancel();
 
-				if (invokeResponse == null)
-				{
-					response.StatusCode = (int)HttpStatusCode.OK;
-				}
-				else
-				{
-					response.StatusCode = invokeResponse.Status;
-					if (invokeResponse.Body != null)
-					{
-						response.SetBody(invokeResponse.Body);
-					}
-				}
-			}
-			catch (SkillWebSocketCallbackException ex)
-			{
-				_botTelemetryClient.TrackException(ex);
+                if (invokeResponse == null)
+                {
+                    response.StatusCode = (int)HttpStatusCode.OK;
+                }
+                else
+                {
+                    response.StatusCode = invokeResponse.Status;
+                    if (invokeResponse.Body != null)
+                    {
+                        response.SetBody(invokeResponse.Body);
+                    }
+                }
+            }
+            catch (SkillWebSocketCallbackException ex)
+            {
+                _botTelemetryClient.TrackException(ex);
 
-				response.StatusCode = (int)HttpStatusCode.InternalServerError;
-				response.SetBody(ex.Message);
+                response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                response.SetBody(ex.Message);
 
-				return response;
-			}
-			catch (Exception ex)
-			{
-				_botTelemetryClient.TrackException(ex);
+                return response;
+            }
+            catch (Exception ex)
+            {
+                _botTelemetryClient.TrackException(ex);
 
-				response.StatusCode = (int)HttpStatusCode.InternalServerError;
-			}
+                response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            }
 
             return response;
         }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Bot.Builder.Skills
                         GetHandoffActivityCallback()),
                     headers);
 
+				_streamingTransportClient.Disconnected += StreamingTransportClient_Disconnected;
                 await _streamingTransportClient.ConnectAsync();
             }
 
@@ -72,7 +73,12 @@ namespace Microsoft.Bot.Builder.Skills
             return endOfConversation;
         }
 
-        public async Task CancelRemoteDialogsAsync(ITurnContext turnContext)
+		private void StreamingTransportClient_Disconnected(object sender, DisconnectedEventArgs e)
+		{
+
+		}
+
+		public async Task CancelRemoteDialogsAsync(ITurnContext turnContext)
         {
             var cancelRemoteDialogEvent = turnContext.Activity.CreateReply();
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Bot.Builder.Skills
                         GetHandoffActivityCallback()),
                     headers);
 
-				_streamingTransportClient.Disconnected += StreamingTransportClient_Disconnected;
                 await _streamingTransportClient.ConnectAsync();
             }
 
@@ -73,12 +72,7 @@ namespace Microsoft.Bot.Builder.Skills
             return endOfConversation;
         }
 
-		private void StreamingTransportClient_Disconnected(object sender, DisconnectedEventArgs e)
-		{
-
-		}
-
-		public async Task CancelRemoteDialogsAsync(ITurnContext turnContext)
+        public async Task CancelRemoteDialogsAsync(ITurnContext turnContext)
         {
             var cancelRemoteDialogEvent = turnContext.Activity.CreateReply();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

For websocket transport, we need to make sure all failure cases are accounted for so whoever calling a skill over websocket knows what to do when it gets the failure responses.

This change includes the following additional error case handling:
1. 400 for empty payload
2. 400 for invalid payload (not an Activity)
3. 500 for callback from skill to calling bot on SendActivity, UpdateActivity and DeleteActivity

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
