### PR TITLE
[Botskills] Replace 'require' for reading JSON files

### DIFF
--- a/lib/typescript/botskills/src/botskills-connect.ts
+++ b/lib/typescript/botskills/src/botskills-connect.ts
@@ -4,7 +4,7 @@
  */
 
 import * as program from 'commander';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { extname, isAbsolute, join, resolve } from 'path';
 import { ConnectSkill } from './functionality';
 import { ConsoleLogger, ILogger } from './logger';
@@ -155,7 +155,7 @@ configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (a
 if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     // tslint:disable-next-line
-    const cognitiveModelsFile: ICognitiveModelFile = require(cognitiveModelsFilePath);
+    const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
 }
 

--- a/lib/typescript/botskills/src/botskills-disconnect.ts
+++ b/lib/typescript/botskills/src/botskills-disconnect.ts
@@ -4,7 +4,7 @@
  */
 
 import * as program from 'commander';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { extname, isAbsolute, join, resolve } from 'path';
 import { DisconnectSkill } from './functionality';
 import { ConsoleLogger, ILogger} from './logger';
@@ -124,7 +124,7 @@ configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (a
 if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     // tslint:disable-next-line
-    const cognitiveModelsFile: ICognitiveModelFile = require(cognitiveModelsFilePath);
+    const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
 }
 

--- a/lib/typescript/botskills/src/botskills-refresh.ts
+++ b/lib/typescript/botskills/src/botskills-refresh.ts
@@ -4,6 +4,7 @@
  */
 
 import * as program from 'commander';
+import { readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { RefreshSkill } from './functionality';
 import { ConsoleLogger, ILogger} from './logger';
@@ -92,7 +93,7 @@ configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (a
 if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     // tslint:disable-next-line
-    const cognitiveModelsFile: ICognitiveModelFile = require(cognitiveModelsFilePath);
+    const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
 }
 

--- a/lib/typescript/botskills/src/botskills-update.ts
+++ b/lib/typescript/botskills/src/botskills-update.ts
@@ -4,7 +4,7 @@
  */
 
 import * as program from 'commander';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { extname, isAbsolute, join, resolve } from 'path';
 import { UpdateSkill } from './functionality';
 import { ConsoleLogger, ILogger } from './logger';
@@ -150,7 +150,7 @@ configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (a
 if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     // tslint:disable-next-line
-    const cognitiveModelsFile: ICognitiveModelFile = require(cognitiveModelsFilePath);
+    const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
 }
 

--- a/lib/typescript/botskills/src/botskills.ts
+++ b/lib/typescript/botskills/src/botskills.ts
@@ -6,14 +6,15 @@
 
 // tslint:disable:no-object-literal-type-assertion
 import * as program from 'commander';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import * as process from 'process';
 import * as semver from 'semver';
 import { ConsoleLogger, ILogger} from './logger/logger';
 
 const logger: ILogger = new ConsoleLogger();
 
-// tslint:disable-next-line:no-var-requires no-require-imports
-const pkg: IPackage = require('../package.json');
+const pkg: IPackage = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'UTF8'));
 
 const requiredVersion: string = pkg.engines.node;
 if (!semver.satisfies(process.version, requiredVersion)) {
@@ -32,7 +33,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 };
 
 program
-    .version(pkg.version, '-v, --Version')
+    .version(pkg.version, '-v, --version')
     .description(`The skill program makes it easy to manipulate skills for Microsoft Bot Framework tools.`);
 
 program

--- a/lib/typescript/botskills/src/functionality/connectSkill.ts
+++ b/lib/typescript/botskills/src/functionality/connectSkill.ts
@@ -197,7 +197,6 @@ export class ConnectSkill {
             // End of manifest schema validation
 
             // Take VA Skills configurations
-            //tslint:disable-next-line: no-var-requires non-literal-require
             const assistantSkillsFile: ISkillFile = JSON.parse(readFileSync(configuration.skillsFile, 'UTF8'));
             const assistantSkills: ISkillManifest[] = assistantSkillsFile.skills || [];
 

--- a/lib/typescript/botskills/src/functionality/disconnectSkill.ts
+++ b/lib/typescript/botskills/src/functionality/disconnectSkill.ts
@@ -32,7 +32,6 @@ export class DisconnectSkill {
 
                 return false;
             }
-            // tslint:disable-next-line:no-var-require non-literal-require
             const dispatchData: IDispatchFile = JSON.parse(
                 readFileSync(dispatchFilePath)
                 .toString());
@@ -79,8 +78,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             }
 
             // Take VA Skills configurations
