### PR TITLE
remove break string because it's not really needed

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var response = SpeechUtility.ListToSpeechReadyString(_promptOptions);
 
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{listItemSpeakProperty}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{listItemSpeakProperty}"));
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var item1 = string.Format(CommonStrings.LatestItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1} {CommonStrings.And} {item2}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1} {CommonStrings.And} {item2}"));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var response = SpeechUtility.ListToSpeechReadyString(_activity);
 
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{listItemSpeakProperty}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{listItemSpeakProperty}"));
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1} {CommonStrings.And} {item2}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1} {CommonStrings.And} {item2}"));
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
             var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
             var item3 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1}, {item2} {CommonStrings.And} {item3}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1}, {item2} {CommonStrings.And} {item3}"));
         }
 
         [TestMethod]
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
             var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
             var item3 = string.Format(CommonStrings.ThirdItem, listItemSpeakProperty);
             var item4 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{SpeechUtility.BreakString}{item1}, {item2}, {item3} {CommonStrings.And} {item4}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1}, {item2}, {item3} {CommonStrings.And} {item4}"));
         }
     }
 }

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Bot.Builder.Solutions.Responses
 
     public class SpeechUtility
     {
-        public const string BreakString = "<break/>";
-
         /// <summary>
         /// Concatenate PromptOption string properties into a formatted speech-ready string.
         /// </summary>
@@ -91,11 +89,7 @@ namespace Microsoft.Bot.Builder.Solutions.Responses
         /// <returns>Formatted speech-ready string.</returns>
         private static string ListToSpeechReadyString(string parentString, List<string> selectionStrings, ReadPreference readOrder, int maxSize)
         {
-            var result = string.Empty;
-            if (!string.IsNullOrEmpty(parentString))
-            {
-                result += parentString + BreakString;
-            }
+            var result = parentString ?? string.Empty;
 
             List<string> itemDetails = new List<string>();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

The break string for speak property is not really needed given they're in different sentence and the pause is good enough. This also causes SSML issue so removing it.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
