### PR TITLE
[Botskills] Add a new Known Issue of the CLI tool

### DIFF
--- a/docs/reference/knownissues.md
+++ b/docs/reference/knownissues.md
@@ -115,4 +115,9 @@ This is a known issue with node-gyp: [nodejs/node-gyp#1663](https://github.com/n
 
 There is a known issue in the `Botskills` CLI tool during the command's execution when any of the arguments contains a **trailing backslash** using the `Command Prompt` as terminal. This is due to a parsing issue in the shell.
 
+Example of the `connect` command with a trailing backslash in the `luisFolder` argument:
+``` bash
+botskills connect --botName "<YOUR_VA_NAME>" --localManifest "<YOUR_LOCAL_MANIFEST_FILE>" --luisFolder "<YOUR_LUIS_FOLDER_PATH>\" --ts
+```
+
 So, to avoid this, it's highly recommended to use `PowerShell 6` to execute the CLI tool commands. Also, you can remove the trailing backslash of the argument.

--- a/docs/reference/knownissues.md
+++ b/docs/reference/knownissues.md
@@ -110,3 +110,9 @@ Then the bot will recreate the state `-documents` when it starts if it doesn't e
 ## If Visual Studio 2019 Preview is installed, node-gyp cannot find MSBuild.exe
 
 This is a known issue with node-gyp: [nodejs/node-gyp#1663](https://github.com/nodejs/node-gyp/issues/1663). Uninstalling Visual Studio 2019 Preview fixes the issue.
+
+## Botskills CLI tool can't resolve trailing backslash in any of the arguments using Command Prompt as terminal
+
+There is a known issue in the `Botskills` CLI tool during the command's execution when any of the arguments contains a **trailing backslash** using the `Command Prompt` as terminal. This is due to a parsing issue in the shell.
+
+So, to avoid this, it's highly recommended to use `PowerShell 6` to execute the CLI tool commands. Also, you can remove the trailing backslash of the argument.

--- a/lib/typescript/botskills/src/functionality/connectSkill.ts
+++ b/lib/typescript/botskills/src/functionality/connectSkill.ts
@@ -138,10 +138,10 @@ export class ConnectSkill {
                 // Parse LU file
                 this.logger.message(`Parsing ${luisApp} LU file...`);
                 const ludownParseCommand: string[] = ['ludown', 'parse', 'toluis'];
-                ludownParseCommand.push(...['--in', luFilePath]);
-                ludownParseCommand.push(...['--luis_culture', configuration.language]);
-                ludownParseCommand.push(...['--out_folder', configuration.luisFolder]);
-                ludownParseCommand.push(...['--out', `"${luisFile}"`]);
+                ludownParseCommand.push(...[`--in "${luFilePath}"`]);
+                ludownParseCommand.push(...[`--luis_culture "${configuration.language}"`]);
+                ludownParseCommand.push(...[`--out_folder "${configuration.luisFolder}"`]);
+                ludownParseCommand.push(...[`--out "${luisFile}"`]);
 
                 await this.runCommand(ludownParseCommand, `Parsing ${luisApp} LU file`);
 

--- a/lib/typescript/botskills/src/functionality/refreshSkill.ts
+++ b/lib/typescript/botskills/src/functionality/refreshSkill.ts
@@ -60,8 +60,8 @@ export class RefreshSkill {
 
             const luisgenCommand: string[] = ['luisgen'];
             luisgenCommand.push(this.dispatchJsonFilePath);
-            luisgenCommand.push(...[`-${configuration.lgLanguage}`, `"DispatchLuis"`]);
-            luisgenCommand.push(...['-o', configuration.lgOutFolder]);
+            luisgenCommand.push(...[`-${configuration.lgLanguage} "DispatchLuis"`]);
+            luisgenCommand.push(...[`-o "${configuration.lgOutFolder}"`]);
 
             await this.runCommand(luisgenCommand, `Executing luisgen for the ${configuration.dispatchName} file`);
         } catch (err) {


### PR DESCRIPTION
## Purpose
There is an issue in `botskills` CLI tool using a **trailing backslash** for any of the tool's arguments.

## Changes

- Add a new `Known Issue` with the title **Botskills CLI tool can't resolve trailing backslash in any of the arguments using Command Prompt as terminal**
- Update the internal execution of `luisgen` command

## Tests
It's covered with the `botskills` CLI tool tests 

## Feature Plan
\-