-            //tslint:disable-next-line: no-var-requires non-literal-require
-            const assistantSkillsFile: ISkillFile = require(configuration.skillsFile);
+            const assistantSkillsFile: ISkillFile = JSON.parse(readFileSync(configuration.skillsFile, 'UTF8'));
             const assistantSkills: ISkillManifest[] = assistantSkillsFile.skills || [];
 
             // Check if the skill is present in the assistant

--- a/lib/typescript/botskills/src/functionality/listSkill.ts
+++ b/lib/typescript/botskills/src/functionality/listSkill.ts
@@ -22,7 +22,6 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
                 return false;
             }
             // Take VA Skills configurations
-            //tslint:disable-next-line:non-literal-require
             const assistantSkillsFile: ISkillFile = JSON.parse(readFileSync(configuration.skillsFile, 'UTF8'));
             if (!assistantSkillsFile.skills) {
                 this.logger.message('There are no Skills connected to the assistant.');

--- a/lib/typescript/botskills/src/functionality/updateSkill.ts
+++ b/lib/typescript/botskills/src/functionality/updateSkill.ts
@@ -50,8 +50,7 @@
             const skillManifest: ISkillManifest = configuration.localManifest
             ? this.getLocalManifest(configuration.localManifest)
             : await this.getRemoteManifest(configuration.remoteManifest);
-            //tslint:disable-next-line: no-var-requires non-literal-require
-            const assistantSkillsFile: ISkillFile = require(configuration.skillsFile);
+            const assistantSkillsFile: ISkillFile = JSON.parse(readFileSync(configuration.skillsFile, 'UTF8'));
             const assistantSkills: ISkillManifest[] = assistantSkillsFile.skills || [];
             // Check if the skill is already connected to the assistant
             if (assistantSkills.find((assistantSkill: ISkillManifest) => assistantSkill.id === skillManifest.id)) {

--- a/lib/typescript/botskills/src/utils/authenticationUtils.ts
+++ b/lib/typescript/botskills/src/utils/authenticationUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { ILogger } from '../logger';
 import {
     IAppSettingOauthConnection,
@@ -148,8 +148,7 @@ export class AuthenticationUtils {
 
                 // update appsettings.json
                 logger.message('Updating appsettings.json ...');
-                // tslint:disable-next-line:non-literal-require
-                const appSettings: IAppSettingOauthConnection = require(configuration.appSettingsFile);
+                const appSettings: IAppSettingOauthConnection = JSON.parse(readFileSync(configuration.appSettingsFile, 'UTF8'));
 
                 // check for and remove existing aad connections
                 if (appSettings.oauthConnections) {

--- a/lib/typescript/botskills/test/disconnect.test.js
+++ b/lib/typescript/botskills/test/disconnect.test.js
@@ -103,7 +103,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             const errorList = this.logger.getError();
 
             strictEqual(errorList[errorList.length - 1], `There was an error while disconnecting the Skill ${config.skillId} from the Assistant:
-SyntaxError: Unexpected identifier`);
+SyntaxError: Unexpected token N in JSON at position 0`);
         });
 
         it("when the dispatchName and dispatchFolder point to a nonexistent file", async function () {

--- a/lib/typescript/botskills/test/mocks/resources/filledSkillsArray.json
+++ b/lib/typescript/botskills/test/mocks/resources/filledSkillsArray.json
@@ -5,9 +5,6 @@
         },
         {
             "id": "testDispatch"
-        },
-        {
-            "id": "connectableSkill"
         }
     ]
 }


### PR DESCRIPTION
<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...
Close #123: Description for this goes here.
-->
Close #1640 

## Purpose
Replace `require` sentences for reading `JSON` files in order to prevent caching these files.

## Changes
Replace `require(PATH)` with `JSON.parse(fs.readFileSync(PATH, 'UTF8'))`

## Tests
All tests are already covering these changes, except for one test that needed some changes as the error expected changed from `Unexpected identifier` to `Unexpected token N in JSON at position 0`.

## Feature Plan
N/A