### PR TITLE
[Skills] fix the issue where in webchat skill responses are not sent back to user properly

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Bot.Builder.Skills
             : base(skillManifest.Id)
         {
             _skillManifest = skillManifest ?? throw new ArgumentNullException(nameof(SkillManifest));
-			_serviceClientCredentials = serviceClientCredentials ?? throw new ArgumentNullException(nameof(serviceClientCredentials));
+            _serviceClientCredentials = serviceClientCredentials ?? throw new ArgumentNullException(nameof(serviceClientCredentials));
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _userState = userState;
-			_skillTransport = skillTransport ?? new SkillWebSocketTransport(_skillManifest, _serviceClientCredentials);
+            _skillTransport = skillTransport ?? new SkillWebSocketTransport(_skillManifest, _serviceClientCredentials, telemetryClient);
 
-			if (authDialog != null)
+            if (authDialog != null)
             {
                 _authDialog = authDialog;
                 AddDialog(authDialog);

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -20,20 +20,20 @@ namespace Microsoft.Bot.Builder.Skills
         private IStreamingTransportClient _streamingTransportClient;
         private readonly SkillManifest _skillManifest;
         private readonly IServiceClientCredentials _serviceClientCredentials;
-		private readonly IBotTelemetryClient _botTelemetryClient;
+        private readonly IBotTelemetryClient _botTelemetryClient;
         private bool endOfConversation = false;
 
         public SkillWebSocketTransport(
-			SkillManifest skillManifest,
-			IServiceClientCredentials serviceCLientCredentials,
-			IBotTelemetryClient botTelemetryClient,
-			IStreamingTransportClient streamingTransportClient = null)
+            SkillManifest skillManifest,
+            IServiceClientCredentials serviceCLientCredentials,
+            IBotTelemetryClient botTelemetryClient,
+            IStreamingTransportClient streamingTransportClient = null)
         {
             _skillManifest = skillManifest ?? throw new ArgumentNullException(nameof(skillManifest));
             _serviceClientCredentials = serviceCLientCredentials ?? throw new ArgumentNullException(nameof(serviceCLientCredentials));
-			_botTelemetryClient = botTelemetryClient;
-			_streamingTransportClient = streamingTransportClient;
-		}
+            _botTelemetryClient = botTelemetryClient;
+            _streamingTransportClient = streamingTransportClient;
+        }
 
         public async Task<bool> ForwardToSkillAsync(ITurnContext turnContext, Activity activity, Action<Activity> tokenRequestHandler = null)
         {
@@ -47,12 +47,12 @@ namespace Microsoft.Bot.Builder.Skills
                 var headers = new Dictionary<string, string>();
                 headers.Add("Authorization", $"Bearer {token}");
 
-				// establish websocket connection
-				_streamingTransportClient = new WebSocketClient(
+                // establish websocket connection
+                _streamingTransportClient = new WebSocketClient(
                     EnsureWebSocketUrl(_skillManifest.Endpoint.ToString()),
                     new SkillCallingRequestHandler(
                         turnContext,
-						_botTelemetryClient,
+                        _botTelemetryClient,
                         GetTokenCallback(turnContext, tokenRequestHandler),
                         GetHandoffActivityCallback()),
                     headers);
@@ -60,16 +60,16 @@ namespace Microsoft.Bot.Builder.Skills
                 await _streamingTransportClient.ConnectAsync();
             }
 
-			// set recipient to the skill
-			var recipientId = activity.Recipient.Id;
-			activity.Recipient.Id = _skillManifest.MSAappId;
+            // set recipient to the skill
+            var recipientId = activity.Recipient.Id;
+            activity.Recipient.Id = _skillManifest.MSAappId;
 
-			// Serialize the activity and POST to the Skill endpoint
-			var body = new StringContent(JsonConvert.SerializeObject(activity, SerializationSettings.BotSchemaSerializationSettings), Encoding.UTF8, SerializationSettings.ApplicationJson);
+            // Serialize the activity and POST to the Skill endpoint
+            var body = new StringContent(JsonConvert.SerializeObject(activity, SerializationSettings.BotSchemaSerializationSettings), Encoding.UTF8, SerializationSettings.ApplicationJson);
             var request = Request.CreatePost(string.Empty, body);
 
-			// set back recipient id to make things consistent
-			activity.Recipient.Id = recipientId;
+            // set back recipient id to make things consistent
+            activity.Recipient.Id = recipientId;
 
             await _streamingTransportClient.SendAsync(request);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Skills
         {
             if (_streamingTransportClient != null)
             {
-				_streamingTransportClient.Disconnect();
+                _streamingTransportClient.Disconnect();
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

Right now for Webchat, there's a weird issue where calls to skill won't be sent back to user. It's because we tempered with the Recipient id of the activity before sending it to the skill to set it to be the skill's msa id. It has to remain as the current bot's id for the activity sending to work. So set it back to original value after call to skill is constructed to fix the issue.

also added logger to log the exception on SkillCallingRequestHandler class since we can't throw the exception back because it's an API call.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
