### PR TITLE
[Speech]set ssml to neural

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetSpeakMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetSpeakMiddleware.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Solutions.Middleware
             if (rootElement == null || rootElement.Name.LocalName != "speak")
             {
                 // If the text is not valid XML, or if it's not a <speak> node, treat it as plain text.
-                rootElement = new XElement(NamespaceURI + "speak", new XRaw(activity.Speak));
+                rootElement = new XElement(NamespaceURI + "speak", activity.Speak);
             }
 
             AddAttributeIfMissing(rootElement, "version", "1.0");
@@ -170,22 +170,6 @@ namespace Microsoft.Bot.Builder.Solutions.Middleware
             if (existingAttribute?.Value == currentAttributeValue)
             {
                 existingAttribute?.SetValue(newAttributeValue);
-            }
-        }
-
-        private class XRaw : XText
-        {
-            public XRaw(string text)
-                : base(text)
-            { }
-
-            public XRaw(XText text)
-                : base(text)
-            { }
-
-            public override void WriteTo(System.Xml.XmlWriter writer)
-            {
-                writer.WriteRaw(this.Value);
             }
         }
     }

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetSpeakMiddleware.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetSpeakMiddleware.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Solutions.Middleware
     {
         private const string DefaultLocale = "en-US";
 
-        private const string DefaultVoiceFont = "Microsoft Server Speech Text to Speech Voice (en-US, Jessa24kRUS)";
+        private const string DefaultVoiceFont = "Microsoft Server Speech Text to Speech Voice (en-US, JessaNeural)";
 
         private static string _locale;
 
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Solutions.Middleware
             if (rootElement == null || rootElement.Name.LocalName != "speak")
             {
                 // If the text is not valid XML, or if it's not a <speak> node, treat it as plain text.
-                rootElement = new XElement(NamespaceURI + "speak", activity.Speak);
+                rootElement = new XElement(NamespaceURI + "speak", new XRaw(activity.Speak));
             }
 
             AddAttributeIfMissing(rootElement, "version", "1.0");
@@ -170,6 +170,22 @@ namespace Microsoft.Bot.Builder.Solutions.Middleware
             if (existingAttribute?.Value == currentAttributeValue)
             {
                 existingAttribute?.SetValue(newAttributeValue);
+            }
+        }
+
+        private class XRaw : XText
+        {
+            public XRaw(string text)
+                : base(text)
+            { }
+
+            public XRaw(XText text)
+                : base(text)
+            { }
+
+            public override void WriteTo(System.Xml.XmlWriter writer)
+            {
+                writer.WriteRaw(this.Value);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

Set default SSML to neural to provide a better experience

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
