### PR TITLE
add flag to include nuget pkgs so nuspec can pick up packages needed

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
@@ -18,7 +18,7 @@
     <RestoreAdditionalProjectSources>
       https://botbuilder.myget.org/F/experimental/api/v3/index.json;
     </RestoreAdditionalProjectSources>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> 
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
@@ -18,6 +18,7 @@
     <RestoreAdditionalProjectSources>
       https://botbuilder.myget.org/F/experimental/api/v3/index.json;
     </RestoreAdditionalProjectSources>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Microsoft.Bot.Builder.Skills.csproj
@@ -18,7 +18,7 @@
     <RestoreAdditionalProjectSources>
       https://botbuilder.myget.org/F/experimental/api/v3/index.json;
     </RestoreAdditionalProjectSources>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> 
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...
Close #123: Description for this goes here.
-->

To include Microsoft.Bot.Builder.Protocol and Microsoft.Bot.Builder.Protocol.WebSockets we need to copy the nuget packages. This change adds the flag to include all the nuget package dependencies so nuspec can pick up the packages needed

## Purpose
*What is the context of this pull request? Why is it being done?*

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

*Include illustrative screenshots for context if applicable.*

## Tests
*Is this covered by existing tests or new ones? If no, why not?*

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*