### PR TITLE
Docs - Add link to sample project for mac users

### DIFF
--- a/docs/tutorials/csharp/skill.md
+++ b/docs/tutorials/csharp/skill.md
@@ -41,7 +41,7 @@ A Bot Framework Skill app (in C#) that greets a new user.
 
 > It's important to ensure all of the following pre-requisites are installed on your machine prior to attempting deployment otherwise you may run into deployment issues.
 
-1. Install the [Skill Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.BotSkillTemplate). Note that Visual Studio on Mac doesn't support VSIX so instead [clone the Sample from our repo](https://github.com/microsoft/botframework-solutions/tree/master/templates/Skill-Template/csharp/Sample).
+1. Install the [Skill Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.BotSkillTemplate). *Note that Visual Studio on Mac doesn't support VSIX packages, instead [clone the Skill Template sample from our repository](https://github.com/microsoft/botframework-solutions/tree/master/templates/Skill-Template/csharp/Sample).*
 2. Ensure you have updated [.NET Core](https://www.microsoft.com/net/download) to the latest version.  
 3. Ensure the [Node Package manager](https://nodejs.org/en/) is installed.
 4. PowerShell Core version 6 (Required for cross platform deployment support)

--- a/docs/tutorials/csharp/skill.md
+++ b/docs/tutorials/csharp/skill.md
@@ -41,7 +41,7 @@ A Bot Framework Skill app (in C#) that greets a new user.
 
 > It's important to ensure all of the following pre-requisites are installed on your machine prior to attempting deployment otherwise you may run into deployment issues.
 
-1. Install the [Skill Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.BotSkillTemplate)
+1. Install the [Skill Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.BotSkillTemplate). Note that Visual Studio on Mac doesn't support VSIX so instead [clone the Sample from our repo](https://github.com/microsoft/botframework-solutions/tree/master/templates/Skill-Template/csharp/Sample).
 2. Ensure you have updated [.NET Core](https://www.microsoft.com/net/download) to the latest version.  
 3. Ensure the [Node Package manager](https://nodejs.org/en/) is installed.
 4. PowerShell Core version 6 (Required for cross platform deployment support)

--- a/docs/tutorials/csharp/virtualassistant.md
+++ b/docs/tutorials/csharp/virtualassistant.md
@@ -38,7 +38,7 @@ A Virtual Assistant app (in C#) that greets a new user.
 > It's important to ensure all of the following prerequisites are installed on your machine prior to attempting deployment otherwise you may run into deployment issues.
 
 1. Download and install Visual Studio (2017 or 2019) for PC or Mac
-1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). Note that Visual Studio on Mac doesn't support VSIX so instead [clone the Sample from our repo](https://github.com/microsoft/botframework-solutions/tree/master/templates/Virtual-Assistant-Template/csharp/Sample).
+1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). *Note that Visual Studio on Mac doesn't support VSIX packages, instead [clone the Skill Template sample from our repository](https://github.com/microsoft/botframework-solutions/tree/master/templates/Skill-Template/csharp/Sample).*
 2. Download and install [.NET Core SDK](https://www.microsoft.com/net/download).  
 3. Download and install [Node Package manager](https://nodejs.org/en/).
 4. Download and install PowerShell Core version 6 (required for cross platform deployment support):

--- a/docs/tutorials/csharp/virtualassistant.md
+++ b/docs/tutorials/csharp/virtualassistant.md
@@ -37,8 +37,8 @@ A Virtual Assistant app (in C#) that greets a new user.
 
 > It's important to ensure all of the following prerequisites are installed on your machine prior to attempting deployment otherwise you may run into deployment issues.
 
-1. Download and install Visual Studio (any version) for PC or Mac
-1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). (Currently not supported on Mac.  See Appendix for details)
+1. Download and install Visual Studio (2017 or 2019) for PC or Mac
+1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). Note that Visual Studio on Mac doesn't support VSIX so instead [clone the Sample from our repo](https://github.com/microsoft/botframework-solutions/tree/master/templates/Virtual-Assistant-Template/csharp/Sample).
 2. Download and install [.NET Core SDK](https://www.microsoft.com/net/download).  
 3. Download and install [Node Package manager](https://nodejs.org/en/).
 4. Download and install PowerShell Core version 6 (required for cross platform deployment support):


### PR DESCRIPTION
When creating a VA template on Mac there is a blocker that VS on Mac doesn't support VSIX. To counter this whilst we work on the VSCode templates providing a link to the sample project a developer can clone.