### PR TITLE
[BotBuilder Solutions][TypeScript] Fix 'import-name' rule issue

### DIFF
--- a/lib/typescript/botbuilder-solutions/src/authentication/multiProviderAuthDialog.ts
+++ b/lib/typescript/botbuilder-solutions/src/authentication/multiProviderAuthDialog.ts
@@ -107,7 +107,9 @@ export class MultiProviderAuthDialog extends ComponentDialog {
         }
 
         const adapter: BotFrameworkAdapter = <BotFrameworkAdapter> stepContext.context.adapter;
-        const tokenStatusCollection: TokenStatus[] = await adapter.getTokenStatus(stepContext.context, stepContext.context.activity.from.id);
+        const tokenStatusCollection: TokenStatus[] = await adapter.getTokenStatus(
+            stepContext.context,
+            stepContext.context.activity.from.id);
 
         const matchingProviders: TokenStatus[] = tokenStatusCollection.filter((p: TokenStatus) => {
             return (p.hasToken || false) && this.authenticationConnections.some((t: IOAuthConnection) => {

--- a/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
@@ -7,14 +7,21 @@ import * as dayjs from 'dayjs';
 import i18next from 'i18next';
 
 export namespace DateTimeExtensions {
+    let currentLocale: string;
+
+    function importLocale(locale: string): void {
+        const localeImport: string = locale === 'zh' ?
+        `../resources/customizeLocale/zh` :
+        `dayjs/locale/${locale}`;
+        import(localeImport);
+    }
 
     export function toSpeechDateString(date: Date, includePrefix: boolean = false): string {
-        const localeImport: string = i18next.language === 'zh' ?
-        `../resources/customizeLocale/zh` :
-        `dayjs/locale/${i18next.language}`;
-
-        import(localeImport);
         const locale: string = i18next.language;
+        if (currentLocale !== locale) {
+            currentLocale = locale;
+            importLocale(locale);
+        }
         const utcDate: Date = new Date();
         utcDate.setHours(date.getHours());
         utcDate.setMinutes(date.getMinutes());

--- a/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
@@ -4,18 +4,16 @@
  */
 
 import * as dayjs from 'dayjs';
-// tslint:disable
-import 'dayjs/locale/de';
-import 'dayjs/locale/es';
-import 'dayjs/locale/it';
-import 'dayjs/locale/fr';
-import '../resources/customizeLocale/zh';
 import i18next from 'i18next';
-// tslint:enable
 
 export namespace DateTimeExtensions {
 
     export function toSpeechDateString(date: Date, includePrefix: boolean = false): string {
+        const localeImport: string = i18next.language === 'zh' ?
+        `../resources/customizeLocale/zh` :
+        `dayjs/locale/${i18next.language}`;
+
+        import(localeImport);
         const locale: string = i18next.language;
         const utcDate: Date = new Date();
         utcDate.setHours(date.getHours());

--- a/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
@@ -10,10 +10,14 @@ export namespace DateTimeExtensions {
     let currentLocale: string;
 
     function importLocale(locale: string): void {
-        const localeImport: string = locale === 'zh' ?
-        `../resources/customizeLocale/zh` :
-        `dayjs/locale/${locale}`;
-        import(localeImport);
+        try {
+            const localeImport: string = locale === 'zh' ?
+            `../resources/customizeLocale/zh` :
+            `dayjs/locale/${locale}`;
+            import(localeImport);
+        } catch (err) {
+            throw new Error(`There was an error during the import of the locale:${locale}, Error:${err}`);
+        }
     }
 
     export function toSpeechDateString(date: Date, includePrefix: boolean = false): string {


### PR DESCRIPTION
Fix #1637

## Purpose
During the execution of the `build` command, which contains the `linting`, the `import-name` rule of **TSLint** fails (however, the build passes successfully)

## Changes

- Fix `import-name` rule of **TSLint**
- Change the implementation of the **dynamic imports**
- Fix `TSLint` issues

## Tests
The dynamic imports are covered with tests (`dateTimeExtensions.test.js`). However, some validation tests are missing, we plan to do it as a next step.

## Feature Plan
\-