### PR TITLE
Updated default PR comment with sections for bots/deployment scripts

### DIFF
--- a/.github/Tasks/Pull-Request-Commenter/Default/default.txt
+++ b/.github/Tasks/Pull-Request-Commenter/Default/default.txt
@@ -1,5 +1,14 @@
 Thank you for raising a pull request. Please ensure you have have completed the following:
 
+#### General
 - [ ] I have commented my code, particularly in hard-to-understand areas	
 - [ ] I have added or updated the appropriate tests	
 - [ ] I have updated related documentation
+
+#### Bots
+- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
+- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful
+
+#### Deployment Scripts
+- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
+- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects

--- a/.github/Tasks/Pull-Request-Commenter/bots.txt
+++ b/.github/Tasks/Pull-Request-Commenter/bots.txt
@@ -1,7 +1,0 @@
-Thank you for raising a pull request. Please ensure you have have completed the following:
-
-- [ ] I have commented my code, particularly in hard-to-understand areas	
-- [ ] I have added or updated the appropriate tests	
-- [ ] I have updated related documentation
-- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
-- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

--- a/.github/Tasks/Pull-Request-Commenter/default.txt
+++ b/.github/Tasks/Pull-Request-Commenter/default.txt
@@ -1,5 +1,0 @@
-Thank you for raising a pull request. Please ensure you have have completed the following:
-
-- [ ] I have commented my code, particularly in hard-to-understand areas	
-- [ ] I have added or updated the appropriate tests	
-- [ ] I have updated related documentation

--- a/.github/Tasks/Pull-Request-Commenter/deployment_scripts.txt
+++ b/.github/Tasks/Pull-Request-Commenter/deployment_scripts.txt
@@ -1,6 +1,0 @@
-Thank you for raising a pull request. Please ensure you have have completed the following:
-
-- [ ] I have commented my code, particularly in hard-to-understand areas	
-- [ ] I have updated related documentation
-- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
-- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects


### PR DESCRIPTION
<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...
Close #123: Description for this goes here.
-->

## Purpose
*What is the context of this pull request? Why is it being done?*
Default commenter for new PRs

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*
It turns out having conditional comments based on where a PR is created is more advanced than the available functionality. For now we will have a single comment with sections for General, Bots, and Deployment Scripts that users can validate based on the changes they have made.

## Tests
*Is this covered by existing tests or new ones? If no, why not?*
n/a

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
Configuration in VSTS after this is complete