### PR TITLE
[DevOps][TypeScript] Implement different test/coverage script for dev and CI

### DIFF
--- a/lib/typescript/botbuilder-skills/.nycrc
+++ b/lib/typescript/botbuilder-skills/.nycrc
@@ -9,7 +9,6 @@
     "**/*.d.ts"
   ],
   "reporter": [
-    "cobertura",
     "html",
     "text"
   ],

--- a/lib/typescript/botbuilder-skills/package.json
+++ b/lib/typescript/botbuilder-skills/package.json
@@ -12,8 +12,9 @@
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "lint": "tslint -t vso ./src/**/*.ts",
-        "test": "mocha test/",
-        "coverage": "nyc mocha test/"
+        "test": "mocha",
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "@azure/cognitiveservices-luis-authoring": "^2.1.0",

--- a/lib/typescript/botbuilder-skills/test/mocha.opts
+++ b/lib/typescript/botbuilder-skills/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/lib/typescript/botbuilder-solutions/.nycrc
+++ b/lib/typescript/botbuilder-solutions/.nycrc
@@ -9,7 +9,6 @@
     "**/*.d.ts"
   ],
   "reporter": [
-    "cobertura",
     "html",
     "text"
   ],

--- a/lib/typescript/botbuilder-solutions/package.json
+++ b/lib/typescript/botbuilder-solutions/package.json
@@ -12,8 +12,9 @@
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
         "lint": "tslint -t vso ./src/**/*.ts",
-        "test": "mocha test/",
-        "coverage": "nyc mocha test/"
+        "test": "mocha",
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "adaptivecards": "^1.1.3",

--- a/lib/typescript/botbuilder-solutions/test/mocha.opts
+++ b/lib/typescript/botbuilder-solutions/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/lib/typescript/botskills/.nycrc
+++ b/lib/typescript/botskills/.nycrc
@@ -11,8 +11,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "sourceMap": true,
   "cache": true

--- a/lib/typescript/botskills/package.json
+++ b/lib/typescript/botskills/package.json
@@ -11,8 +11,9 @@
     "build": "tsc",
     "lint": "tslint -t vso ./src/**/*.ts",
     "lint-fix": "tslint --fix ./src/**/*.ts",
-    "test": "mocha test/",
-    "coverage": "nyc npm run test"
+    "test": "mocha",
+    "coverage": "nyc mocha",
+    "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
   },
   "directories": {
     "lib": "lib"

--- a/lib/typescript/botskills/test/mocha.opts
+++ b/lib/typescript/botskills/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 50000
 --colors
 --recursive

--- a/lib/typescript/common/config/rush/command-line.json
+++ b/lib/typescript/common/config/rush/command-line.json
@@ -17,6 +17,13 @@
         },
         {
             "commandKind": "bulk",
+            "name": "test",
+            "summary": "Run test",
+            "safeForSimultaneousRushProcesses": true,
+            "enableParallelism": true
+        },
+        {
+            "commandKind": "bulk",
             "name": "coverage",
             "summary": "Run test with coverage",
             "safeForSimultaneousRushProcesses": true,
@@ -24,8 +31,8 @@
         },
         {
             "commandKind": "bulk",
-            "name": "test",
-            "summary": "Run test",
+            "name": "test-coverage-ci",
+            "summary": "Run test with coverage to publish in Azure Pipelines",
             "safeForSimultaneousRushProcesses": true,
             "enableParallelism": true
         }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/.nycrc
@@ -14,8 +14,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_.nycrc
@@ -12,8 +12,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/_package.json
@@ -15,7 +15,8 @@
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
         "test": "mocha",
-        "coverage": "nyc mocha"
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/customAssistant/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_.nycrc
@@ -11,8 +11,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/_package.json
@@ -14,8 +14,9 @@
         "lint-fix": "tslint --fix ./src/**/*.ts",
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
-        "test": "mocha test/",
-        "coverage": "nyc npm run test"
+        "test": "mocha",
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/customSkill/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 50000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
@@ -62,8 +62,9 @@
     ]
   },
   "scripts": {
-    "test": "mocha test/",
-    "coverage": "nyc npm run test",
+    "test": "mocha",
+    "coverage": "nyc mocha",
+    "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/mocha.opts
@@ -1,4 +1,3 @@
---reporter mocha-junit-reporter
 --timeout 30000
 --recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.nycrc
@@ -12,8 +12,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/package.json
@@ -15,7 +15,8 @@
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
         "test": "mocha",
-        "coverage": "nyc mocha"
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/test/mocha.opts
@@ -1,4 +1,2 @@
---reporter mocha-junit-reporter
 --timeout 50000
---recursive
 --colors

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.nycrc
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/.nycrc
@@ -11,8 +11,7 @@
   ],
   "reporter": [
     "html",
-    "text",
-    "cobertura"
+    "text"
   ],
   "all": true,
   "cache": true

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/package.json
@@ -14,8 +14,9 @@
         "lint-fix": "tslint --fix ./src/**/*.ts",
         "start": "npm run build && node ./lib/index.js NODE_ENV=development",
         "watch": "nodemon ./lib/index.js NODE_ENV=development",
