### PR TITLE
Fix project folder parameter in bot deploy script

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
@@ -197,7 +197,7 @@ if ($outputs)
 	Invoke-Expression "$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1') -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -outFolder `"$($projDir)`" -languages `"$($languages)`""
 	
 	# Publish bot
-	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder `"$($projDir)`""
 
 	Write-Host "> Done."
 }

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/publish.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/publish.ps1
@@ -19,7 +19,7 @@ else {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Get path to csproj file
-	$projFile = Get-ChildItem $prjFolder `
+	$projFile = Get-ChildItem $projFolder `
 		| Where-Object {$_.extension -eq ".csproj" } `
 		| Select-Object -First 1
 

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
@@ -197,7 +197,7 @@ if ($outputs)
 	Invoke-Expression "$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1') -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -outFolder `"$($projDir)`" -languages `"$($languages)`""
 	
 	# Publish bot
-	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder `"$($projDir)`""
 
 	Write-Host "> Done."
 }

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/publish.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/publish.ps1
@@ -19,7 +19,7 @@ else {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Get path to csproj file
-	$projFile = Get-ChildItem $prjFolder `
+	$projFile = Get-ChildItem $projFolder `
 		| Where-Object {$_.extension -eq ".csproj" } `
 		| Select-Object -First 1
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -197,7 +197,7 @@ if ($outputs)
 	Invoke-Expression "$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1') -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -qnaSubscriptionKey $($outputs.qnaMaker.value.key) -outFolder `"$($projDir)`" -languages `"$($languages)`""
 	
 	# Publish bot
-	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder `"$($projDir)`""
 
 	Write-Host "> Done."
 }

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/publish.ps1
@@ -19,7 +19,7 @@ else {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Get path to csproj file
-	$projFile = Get-ChildItem $prjFolder `
+	$projFile = Get-ChildItem $projFolder `
 		| Where-Object {$_.extension -eq ".csproj" } `
 		| Select-Object -First 1
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
@@ -197,7 +197,7 @@ if ($outputs)
 	Invoke-Expression "$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1') -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -qnaSubscriptionKey $($outputs.qnaMaker.value.key) -outFolder `"$($projDir)`" -languages `"$($languages)`""
 	
 	# Publish bot
-	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup)"
+	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"
 
 	Write-Host "> Done."
 }

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
@@ -197,7 +197,7 @@ if ($outputs)
 	Invoke-Expression "$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1') -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -qnaSubscriptionKey $($outputs.qnaMaker.value.key) -outFolder `"$($projDir)`" -languages `"$($languages)`""
 	
 	# Publish bot
-	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"
+	Invoke-Expression "$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder `"$($projDir)`""
 
 	Write-Host "> Done."
 }

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/publish.ps1
@@ -19,7 +19,7 @@ else {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Get path to csproj file
-	$projFile = Get-ChildItem $prjFolder `
+	$projFile = Get-ChildItem $projFolder `
 		| Where-Object {$_.extension -eq ".csproj" } `
 		| Select-Object -First 1
 


### PR DESCRIPTION
## Description

I had built a parent PowerShell file to deploy a C# Virtual Assistant bot abstracted from the script bundled with the template. However, the `projDir`/`projFolder` parameter is not passed through from `deploy.ps1` to `publish.ps1` - including usage of a misspelled variable.

Closes #1570

### Bug Fixes

When deploying the Virtual Assistant C# template, `deploy.ps1` will now pass along the `$projDir` parameter into `publish.ps1`. Additionally, a variable name was fixed from `$prjFolder` to `$projFolder` which produced erroneous behavior.