### PR TITLE
Resolve 400 bad request error from long-running Point of Interest Skills

### DIFF
--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/ServiceHelper.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/ServiceHelper.cs
@@ -17,7 +17,11 @@ namespace PointOfInterestSkill.Services
         /// <returns>Generated httpClient.</returns>
         public static HttpClient GetHttpClient()
         {
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            if (!httpClient.DefaultRequestHeaders.Contains("Accept"))
+            {
+                httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            }
+
             return httpClient;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

### Bug Fixes
Close #1603 - previously the Accept header on HttpClient requests was added with each instance, eventually this becomes too long and is not accepted by services. This only needs to be added once.

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->
Run POI Skill and validate that the Accept header is only added one time to the HttpClient