-        "test": "mocha test/",
-        "coverage": "nyc npm run test"
+        "test": "mocha",
+        "coverage": "nyc mocha",
+        "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^1.3.0",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mocha.opts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/test/mocha.opts
@@ -1,4 +1,2 @@
---reporter mocha-junit-reporter
 --timeout 50000
---recursive
 --colors

--- a/yaml/typescript/botbuilder-skills.yml
+++ b/yaml/typescript/botbuilder-skills.yml
@@ -32,7 +32,7 @@ steps:
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
   workingDirectory: lib/typescript
-  displayName: 'rush coverage'
+  displayName: 'rush test-coverage-ci'
 
 - task: PublishTestResults@2
   displayName: 'publish test results'

--- a/yaml/typescript/botbuilder-skills.yml
+++ b/yaml/typescript/botbuilder-skills.yml
@@ -28,11 +28,11 @@ steps:
   workingDirectory: lib/typescript
   displayName: 'rush build'
 
-- pwsh: 'node ./common/scripts/install-run-rush.js coverage'
+- pwsh: 'node ./common/scripts/install-run-rush.js test-coverage-ci'
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
   workingDirectory: lib/typescript
-  displayName: 'rush test-coverage-ci'
+  displayName: 'rush test coverage'
 
 - task: PublishTestResults@2
   displayName: 'publish test results'

--- a/yaml/typescript/botbuilder-solutions.yml
+++ b/yaml/typescript/botbuilder-solutions.yml
@@ -32,7 +32,7 @@ steps:
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
   workingDirectory: lib/typescript
-  displayName: 'rush coverage'
+  displayName: 'rush test-coverage-ci'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results '

--- a/yaml/typescript/botbuilder-solutions.yml
+++ b/yaml/typescript/botbuilder-solutions.yml
@@ -28,11 +28,11 @@ steps:
   workingDirectory: lib/typescript
   displayName: 'rush build'
 
-- pwsh: 'node .\common\scripts\install-run-rush.js coverage'
+- pwsh: 'node .\common\scripts\install-run-rush.js test-coverage-ci'
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
   workingDirectory: lib/typescript
-  displayName: 'rush test-coverage-ci'
+  displayName: 'rush test coverage'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results '

--- a/yaml/typescript/botskills.yml
+++ b/yaml/typescript/botskills.yml
@@ -35,7 +35,7 @@ steps:
     command: custom
     workingDir: lib/typescript/botskills
     verbose: false
-    customCommand: 'run coverage'
+    customCommand: 'run test-coverage-ci'
     
 - task: PublishTestResults@2
   displayName: 'publish test results'

--- a/yaml/typescript/sample-assistant.yml
+++ b/yaml/typescript/sample-assistant.yml
@@ -36,7 +36,7 @@ steps:
     command: custom
     workingDir: 'templates/Virtual-Assistant-Template/typescript/samples/sample-assistant'
     verbose: false
-    customCommand: 'run coverage'
+    customCommand: 'run test-coverage-ci'
 
 - task: PublishTestResults@2
   displayName: 'publish test results'

--- a/yaml/typescript/sample-skill.yml
+++ b/yaml/typescript/sample-skill.yml
@@ -38,7 +38,7 @@ steps:
     command: custom
     workingDir: 'templates/Virtual-Assistant-Template/typescript/samples/sample-skill'
     verbose: false
-    customCommand: 'run coverage'
+    customCommand: 'run test-coverage-ci'
 
 - task: PublishTestResults@2
   displayName: 'publish test results'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Add `test-coverage-ci` script to generate the reports for Pipelines.
- Change the `test` and `coverage` scripts to provide meaningful messages for developers.

## Testing Steps
1. Go to `./templates/Virtual-Assistant-Template/typescript/samples/sample-assistant` and open a PowerShell terminal.
1. Run `npm i` to install dependencies.
1. Run `npm run build` to build the project.
1. Run `npm run coverage` and review the test and coverage reports in console.
![image](https://user-images.githubusercontent.com/12394167/59385746-6b0b4b80-8d3b-11e9-88bf-d48b3ad0302d.png)
1. Run `npm run test-coverage-ci` and check the reports.
![image](https://user-images.githubusercontent.com/12394167/59385759-72caf000-8d3b-11e9-9e4e-6125d35bf686.png)
