### PR TITLE
Improve Speak for POI

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions.tests/Responses/SpeechUtilityTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var response = SpeechUtility.ListToSpeechReadyString(_promptOptions);
 
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{listItemSpeakProperty}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {listItemSpeakProperty}"));
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var item1 = string.Format(CommonStrings.LatestItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1} {CommonStrings.And} {item2}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {item1} {CommonStrings.And} {item2}"));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var response = SpeechUtility.ListToSpeechReadyString(_activity);
 
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{listItemSpeakProperty}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {listItemSpeakProperty}"));
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
 
             var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1} {CommonStrings.And} {item2}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {item1} {CommonStrings.And} {item2}"));
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
             var item1 = string.Format(CommonStrings.FirstItem, listItemSpeakProperty);
             var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
             var item3 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1}, {item2} {CommonStrings.And} {item3}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {item1}, {item2} {CommonStrings.And} {item3}"));
         }
 
         [TestMethod]
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests
             var item2 = string.Format(CommonStrings.SecondItem, listItemSpeakProperty);
             var item3 = string.Format(CommonStrings.ThirdItem, listItemSpeakProperty);
             var item4 = string.Format(CommonStrings.LastItem, listItemSpeakProperty);
-            Assert.AreEqual(response, string.Format($"{parentSpeakProperty}{item1}, {item2}, {item3} {CommonStrings.And} {item4}"));
+            Assert.AreEqual(response, string.Format($"{parentSpeakProperty} {item1}, {item2}, {item3} {CommonStrings.And} {item4}"));
         }
     }
 }

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/SpeechUtility.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder.Solutions.Responses
         /// <returns>Formatted speech-ready string.</returns>
         private static string ListToSpeechReadyString(string parentString, List<string> selectionStrings, ReadPreference readOrder, int maxSize)
         {
-            var result = parentString ?? string.Empty;
+            var result = $"{parentString} " ?? string.Empty;
 
             List<string> itemDetails = new List<string>();
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
@@ -433,7 +433,7 @@ namespace PointOfInterestSkill.Dialogs
                         var promptReplacements = new StringDictionary
                         {
                             { "Name", pointOfInterestList[i].Name },
-                            { "Address", pointOfInterestList[i].Address },
+                            { "Address", pointOfInterestList[i].AddressForSpeak },
                         };
                         pointOfInterestList[i].Speak = ResponseManager.GetResponse(promptTemplate, promptReplacements).Text;
                     }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointofInterestModel.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointofInterestModel.cs
@@ -74,6 +74,9 @@ namespace PointOfInterestSkill.Models
             Address = foursquarePoi.Location?.FormattedAddress != null
                 ? string.Join(", ", foursquarePoi.Location.FormattedAddress.Take(foursquarePoi.Location.FormattedAddress.Length - 1))
                 : Address;
+            AddressForSpeak = foursquarePoi.Location?.FormattedAddress != null
+                ? foursquarePoi.Location.FormattedAddress[0]
+                : Address;
             Geolocation = (foursquarePoi.Location != null)
                 ? new LatLng() { Latitude = foursquarePoi.Location.Lat, Longitude = foursquarePoi.Location.Lng }
                 : Geolocation;
@@ -137,6 +140,17 @@ namespace PointOfInterestSkill.Models
         /// The formatted address of this point of interest.
         /// </value>
         public string Address { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted address of the point of interest
+        /// that we put in the Speak property of the Activity to support
+        /// speech scenarios
+        /// Availability: Azure Maps, Foursquare.
+        /// </summary>
+        /// <value>
+        /// The formatted address of this point of interest for speech.
+        /// </value>
+        public string AddressForSpeak { get; set; }
 
         /// <summary>
         /// Gets or sets the geolocation of the point of interest.

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointofInterestModel.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointofInterestModel.cs
@@ -40,6 +40,10 @@ namespace PointOfInterestSkill.Models
             Address = !string.IsNullOrEmpty(azureMapsPoi.Address?.FreeformAddress)
                 ? azureMapsPoi.Address?.FreeformAddress
                 : Address;
+
+            // Set if to be the same as Address for now
+            // Change it to proper handling when using AzureMaps again
+            AddressForSpeak = Address;
             Geolocation = azureMapsPoi.Position
                 ?? Geolocation;
             Category = (azureMapsPoi.Poi?.Classifications != null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail under any applicable category below and remove those that don't apply. This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ for more information on automation. 
For example...
Close #123: This description for this goes here.-->

Right now we're sending back the full address for speech including state and zip code. We should remove them for Speak property. This change adds a new property AddressForSpeak and uses it to populate Speak property. Also added extra space to avoid '.' being read out.

### Architecture

### Bug Fixes

### Conversational Experience

### Maintenance

### Language Understanding

## Testing Steps
<!--- Include any instructions for testing your Pull Request. Include sample utterances, steps, etc. -->

## Checklist
<!--- You can remove any items below that don't apply to the pull request. -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the appropriate unit tests
- [ ] I have tested any new/updated dialogs using Speech in the emulator to ensure the [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) property is set to enable a high quality speech-first experience and the appropriate [InputHints](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) are set correctly. 
- [ ] I have updated related documentation

<!--- If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant-->
- [ ] A duplicate issue is filed to track future  work.

<!--- If you have updated responses or `.lu` files:-->
- [ ] All languages have been updated
- [ ] You have tested deployment with your new models
