### PR TITLE
[TypeScript][BotBuilder-Skills] Allow ITriggers with nullable properties

### DIFF
--- a/lib/typescript/botbuilder-skills/src/models/skillManifest.ts
+++ b/lib/typescript/botbuilder-skills/src/models/skillManifest.ts
@@ -45,9 +45,9 @@ export interface IActionDefinition {
  * Definition of the triggers for a given action within a Skill.
  */
 export interface ITriggers {
-    utterances: IUtterance[];
+    utterances?: IUtterance[];
     utteranceSources: IUtteranceSources[];
-    events: IEvent[];
+    events?: IEvent[];
 }
 
 /**

--- a/lib/typescript/botbuilder-skills/src/skillManifestGenerator.ts
+++ b/lib/typescript/botbuilder-skills/src/skillManifestGenerator.ts
@@ -134,6 +134,10 @@ export class SkillManifestGenerator {
                             });
                         });
 
+                        if (action.definition.triggers.utterances === undefined) {
+                            action.definition.triggers.utterances = [];
+                        }
+
                         action.definition.triggers.utterances.push({
                             locale: utteranceSource.locale,
                             text: utterancesToAdd


### PR DESCRIPTION
## Purpose
Fix #1648: Not able to connect skill

This pull-request updates the implementation of the `ISkillManifest` interface to allow nullable properties for `ITriggers`.

## Changes
- Add `undefined` type to `ITriggers` properties.
- Modify the `SkillManifestGenerator` to handle `utterances` as `undefined`.

## Tests
1. Go to `./lib/typescript` and open a PowerShell terminal
1. Run `rush install` to install dependencies
1. Run `rush build` to build the projects
1. Run `rush test` to run the tests and check that everything work fine
