### PR TITLE
Update RouterDialog to pass through Invoke Events

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
@@ -89,6 +89,13 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
                             break;
                         }
 
+                    case ActivityTypes.Invoke:
+                        {
+                            // Used by Teams for Authentication scenarios.
+                            await innerDc.ContinueDialogAsync().ConfigureAwait(false);
+                            break;
+                        }
+
                     default:
                         {
                             await OnSystemMessageAsync(innerDc).ConfigureAwait(false);


### PR DESCRIPTION
Update to our RouterDialog implementation to pass Invoke Activity Types through to the active dialog which in the case of Teams is the OAuthPrompt. This change coupled with the new 4.4.5 BF SDK ensures auth works right out of the box with Teams.