### PR TITLE
RequestOAuthFlow event in Direct Line Speech auth scenario

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -151,6 +151,14 @@ namespace Microsoft.Bot.Builder.Solutions.Authentication
 
                 await stepContext.Context.SendActivityAsync(noLinkedAccountResponse).ConfigureAwait(false);
 
+                // Enable Direct Line Speech clients to receive an event that will tell them
+                // to trigger a sign-in flow when a token isn't present
+                var requestOAuthFlowEvent = stepContext.Context.Activity.CreateReply();
+                requestOAuthFlowEvent.Type = ActivityTypes.Event;
+                requestOAuthFlowEvent.Name = "RequestOAuthFlow";
+
+                await stepContext.Context.SendActivityAsync(requestOAuthFlowEvent).ConfigureAwait(false);
+
                 return new DialogTurnResult(DialogTurnStatus.Cancelled);
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Maintenance
If a token is missing for a user using the direct line speech channel, their client will receive an event named "RequestOAuthFlow"
It's up to the client to configure this with their sign-in scenario

#1528 

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->
On the DL Speech client, trigger a productivity skill and verify that the VA sends both a message telling them to log in as well as an event named RequestOAuthFlow

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [x] I have commented my code, particularly in hard-to-understand areas