### PR TITLE
[TypeScript][BotBuilder-Libs] Migrate from TSLint to ESLint

### DIFF
--- a/lib/typescript/botbuilder-skills/.eslintrc.js
+++ b/lib/typescript/botbuilder-skills/.eslintrc.js
@@ -1,0 +1,33 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',  // Specifies the ESLint parser
+    plugins: [
+        '@typescript-eslint',
+        '@typescript-eslint/tslint'
+    ],
+    extends: [
+        'plugin:@typescript-eslint/recommended'
+    ],
+    parserOptions: {
+        ecmaVersion: 2018,  // Allows for the parsing of modern ECMAScript features
+        sourceType: 'module',  // Allows for the use of imports
+        project: './tsconfig.json'
+    },
+    rules: {
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['error', {
+          'args': 'none'
+        }],
+        '@typescript-eslint/no-use-before-define': 'off',
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/no-inferrable-types': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/interface-name-prefix': [ 'error', 'always' ],
+        '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
+        '@typescript-eslint/tslint/config': [
+            'warn',
+            {
+                lintFile: './tslint.json'
+            }
+        ]
+    },
+};

--- a/lib/typescript/botbuilder-skills/package.json
+++ b/lib/typescript/botbuilder-skills/package.json
@@ -11,7 +11,7 @@
         "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
-        "lint": "tslint -t vso ./src/**/*.ts",
+        "lint": "eslint ./src/**/*.ts",
         "test": "mocha",
         "coverage": "nyc mocha",
         "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
@@ -39,7 +39,11 @@
     "devDependencies": {
         "@types/restify": "^7.2.4",
         "@types/uuid": "^3.4.4",
+        "@typescript-eslint/eslint-plugin": "^1.10.2",
+        "@typescript-eslint/eslint-plugin-tslint": "^1.10.2",
+        "@typescript-eslint/parser": "^1.10.2",
         "copyfiles": "^2.1.0",
+        "eslint": "^5.16.0",
         "mocha": "^6.1.4",
         "mocha-junit-reporter": "^1.22.0",
         "nyc": "^14.1.1",
@@ -47,7 +51,7 @@
         "rimraf": "^2.6.2",
         "supertest": "^4.0.2",
         "tslint": "^5.12.1",
-        "tslint-microsoft-contrib": "6.0.0",
+        "tslint-microsoft-contrib": "^6.2.0",
         "@types/nock": "^10.0.3",
         "typescript": "3.4.5"
     },

--- a/lib/typescript/botbuilder-skills/src/auth/microsoftAppCredentialsEx.ts
+++ b/lib/typescript/botbuilder-skills/src/auth/microsoftAppCredentialsEx.ts
@@ -6,7 +6,7 @@
 import { MicrosoftAppCredentials } from 'botframework-connector';
 
 export class MicrosoftAppCredentialsEx extends MicrosoftAppCredentials {
-    constructor(appId: string, password: string, oauthScope?: string) {
+    public constructor(appId: string, password: string, oauthScope?: string) {
         super(appId, password);
         if (oauthScope) {
             this.oAuthScope = oauthScope;

--- a/lib/typescript/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
+++ b/lib/typescript/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
@@ -25,7 +25,7 @@ export class MsJWTAuthenticationProvider implements IAuthenticationProvider {
     private readonly httpClient: ServiceClient;
     private readonly appId: string;
 
-    constructor(appId: string) {
+    public constructor(appId: string) {
         this.httpClient = new ServiceClient();
         this.appId = appId;
     }
@@ -39,19 +39,20 @@ export class MsJWTAuthenticationProvider implements IAuthenticationProvider {
                 url: this.openIdMetadataUrl
             });
 
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             const jwksUri: string = <string>jwksInfo.parsedBody.jwks_uri;
             const jwksClient: jwks.JwksClient = jwks({ jwksUri: jwksUri });
 
             const getKey: signingKeyResolver = (headers: jwks.Headers, cb: (err: Error, signingKey: string) => void): void => {
-                jwksClient.getSigningKey(headers.kid, (err: Error, key: jwks.Jwk) => {
+                jwksClient.getSigningKey(headers.kid, (err: Error, key: jwks.Jwk): void => {
                     cb(err, key.publicKey || key.rsaPublicKey || '');
                 });
             };
 
             // tslint:disable-next-line:typedef
-            const decoder: Promise<{[key: string]: Object}> = new Promise((resolve, reject) => {
-                verify(token, getKey, (err: Error, decodedObj: Object) => {
-                    if (err) { reject(err); }
+            const decoder: Promise<{[key: string]: Object}> = new Promise((resolve, reject): void => {
+                verify(token, getKey, (err: Error, decodedObj: Object): void => {
+                    if (err !== undefined) { reject(err); }
                     const result: {[key: string]: Object} = <{[key: string]: Object}>decodedObj;
                     resolve(result);
                 });

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
@@ -18,7 +18,7 @@ export class SkillHttpAdapter extends BotFrameworkAdapter {
     private readonly authenticationProvider?: IAuthenticationProvider;
     private readonly telemetryClient?: BotTelemetryClient;
 
-    constructor(
+    public constructor(
         botAdapter: SkillHttpBotAdapter,
         authenticationProvider?: IAuthenticationProvider,
         telemetryClient?: BotTelemetryClient,
@@ -34,6 +34,7 @@ export class SkillHttpAdapter extends BotFrameworkAdapter {
     public async processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
         if (this.authenticationProvider) {
             // grab the auth header from the inbound http request
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             const headers: { [header: string]: string | string[] | undefined } = req.headers;
             const authHeader: string = <string> headers[this.authHeaderName];
             const authenticated: boolean = await this.authenticationProvider.authenticate(authHeader);
@@ -70,7 +71,7 @@ export class SkillHttpAdapter extends BotFrameworkAdapter {
     }
 }
 
-function parseRequest(req: WebRequest): Promise<Activity> {
+async function parseRequest(req: WebRequest): Promise<Activity> {
     // tslint:disable-next-line:typedef
     return new Promise((resolve, reject): void => {
         function returnActivity(activity: Activity): void {
@@ -84,18 +85,21 @@ function parseRequest(req: WebRequest): Promise<Activity> {
 
         if (req.body) {
             try {
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 returnActivity(req.body);
             } catch (err) {
                 reject(err);
             }
         } else {
             let requestData: string = '';
-            req.on('data', (chunk: string) => {
+            req.on('data', (chunk: string): void => {
                 requestData += chunk;
             });
-            req.on('end', () => {
+            req.on('end', (): void => {
                 try {
+                    // eslint-disable-next-line @typescript-eslint/tslint/config
                     req.body = JSON.parse(requestData);
+                    // eslint-disable-next-line @typescript-eslint/tslint/config
                     returnActivity(req.body);
                 } catch (err) {
                     reject(err);

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpBotAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpBotAdapter.ts
@@ -8,7 +8,7 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
     private readonly telemetryClient: BotTelemetryClient;
     private readonly queuedActivities: Partial<Activity>[];
 
-    constructor(telemetryClient: BotTelemetryClient) {
+    public constructor(telemetryClient: BotTelemetryClient) {
         super();
         this.telemetryClient = telemetryClient;
         this.queuedActivities = [];
@@ -17,7 +17,7 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
     public async sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
         const responses: ResourceResponse[] = [];
 
-        activities.forEach(async (activity: Partial<Activity>) => {
+        activities.forEach(async (activity: Partial<Activity>): Promise<void> => {
             if (!activity.id) {
                 activity.id = uuid();
             }
@@ -31,6 +31,7 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
                 // hack directly in the POST method. Replicating that here
                 // to keep the behavior as close as possible to facilitate
                 // more realistic tests.
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 const delayMs: number = activity.value;
                 await sleep(delayMs);
             } else if (activity.type === ActivityTypes.Trace && activity.channelId !== 'emulator') {
@@ -48,15 +49,15 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
         return responses;
     }
 
-    public deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
+    public async deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void> {
         throw new Error('Http Request/Response model doesn\'t support DeleteActivityAsync call!');
     }
 
-    public updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
+    public async updateActivity(context: TurnContext, activity: Partial<Activity>): Promise<void> {
         throw new Error('Http Request/Response model doesn\'t support UpdateActivityAsync call!');
     }
 
-    public continueConversation(reference: Partial<ConversationReference>, logic: BotCallbackHandler): Promise<void> {
+    public async continueConversation(reference: Partial<ConversationReference>, logic: BotCallbackHandler): Promise<void> {
         throw new Error('Http Request/Response model doesn\'t support ContinueConversationAsync call!');
     }
 
@@ -96,7 +97,7 @@ export class SkillHttpBotAdapter extends BotAdapter implements IActivityHandler,
     }
 }
 
-function sleep(delay: number): Promise<void> {
+async function sleep(delay: number): Promise<void> {
     return new Promise<void>((resolve: (value: void) => void): void => {
         setTimeout(resolve, delay);
     });

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
@@ -19,11 +19,11 @@ export class SkillHttpTransport implements ISkillTransport {
     /**
      * Http SkillTransport implementation
      */
-    constructor(skillManifest: ISkillManifest, appCredentials: MicrosoftAppCredentials, httpClient?: HttpClient) {
-        if (!skillManifest) { throw new Error('skillManifest has no value'); }
+    public constructor(skillManifest: ISkillManifest, appCredentials: MicrosoftAppCredentials, httpClient?: HttpClient) {
+        if (skillManifest === undefined) { throw new Error('skillManifest has no value'); }
         this.skillManifest = skillManifest;
 
-        if (!appCredentials) { throw new Error('appCredentials has no value'); }
+        if (appCredentials === undefined) { throw new Error('appCredentials has no value'); }
         this.appCredentials = appCredentials;
 
         this.httpClient = httpClient || new DefaultHttpClient();
@@ -47,7 +47,7 @@ export class SkillHttpTransport implements ISkillTransport {
         // - We have to cast "request as any" to avoid a build break relating to different versions
         //   of @azure/ms-rest-js being used by botframework-connector. This is just a build issue and
         //   shouldn't effect production bots.
-        //tslint:disable-next-line: no-any
+        // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
         await this.appCredentials.signRequest(<any>request);
 
         const response: HttpOperationResponse = await this.httpClient.sendRequest(request);
@@ -67,6 +67,7 @@ export class SkillHttpTransport implements ISkillTransport {
             throw new Error(result);
         }
 
+        // eslint-disable-next-line @typescript-eslint/tslint/config
         const responseBody: Activity[] = JSON.parse(response.bodyAsText || '[]');
 
         // Retrieve Activity responses
@@ -74,7 +75,7 @@ export class SkillHttpTransport implements ISkillTransport {
         const filteredResponses: Activity[] = [];
         let endOfConversation: boolean = false;
 
-        skillResponses.forEach(async (skillResponse: Activity) => {
+        skillResponses.forEach(async (skillResponse: Activity): Promise<void> => {
             // Once a Skill has finished it signals that it's handing back control to the parent through a
             // EndOfConversation event which then causes the SkillDialog to be closed. Otherwise it remains "in control".
             if (skillResponse.type === ActivityTypes.EndOfConversation) {

--- a/lib/typescript/botbuilder-skills/src/protocol/router.ts
+++ b/lib/typescript/botbuilder-skills/src/protocol/router.ts
@@ -12,7 +12,7 @@ export class Router {
     private readonly routes: IRouteTemplate[];
     private readonly root: TrieNode;
 
-    constructor(routes: IRouteTemplate[]) {
+    public constructor(routes: IRouteTemplate[]) {
         this.routes = routes;
         this.root = new TrieNode('root');
         this.compile();
@@ -31,7 +31,7 @@ export class Router {
         if (initial) {
             let current: TrieNode = initial;
             const routeData: Map<string, Object> = new Map();
-            parts.forEach((part: string) => {
+            parts.forEach((part: string): void => {
                 const next: TrieNode|undefined = current.tryGetNext(part);
                 if (next) {
                     // found an exact match, keep going
@@ -61,7 +61,7 @@ export class Router {
     }
 
     private compile(): void {
-        this.routes.forEach((route: IRouteTemplate) => {
+        this.routes.forEach((route: IRouteTemplate): void => {
             let path: string = route.path;
             if (path.startsWith('/')) {
                 path = path.substr(1);
@@ -71,7 +71,7 @@ export class Router {
 
             const methodName: TrieNode = this.root.add(route.method);
             let current: TrieNode = methodName;
-            parts.forEach((part: string) => {
+            parts.forEach((part: string): void => {
                 current = current.add(part);
             });
 
@@ -92,7 +92,7 @@ class TrieNode {
     public action?: IRouteAction;
     public next: Map<string, TrieNode>;
 
-    constructor(value: string) {
+    public constructor(value: string) {
         this.value = value;
         this.isVariable = value.startsWith('{') && value.endsWith('}');
         this.next = new Map();
@@ -118,6 +118,6 @@ class TrieNode {
 
     public getVariables(): TrieNode[] {
         return Array.from(this.next.values())
-            .filter((x: TrieNode) => x.isVariable);
+            .filter((x: TrieNode): boolean => x.isVariable);
     }
 }

--- a/lib/typescript/botbuilder-skills/src/skillContext.ts
+++ b/lib/typescript/botbuilder-skills/src/skillContext.ts
@@ -9,7 +9,7 @@
 export class SkillContext {
     private readonly contextStorage: { [key: string]: Object };
 
-    constructor(contextStorage?: { [key: string]: Object }) {
+    public constructor(contextStorage?: { [key: string]: Object }) {
         this.contextStorage = contextStorage || {};
     }
 

--- a/lib/typescript/botbuilder-skills/src/skillDialog.ts
+++ b/lib/typescript/botbuilder-skills/src/skillDialog.ts
@@ -12,7 +12,6 @@ import { SkillHttpTransport } from './http';
 import { IAction, ISkillManifest, ISlot, SkillEvents } from './models';
 import { SkillContext } from './skillContext';
 import { ISkillTransport, TokenRequestHandler } from './skillTransport';
-import { SkillWebSocketTransport } from './websocket';
 
 /**
  * The SkillDialog class provides the ability for a Bot to send/receive messages to a remote Skill (itself a Bot).
@@ -27,20 +26,22 @@ export class SkillDialog extends ComponentDialog {
 
     private readonly queuedResponses: Activity[];
 
-    constructor(skillManifest: ISkillManifest,
-                appCredentials: MicrosoftAppCredentials,
-                telemetryClient: BotTelemetryClient,
-                skillContextAccessor: StatePropertyAccessor<SkillContext>,
-                authDialog?: MultiProviderAuthDialog,
-                skillTransport?: ISkillTransport) {
+    public constructor(
+        skillManifest: ISkillManifest,
+        appCredentials: MicrosoftAppCredentials,
+        telemetryClient: BotTelemetryClient,
+        skillContextAccessor: StatePropertyAccessor<SkillContext>,
+        authDialog?: MultiProviderAuthDialog,
+        skillTransport?: ISkillTransport
+    ) {
         super(skillManifest.id);
-        if (!skillManifest) { throw new Error('skillManifest has no value'); }
+        if (skillManifest === undefined) { throw new Error('skillManifest has no value'); }
         this.skillManifest = skillManifest;
 
-        if (!appCredentials) { throw new Error('appCredentials has no value'); }
+        if (appCredentials === undefined) { throw new Error('appCredentials has no value'); }
         this.appCredentials = appCredentials;
 
-        if (!telemetryClient) { throw new Error('telemetryClient has no value'); }
+        if (telemetryClient === undefined) { throw new Error('telemetryClient has no value'); }
         this.telemetryClient = telemetryClient;
 
         this.queuedResponses = [];
@@ -58,7 +59,7 @@ export class SkillDialog extends ComponentDialog {
         if (reason === DialogReason.cancelCalled) {
             // when dialog is being ended/cancelled, send an activity to skill
             // to cancel all dialogs on the skill side
-            if (this.skillTransport) {
+            if (this.skillTransport !== undefined) {
                 await this.skillTransport.cancelRemoteDialogs(context);
             }
         }
@@ -87,10 +88,10 @@ export class SkillDialog extends ComponentDialog {
         const actionName: string = <string>(options || '');
         if (actionName) {
             // Find the specified within the selected Skill for slot filling evaluation
-            const action: IAction|undefined = this.skillManifest.actions.find((item: IAction) => item.id === actionName);
+            const action: IAction|undefined = this.skillManifest.actions.find((item: IAction): boolean => item.id === actionName);
             if (action !== undefined) {
                 // If the action doesn't define any Slots or SkillContext is empty then we skip slot evaluation
-                if (action.definition.slots && action.definition.slots.length > 0) {
+                if (action.definition.slots !== undefined && action.definition.slots.length > 0) {
                     // Match Slots to Skill Context
                     slots = await this.matchSkillContextToSlots(innerDC, action.definition.slots, skillContext);
                 }
@@ -110,16 +111,16 @@ export class SkillDialog extends ComponentDialog {
             // Retrieve a distinct list of all slots,
             // some actions may use the same slot so we use distinct to ensure we only get 1 instance.
             const skillSlots: ISlot[] = this.skillManifest.actions.reduce(
-                (acc: ISlot[], curr: IAction) => {
+                (acc: ISlot[], curr: IAction): ISlot[] => {
                     const currDistinct: ISlot[] = curr.definition.slots.filter(
-                        (slot: ISlot) => !acc.find((item: ISlot) => item.name === slot.name)
+                        (slot: ISlot): boolean => !acc.find((item: ISlot): boolean => item.name === slot.name)
                     );
 
                     return acc.concat(currDistinct);
                 },
                 []);
 
-            if (skillSlots) {
+            if (skillSlots !== undefined) {
                 // Match Slots to Skill Context
                 slots = await this.matchSkillContextToSlots(innerDC, skillSlots, skillContext);
             }
@@ -159,6 +160,7 @@ export class SkillDialog extends ComponentDialog {
             const result: DialogTurnResult = await innerDC.continueDialog();
 
             // forward the token response to the skill
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             if (result.status === DialogTurnStatus.complete && isProviderTokenResponse(result.result)) {
                 activity.type = ActivityTypes.Event;
                 activity.name = TokenEvents.tokenResponseEventName;
@@ -186,8 +188,8 @@ export class SkillDialog extends ComponentDialog {
     public async matchSkillContextToSlots(innerDc: DialogContext, actionSlots: ISlot[], skillContext: SkillContext): Promise<SkillContext> {
         const slots: SkillContext = new SkillContext();
 
-        if (actionSlots && actionSlots.length > 0) {
-            actionSlots.forEach(async (slot: ISlot) => {
+        if (actionSlots !== undefined && actionSlots.length > 0) {
+            actionSlots.forEach(async (slot: ISlot): Promise<void> => {
                 // For each slot we check to see if there is an exact match, if so we pass this slot across to the skill
                 const value: Object|undefined = skillContext.getObj(slot.name);
                 if (value) {
@@ -251,6 +253,7 @@ export class SkillDialog extends ComponentDialog {
 
             if (this.authDialog) {
                 const authResult: DialogTurnResult = await dialogContext.beginDialog(this.authDialog.id);
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 if (isProviderTokenResponse(authResult.result)) {
                     const tokenEvent: Activity = ActivityExtensions.createReply(activity);
                     tokenEvent.type = ActivityTypes.Event;

--- a/lib/typescript/botbuilder-skills/src/skillException.ts
+++ b/lib/typescript/botbuilder-skills/src/skillException.ts
@@ -22,7 +22,7 @@ export class SkillException extends Error {
     public exceptionType: SkillExceptionType;
     public innerException: Error;
 
-    constructor(exceptionType: SkillExceptionType, message: string, innerException: Error) {
+    public constructor(exceptionType: SkillExceptionType, message: string, innerException: Error) {
         super(message);
         this.exceptionType = exceptionType;
         this.innerException = innerException;

--- a/lib/typescript/botbuilder-skills/src/skillMiddleware.ts
+++ b/lib/typescript/botbuilder-skills/src/skillMiddleware.ts
@@ -18,7 +18,7 @@ export class SkillMiddleware implements Middleware {
     private readonly skillContextAccessor: StatePropertyAccessor<SkillContext>;
     private readonly dialogStateAccessor: StatePropertyAccessor<DialogState>;
 
-    constructor(
+    public constructor(
         conversationState: ConversationState,
         skillContextAccessor: StatePropertyAccessor<SkillContext>,
         dialogStateAccessor: StatePropertyAccessor<DialogState>
@@ -35,9 +35,10 @@ export class SkillMiddleware implements Middleware {
         if (activity !== undefined && activity.type === ActivityTypes.Event) {
             if (activity.name === SkillEvents.skillBeginEventName && activity.value !== undefined) {
                 const activityValue: string = JSON.stringify(activity.value);
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 const skillContext: SkillContext = JSON.parse(activityValue);
                 //Check for parsing
-                if (skillContext) {
+                if (skillContext !== undefined) {
                     await this.skillContextAccessor.set(turnContext, skillContext);
                 }
             } else if (activity.name === SkillEvents.cancelAllSkillDialogsEventName) {

--- a/lib/typescript/botbuilder-skills/src/skillRouter.ts
+++ b/lib/typescript/botbuilder-skills/src/skillRouter.ts
@@ -16,14 +16,14 @@ export namespace SkillRouter {
      * @returns Whether the intent matches a Skill.
      */
     export function isSkill(skillConfiguration: ISkillManifest[], dispatchIntent: string): ISkillManifest|undefined {
-        const manifest: ISkillManifest|undefined = skillConfiguration.find((skillManifest: ISkillManifest) => {
-            return skillManifest.actions.some((action: IAction) => {
+        const manifest: ISkillManifest|undefined = skillConfiguration.find((skillManifest: ISkillManifest): boolean => {
+            return skillManifest.actions.some((action: IAction): boolean => {
                 return action.id === dispatchIntent;
             });
         });
 
         if (manifest === undefined) {
-            return skillConfiguration.find((s: ISkillManifest) => s.id === dispatchIntent);
+            return skillConfiguration.find((s: ISkillManifest): boolean => s.id === dispatchIntent);
         }
 
         return manifest;

--- a/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketAdapter.ts
@@ -18,7 +18,7 @@ export class SkillWebSocketAdapter extends BotFrameworkAdapter {
     private readonly telemetryClient: BotTelemetryClient;
     private readonly botAdapter: SkillWebSocketBotAdapter;
 
-    constructor(
+    public constructor(
         botAdapter: SkillWebSocketBotAdapter,
         authenticationProvider?: IAuthenticationProvider,
         telemetryClient?: BotTelemetryClient,
@@ -30,14 +30,15 @@ export class SkillWebSocketAdapter extends BotFrameworkAdapter {
         this.telemetryClient = telemetryClient || new NullTelemetryClient();
     }
 
-    // tslint:disable-next-line:no-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/tslint/config
     public async processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
         await this.createWebSocketConnection(req, logic);
     }
 
-    // tslint:disable-next-line:no-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/tslint/config
     private async createWebSocketConnection(req: any, bot: BotCallbackHandler): Promise<void> {
         // MISSING found an equivalent to websocket in TypeScript
+        // eslint-disable-next-line @typescript-eslint/tslint/config
         const socket: Socket = req.socket;
         const handler: SkillWebSocketRequestHandler = new SkillWebSocketRequestHandler(this.telemetryClient);
         const server: Server = new Server(socket, handler);

--- a/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketRequestHandler.ts
+++ b/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketRequestHandler.ts
@@ -13,19 +13,19 @@ export class SkillWebSocketRequestHandler extends RequestHandler {
     public bot!: BotCallbackHandler;
     public activityHandler!: IActivityHandler;
 
-    constructor(telemetryClient: BotTelemetryClient) {
+    public constructor(telemetryClient: BotTelemetryClient) {
         super();
         this.telemetryClient = telemetryClient;
     }
 
-    // tslint:disable-next-line:no-any
+    // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
     public async processRequestAsync(request: ReceiveRequest, logger?: any): Promise<Response> {
-        if (!this.bot) { throw new Error(('Missing parameter.  "instance" is required')); }
-        if (!this.activityHandler) { throw new Error(('Missing parameter.  "instance" is required')); }
+        if (this.bot === undefined) { throw new Error(('Missing parameter.  "bot" is required')); }
+        if (this.activityHandler === undefined) { throw new Error(('Missing parameter.  "activityHandler" is required')); }
 
         const response: Response = new Response();
         // MISSING: await request.readBodyAsString();
-        const bodyParts: string[] = await Promise.all(request.Streams.map((s: ContentStream) => s.readAsString()));
+        const bodyParts: string[] = await Promise.all(request.Streams.map((s: ContentStream): Promise<string> => s.readAsString()));
         const body: string = bodyParts.join();
 
         if (!body || request.Streams.length === 0) {
@@ -34,13 +34,14 @@ export class SkillWebSocketRequestHandler extends RequestHandler {
             return response;
         }
 
-        if (request.Streams.some((x: ContentStream) => x.payloadType !== 'application/json; charset=utf-8')) {
+        if (request.Streams.some((x: ContentStream): boolean => x.payloadType !== 'application/json; charset=utf-8')) {
             response.statusCode = 406;
 
             return response;
         }
 
         try {
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             const activity: Activity = JSON.parse(body);
             const begin: [number, number] = process.hrtime();
             const invokeResponse: InvokeResponse = await this.activityHandler.processActivity(activity, this.bot);
@@ -54,7 +55,7 @@ export class SkillWebSocketRequestHandler extends RequestHandler {
                 metrics: latency
             });
 
-            if (!invokeResponse) {
+            if (invokeResponse === undefined) {
                 response.statusCode = 200;
             } else {
                 response.statusCode = invokeResponse.status;
@@ -63,6 +64,7 @@ export class SkillWebSocketRequestHandler extends RequestHandler {
                 }
             }
         } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             this.telemetryClient.trackException({ exception: error });
             response.statusCode = 500;
         }

--- a/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketTransport.ts
+++ b/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketTransport.ts
@@ -15,7 +15,7 @@ export class SkillWebSocketTransport implements ISkillTransport {
     private streamingTransportClient!: IStreamingTransportClient;
     private endOfConversation: boolean;
 
-    constructor(
+    public constructor(
         skillManifest: ISkillManifest,
         appCredentials: MicrosoftAppCredentials,
         streamingTransportClient?: IStreamingTransportClient
@@ -35,11 +35,9 @@ export class SkillWebSocketTransport implements ISkillTransport {
         activity: Partial<Activity>,
         tokenRequestHandler?: TokenRequestHandler|undefined
     ): Promise<boolean> {
-        if (!this.streamingTransportClient) {
+        if (this.streamingTransportClient === undefined) {
             // acquire AAD token
             MicrosoftAppCredentials.trustServiceUrl(this.skillManifest.endpoint);
-            const token: string = await this.appCredentials.getToken();
-
             // put AAD token in the header
             // MISSING Client doesn't has ctor with headers
 
@@ -73,7 +71,7 @@ export class SkillWebSocketTransport implements ISkillTransport {
     }
 
     public disconnect(): void {
-        if (this.streamingTransportClient) {
+        if (this.streamingTransportClient !== undefined) {
             this.streamingTransportClient.disconnect();
         }
     }

--- a/lib/typescript/botbuilder-skills/tslint.json
+++ b/lib/typescript/botbuilder-skills/tslint.json
@@ -1,27 +1,41 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended",
-        "tslint-microsoft-contrib"
-    ],
-    "linterOptions":{
-      "exclude": [
-        "src/resources/*"
-      ]
-    },
-    "rules": {
-      "function-name": [ true,
-        {
-          "static-method-regex":"^[a-z][\\w\\d]+$"
-        }
-      ],
-      "linebreak-style": false,
-      "member-ordering": false,
-      "no-relative-imports": false,
-      "export-name": false,
-      "completed-docs": false
-    },
-    "rulesDirectory": [
-      "tslint-microsoft-contrib"
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-microsoft-contrib"
+  ],
+  "linterOptions": {
+    "exclude": [
+      "src/resources/*"
     ]
-  }
+  },
+  "rules": {
+    "function-name": [
+      true,
+      {
+        "static-method-regex": "^[a-z][\\w\\d]+$"
+      }
+    ],
+    "strict-boolean-expressions": [
+      true,
+      "allow-undefined-union",
+      "allow-null-union",
+      "allow-mix",
+      "allow-string",
+      "ignore-rhs"
+    ],
+    "linebreak-style": false,
+    "completed-docs": false,
+    "no-relative-imports": false,
+    "export-name": false,
+    "member-ordering": false,
+    "no-use-before-declare": false,
+    "no-function-constructor-with-string-args": false,
+    "no-reserved-keywords": false,
+    "no-increment-decrement": false,
+    "no-unnecessary-bind": false
+  },
+  "rulesDirectory": [
+    "tslint-microsoft-contrib"
+  ]
+}

--- a/lib/typescript/botbuilder-solutions/.eslintignore
+++ b/lib/typescript/botbuilder-solutions/.eslintignore
@@ -1,0 +1,1 @@
+src/resources/General.ts

--- a/lib/typescript/botbuilder-solutions/.eslintrc.js
+++ b/lib/typescript/botbuilder-solutions/.eslintrc.js
@@ -1,0 +1,33 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',  // Specifies the ESLint parser
+    plugins: [
+        '@typescript-eslint',
+        '@typescript-eslint/tslint'
+    ],
+    extends: [
+        'plugin:@typescript-eslint/recommended'
+    ],
+    parserOptions: {
+        ecmaVersion: 2018,  // Allows for the parsing of modern ECMAScript features
+        sourceType: 'module',  // Allows for the use of imports
+        project: './tsconfig.json'
+    },
+    rules: {
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['error', {
+          'args': 'none'
+        }],
+        '@typescript-eslint/no-use-before-define': 'off',
+        '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/no-inferrable-types': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/interface-name-prefix': [ 'error', 'always' ],
+        '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
+        '@typescript-eslint/tslint/config': [
+            'warn',
+            {
+                lintFile: './tslint.json'
+            }
+        ]
+    },
+};

--- a/lib/typescript/botbuilder-solutions/package.json
+++ b/lib/typescript/botbuilder-solutions/package.json
@@ -11,7 +11,7 @@
         "copy-templates": "copyfiles --up 1 \"./src/**/*.json\" \"./lib\"",
         "prebuild": "npm run lint",
         "build": "tsc --p tsconfig.json && npm run copy-templates",
-        "lint": "tslint -t vso ./src/**/*.ts",
+        "lint": "eslint ./src/**/*.ts",
         "test": "mocha",
         "coverage": "nyc mocha",
         "test-coverage-ci": "nyc --reporter=cobertura mocha --reporter mocha-junit-reporter"
@@ -36,14 +36,18 @@
         "@microsoft/recognizers-text-choice": "^1.1.4"
     },
     "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^1.10.2",
+        "@typescript-eslint/eslint-plugin-tslint": "^1.10.2",
+        "@typescript-eslint/parser": "^1.10.2",
         "copyfiles": "^2.1.0",
+        "eslint": "^5.16.0",
         "mocha": "^6.1.4",
         "mocha-junit-reporter": "^1.22.0",
         "nyc": "^14.1.1",
         "replace": "^1.0.0",
         "rimraf": "^2.6.2",
         "tslint": "^5.12.1",
-        "tslint-microsoft-contrib": "6.0.0",
+        "tslint-microsoft-contrib": "^6.2.0",
         "typescript": "3.4.5"
     },
     "env": {

--- a/lib/typescript/botbuilder-solutions/src/dialogs/eventPrompt.ts
+++ b/lib/typescript/botbuilder-solutions/src/dialogs/eventPrompt.ts
@@ -13,12 +13,12 @@ export class EventPrompt extends ActivityPrompt {
     /**
      * EventPrompt
      */
-    constructor(dialogId: string, eventName: string, validator: PromptValidator<Activity>) {
+    public constructor(dialogId: string, eventName: string, validator: PromptValidator<Activity>) {
         super(dialogId, validator);
         this.eventName = eventName;
     }
 
-    protected onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {
+    protected async onRecognize(context: TurnContext, state: object, options: PromptOptions): Promise<PromptRecognizerResult<Activity>> {
         const result: PromptRecognizerResult<Activity> = { succeeded: false };
         const activity: Activity = context.activity;
 

--- a/lib/typescript/botbuilder-solutions/src/dialogs/interruptableDialog.ts
+++ b/lib/typescript/botbuilder-solutions/src/dialogs/interruptableDialog.ts
@@ -12,7 +12,7 @@ export abstract class InterruptableDialog extends ComponentDialog {
     public primaryDialogName: string;
 
     // Constructor
-    constructor(dialogId: string, telemetryClient: BotTelemetryClient) {
+    public constructor(dialogId: string, telemetryClient: BotTelemetryClient) {
         super(dialogId);
         this.primaryDialogName = dialogId;
         this.telemetryClient = telemetryClient;

--- a/lib/typescript/botbuilder-solutions/src/dialogs/routerDialog.ts
+++ b/lib/typescript/botbuilder-solutions/src/dialogs/routerDialog.ts
@@ -12,7 +12,7 @@ import { InterruptionAction } from './interruptionAction';
 
 export abstract class RouterDialog extends InterruptableDialog {
     // Constructor
-    constructor(dialogId: string, telemetryClient: BotTelemetryClient) {
+    public constructor(dialogId: string, telemetryClient: BotTelemetryClient) {
         super(dialogId, telemetryClient);
     }
 
@@ -99,7 +99,7 @@ export abstract class RouterDialog extends InterruptableDialog {
      * @param innerDC - The dialog context for the component.
      * @returns A Promise representing the asynchronous operation.
      */
-    protected onEvent(innerDc: DialogContext): Promise<void> {
+    protected async onEvent(innerDc: DialogContext): Promise<void> {
         return Promise.resolve();
     }
 
@@ -108,7 +108,7 @@ export abstract class RouterDialog extends InterruptableDialog {
      * @param innerDC - The dialog context for the component.
      * @returns A Promise representing the asynchronous operation.
      */
-    protected onSystemMessage(innerDc: DialogContext): Promise<void> {
+    protected async onSystemMessage(innerDc: DialogContext): Promise<void> {
         return Promise.resolve();
     }
 
@@ -117,11 +117,11 @@ export abstract class RouterDialog extends InterruptableDialog {
      * @param innerDC - The dialog context for the component.
      * @returns A Promise representing the asynchronous operation.
      */
-    protected onStart(innerDc: DialogContext): Promise<void> {
+    protected async onStart(innerDc: DialogContext): Promise<void> {
         return Promise.resolve();
     }
 
-    protected onInterruptDialog(dc: DialogContext): Promise<InterruptionAction> {
+    protected async onInterruptDialog(dc: DialogContext): Promise<InterruptionAction> {
         return Promise.resolve(InterruptionAction.NoAction);
     }
 }

--- a/lib/typescript/botbuilder-solutions/src/extensions/activityExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/activityExtensions.ts
@@ -60,7 +60,7 @@ export namespace ActivityExtensions {
             case 'msteams': {
                 if (activity.type === ActivityTypes.ConversationUpdate) {
                     if (activity.membersAdded !== undefined &&
-                        activity.membersAdded.some((m: ChannelAccount) => m.id === activity.recipient.id)) {
+                        activity.membersAdded.some((m: ChannelAccount): boolean => m.id === activity.recipient.id)) {
                         // When bot is added to the conversation (triggers start only once per conversation)
                         return true;
                     }

--- a/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/dateTimeExtensions.ts
@@ -9,22 +9,22 @@ import i18next from 'i18next';
 export namespace DateTimeExtensions {
     let currentLocale: string;
 
-    function importLocale(locale: string): void {
+    async function importLocale(locale: string): Promise<void> {
         try {
             const localeImport: string = locale === 'zh' ?
-            `../resources/customizeLocale/zh` :
-            `dayjs/locale/${locale}`;
-            import(localeImport);
+                `../resources/customizeLocale/zh` :
+                `dayjs/locale/${locale}`;
+            await import(localeImport);
         } catch (err) {
             throw new Error(`There was an error during the import of the locale:${locale}, Error:${err}`);
         }
     }
 
-    export function toSpeechDateString(date: Date, includePrefix: boolean = false): string {
+    export async function toSpeechDateString(date: Date, includePrefix: boolean = false): Promise<string> {
         const locale: string = i18next.language;
         if (currentLocale !== locale) {
             currentLocale = locale;
-            importLocale(locale);
+            await importLocale(locale);
         }
         const utcDate: Date = new Date();
         utcDate.setHours(date.getHours());

--- a/lib/typescript/botbuilder-solutions/src/extensions/listExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/listExtensions.ts
@@ -21,7 +21,7 @@ export namespace ListExtensions {
         let separator: string = '';
 
         const listCount: number = list.length;
-        list.forEach((listItem: T, index: number) => {
+        list.forEach((listItem: T, index: number): void => {
             if (typeof listItem === 'string') {
                 speech = speech.concat(listItem);
             } else {
@@ -30,7 +30,7 @@ export namespace ListExtensions {
             if (listCount > 1) {
                 if (index === listCount - 2) {
                     separator = i18next.t('common:separatorFormat')
-                    .replace('{0}', finalSeparator);
+                        .replace('{0}', finalSeparator);
                 } else {
                     separator = index !== listCount - 1 ? ', ' : '';
                 }

--- a/lib/typescript/botbuilder-solutions/src/localesUtils.ts
+++ b/lib/typescript/botbuilder-solutions/src/localesUtils.ts
@@ -6,16 +6,17 @@ export namespace Locales {
     const defaultLocalesPath: string = join(__dirname, 'locales');
 
     export async function addResourcesFromPath(instance: i18next.i18n, namespace: string, localesPath?: string): Promise<void> {
-        if (!instance) { throw new Error(('Missing parameter.  \'instance\' is required')); }
-        if (!namespace) { throw new Error(('Missing parameter.  \'namespace\' is required')); }
+        if (instance === undefined) { throw new Error(('Missing parameter.  \'instance\' is required')); }
+        if (namespace === undefined) { throw new Error(('Missing parameter.  \'namespace\' is required')); }
         if (localesPath && !isAbsolute(localesPath)) { throw new Error(('\'localesPath\' must be an absolute path')); }
 
         const localesDir: string = localesPath || defaultLocalesPath;
         const files: string[] = readdirSync(localesDir)
-            .filter((file: string) => file.endsWith('.json'));
-        files.forEach((file: string) => {
+            .filter((file: string): boolean => file.endsWith('.json'));
+        files.forEach((file: string): void => {
             const language: string = basename(file, '.json');
             const languagePath: string = join(localesDir, file);
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             const resource: Object = JSON.parse(readFileSync(languagePath, 'utf8'));
             instance.addResourceBundle(language, namespace, resource, true, false);
         });

--- a/lib/typescript/botbuilder-solutions/src/middleware/consoleOutputMiddleware.ts
+++ b/lib/typescript/botbuilder-solutions/src/middleware/consoleOutputMiddleware.ts
@@ -18,10 +18,11 @@ export class ConsoleOutputMiddleware implements Middleware {
         return messageActivity.text === undefined ? <string>messageActivity.speak : messageActivity.text;
     }
 
-    private async onSendActivities(context: TurnContext,
-                                   activities: Partial<Activity>[],
-                                   next: () => Promise<ResourceResponse[]>): Promise<ResourceResponse[]> {
-        activities.forEach((response: Partial<Activity>) => {
+    private async onSendActivities(
+        context: TurnContext,
+        activities: Partial<Activity>[],
+        next: () => Promise<ResourceResponse[]>): Promise<ResourceResponse[]> {
+        activities.forEach((response: Partial<Activity>): void => {
             this.logActivity('', response);
         });
 

--- a/lib/typescript/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
+++ b/lib/typescript/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
@@ -32,7 +32,7 @@ export class ContentModeratorMiddleware implements Middleware {
      * @param subscriptionKey Azure Service Key.
      * @param region Azure Service Region.
      */
-    constructor(subscriptionKey: string, region: string) {
+    public constructor(subscriptionKey: string, region: string) {
         this.subscriptionKey = subscriptionKey;
         this.region = region;
     }

--- a/lib/typescript/botbuilder-solutions/src/middleware/eventDebuggerMiddleware.ts
+++ b/lib/typescript/botbuilder-solutions/src/middleware/eventDebuggerMiddleware.ts
@@ -7,7 +7,7 @@ import { Middleware, TurnContext } from 'botbuilder';
 import { Activity, ActivityTypes } from 'botframework-schema';
 
 export class EventDebuggerMiddleware implements Middleware {
-    public onTurn(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {
+    public async onTurn(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {
         const activity: Activity = turnContext.activity;
 
         if (activity.type === ActivityTypes.Message) {
@@ -16,6 +16,7 @@ export class EventDebuggerMiddleware implements Middleware {
 
             if (text && text.startsWith('/event:')) {
                 const json: string = text.substr('/event:'.length);
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 const body: Activity = JSON.parse(json);
 
                 turnContext.activity.type = ActivityTypes.Event;
@@ -24,20 +25,20 @@ export class EventDebuggerMiddleware implements Middleware {
             }
 
             if (value && value.includes('event')) {
+                // eslint-disable-next-line @typescript-eslint/tslint/config
                 const body: { event: { name: string; text: string; value: string }} = JSON.parse(value);
 
                 turnContext.activity.type = ActivityTypes.Event;
-
-                if (body.event && body.event.name) {
-                    turnContext.activity.name = body.event.name;
-                }
-
-                if (body.event && body.event.text) {
-                    turnContext.activity.text = body.event.text;
-                }
-
-                if (body.event && body.event.value) {
-                    turnContext.activity.value = body.event.value;
+                if (body.event !== undefined) {
+                    if (body.event.name !== undefined) {
+                        turnContext.activity.name = body.event.name;
+                    }
+                    if (body.event.text !== undefined) {
+                        turnContext.activity.text = body.event.text;
+                    }
+                    if (body.event.value !== undefined) {
+                        turnContext.activity.value = body.event.value;
+                    }
                 }
             }
         }

--- a/lib/typescript/botbuilder-solutions/src/middleware/setLocaleMiddleware.ts
+++ b/lib/typescript/botbuilder-solutions/src/middleware/setLocaleMiddleware.ts
@@ -12,7 +12,7 @@ import i18next from 'i18next';
 export class SetLocaleMiddleware implements Middleware {
     private readonly defaultLocale: string;
 
-    constructor(defaultLocale: string) {
+    public constructor(defaultLocale: string) {
         this.defaultLocale = defaultLocale;
     }
 

--- a/lib/typescript/botbuilder-solutions/src/proactive/proactiveState.ts
+++ b/lib/typescript/botbuilder-solutions/src/proactive/proactiveState.ts
@@ -6,7 +6,7 @@
 import { BotState, Storage } from 'botbuilder';
 
 export class ProactiveState extends BotState {
-    constructor(storage: Storage) {
-        super(storage, () => Promise.resolve('ProactiveState'));
+    public constructor(storage: Storage) {
+        super(storage, (): Promise<string> => Promise.resolve('ProactiveState'));
     }
 }

--- a/lib/typescript/botbuilder-solutions/src/proactive/proactiveStateMiddleware.ts
+++ b/lib/typescript/botbuilder-solutions/src/proactive/proactiveStateMiddleware.ts
@@ -17,7 +17,7 @@ export class ProactiveStateMiddleware implements Middleware {
     private readonly proactiveState: ProactiveState;
     private readonly proactiveStateAccessor: StatePropertyAccessor<ProactiveModel>;
 
-    constructor(proactiveState: ProactiveState) {
+    public constructor(proactiveState: ProactiveState) {
         this.proactiveState = proactiveState;
         this.proactiveStateAccessor = this.proactiveState.createProperty<ProactiveModel>(ProactiveModel.name);
     }
@@ -32,7 +32,6 @@ export class ProactiveStateMiddleware implements Middleware {
 
             const hashedUserId: string = MD5Util.computeHash(activity.from.id);
             const conversationReference: Partial<ConversationReference> = TurnContext.getConversationReference(activity);
-            const proactiveData: ProactiveData = { conversation: conversationReference };
 
             if (proactiveState[hashedUserId] !== undefined) {
                 data = { conversation: conversationReference };

--- a/lib/typescript/botbuilder-solutions/src/responses/card.ts
+++ b/lib/typescript/botbuilder-solutions/src/responses/card.ts
@@ -7,12 +7,12 @@ import { ICardData } from './cardData';
 
 export class Card {
 
-    constructor(name: string, data : ICardData) {
+    public constructor(name: string, data: ICardData) {
         this.name = name;
         this.data = data;
     }
 
     public name: string = '';
 
-    public data : ICardData = '';
+    public data: ICardData = '';
 }

--- a/lib/typescript/botbuilder-solutions/src/responses/cardData.ts
+++ b/lib/typescript/botbuilder-solutions/src/responses/cardData.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// tslint:disable-next-line:no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/tslint/config
 export interface ICardData {
 
 }

--- a/lib/typescript/botbuilder-solutions/src/responses/responseManager.ts
+++ b/lib/typescript/botbuilder-solutions/src/responses/responseManager.ts
@@ -21,14 +21,14 @@ export class ResponseManager {
     private static readonly simpleTokensRegex: RegExp = /\{(\w+)\}/g;
     private static readonly complexTokensRegex: RegExp = /\{[^{\}]+(?=})\}/g;
 
-    constructor(locales: string[], responseTemplates: IResponseIdCollection[]) {
+    public constructor(locales: string[], responseTemplates: IResponseIdCollection[]) {
         this.jsonResponses = new Map();
 
-        responseTemplates.forEach((responseTemplate: IResponseIdCollection) => {
+        responseTemplates.forEach((responseTemplate: IResponseIdCollection): void => {
             const resourceName: string = responseTemplate.name;
             const resource: string = responseTemplate.pathToResource || join(__dirname, '..', 'resources');
             this.loadResponses(resourceName, resource);
-            locales.forEach((locale: string) => {
+            locales.forEach((locale: string): void => {
                 try {
                     this.loadResponses(resourceName, resource, locale);
                 } catch {
@@ -71,7 +71,7 @@ export class ResponseManager {
         } else {
             const attachments: Attachment[] = [];
 
-            cards.forEach((card: Card) => {
+            cards.forEach((card: Card): void => {
                 const json: string = this.loadCardJson(card.name, locale, resourcePath);
                 attachments.push(this.buildCardAttachment(json, card.data));
             });
@@ -99,7 +99,7 @@ export class ResponseManager {
         } else {
             const attachments: Attachment[] = [];
 
-            cards.forEach((card: Card) => {
+            cards.forEach((card: Card): void => {
                 const json: string = this.loadCardJson(card.name, locale, resourcePath);
                 attachments.push(this.buildCardAttachment(json, card.data));
             });
@@ -117,26 +117,28 @@ export class ResponseManager {
      * @param containerItems Card list which will be injected to target container.
      * @returns An Activity.
      */
-    public getCardResponseWithContainer(templateId: string,
-                                        card: Card,
-                                        tokens?: Map<string, string>,
-                                        containerName?: string,
-                                        containerItems?: Card[]): Partial<Activity> {
+    public getCardResponseWithContainer(
+        templateId: string,
+        card: Card,
+        tokens?: Map<string, string>,
+        containerName?: string,
+        containerItems?: Card[]): Partial<Activity> {
         const locale: string = i18next.language;
         const resourcePath: string = join(__dirname, '..', 'resources', 'cards');
         const json: string = this.loadCardJson(card.name, locale, resourcePath);
 
         const emailOverviewCard: IAdaptiveCard = this.buildCard(json, card.data);
         if (containerName && emailOverviewCard.body) {
-            const itemContainer: ICardElement|undefined = emailOverviewCard.body.find((item: ICardElement) => {
+            const itemContainer: ICardElement|undefined = emailOverviewCard.body.find((item: ICardElement): boolean => {
                 return item.type === 'Container' && item.id === containerName;
             });
 
             if (itemContainer && containerItems) {
-                containerItems.forEach((cardItem: Card) => {
+                containerItems.forEach((cardItem: Card): void => {
                     const itemJson: string = this.loadCardJson(cardItem.name, locale, resourcePath);
                     const itemCard: IAdaptiveCard = this.buildCard(itemJson, cardItem.data);
                     if (itemCard.body && itemCard.body[0]) {
+                        // eslint-disable-next-line @typescript-eslint/tslint/config
                         const items: ICardElement[] = itemCard.body[0].items;
                         items.push(itemContainer);
                     }
@@ -234,17 +236,18 @@ export class ResponseManager {
         }
 
         try {
+            // eslint-disable-next-line @typescript-eslint/tslint/config
             const content: { [key: string]: Object } = JSON.parse(this.jsonFromFile(jsonPath));
 
             const localeResponses: Map<string, ResponseTemplate> = this.jsonResponses.get(localeKey) || new Map<string, ResponseTemplate>();
 
             Object.entries(content)
-            .forEach((val: [string, Object]) => {
-                const key: string = val[0];
-                const value: ITemplate = <ITemplate>val[1];
-                const template: ResponseTemplate = Object.assign(new ResponseTemplate(), value);
-                localeResponses.set(key, template);
-            });
+                .forEach((val: [string, Object]): void => {
+                    const key: string = val[0];
+                    const value: ITemplate = <ITemplate>val[1];
+                    const template: ResponseTemplate = Object.assign(new ResponseTemplate(), value);
+                    localeResponses.set(key, template);
+                });
 
             this.jsonResponses.set(localeKey, localeResponses);
         } catch (err) {
@@ -284,13 +287,13 @@ export class ResponseManager {
             inputHint: template.inputHint
         };
 
-        if (template.suggestedActions && template.suggestedActions.length > 0) {
+        if (template.suggestedActions !== undefined && template.suggestedActions.length > 0) {
             activity.suggestedActions = {
                 actions: [],
                 to: []
             };
 
-            template.suggestedActions.forEach((action: string) => {
+            template.suggestedActions.forEach((action: string): void => {
                 if (activity.suggestedActions) {
                     activity.suggestedActions.actions.push({
                         type: ActionTypes.ImBack,
@@ -337,7 +340,7 @@ export class ResponseManager {
             const tokens: Map<string, string> = new Map<string, string>();
             // get property names from cardData
             Object.entries(data)
-                .forEach((entry: [string, string]) => {
+                .forEach((entry: [string, string]): void => {
                     if (!tokens.has(entry[0])) {
                         tokens.set(entry[0], entry[1]);
                     }
@@ -356,6 +359,7 @@ export class ResponseManager {
         }
 
         // Deserialize/Serialize logic is needed to prevent JSON exception in prompts
+        // eslint-disable-next-line @typescript-eslint/tslint/config
         return JSON.parse(jsonOut);
     }
 

--- a/lib/typescript/botbuilder-solutions/src/responses/speechUtility.ts
+++ b/lib/typescript/botbuilder-solutions/src/responses/speechUtility.ts
@@ -25,9 +25,10 @@ export enum ReadPreference {
 export namespace SpeechUtility {
     export const breakString: string = '<break/>';
 
-    export function listToSpeechReadyString(toProcess: PromptOptions|Activity,
-                                            readOrder: ReadPreference = ReadPreference.Enumeration,
-                                            maxSize: number = 4): string {
+    export function listToSpeechReadyString(
+        toProcess: PromptOptions|Activity,
+        readOrder: ReadPreference = ReadPreference.Enumeration,
+        maxSize: number = 4): string {
 
         let speakStrings: string[] = [];
         let parent: string = '';
@@ -35,14 +36,15 @@ export namespace SpeechUtility {
         if ((<PromptOptions>toProcess).choices !== undefined) {
             const selectOption: PromptOptions = <PromptOptions>toProcess;
             const choices: (string|Choice)[] = selectOption.choices || [];
-            speakStrings = choices.map((value: string|Choice) => typeof(value) === 'string' ? value : value.value);
+            speakStrings = choices.map((value: string|Choice): string => typeof(value) === 'string' ? value : value.value);
             parent = typeof(selectOption.prompt) === 'string'
                 ? (selectOption.prompt || '')
                 : (selectOption.prompt ? (selectOption.prompt.text || '') : '');
         } else {
             const activity: Activity = <Activity>toProcess;
             const attachments: Attachment[] = activity.attachments || [];
-            speakStrings = attachments.map((value: Attachment) => value.content.speak);
+            // eslint-disable-next-line @typescript-eslint/tslint/config
+            speakStrings = attachments.map((value: Attachment): string => <string> value.content.speak);
             parent = activity.speak || '';
         }
 

--- a/lib/typescript/botbuilder-solutions/src/skills/skillDefinition.ts
+++ b/lib/typescript/botbuilder-solutions/src/skills/skillDefinition.ts
@@ -19,7 +19,7 @@ export class SkillDefinition extends ConnectedService {
 
     public configuration: Map<string, string> = new Map();
 
-    constructor() {
+    public constructor() {
         super(undefined, ServiceTypes.Generic);
     }
 }

--- a/lib/typescript/botbuilder-solutions/src/skills/skillEvent.ts
+++ b/lib/typescript/botbuilder-solutions/src/skills/skillEvent.ts
@@ -13,7 +13,7 @@ export class SkillEvent extends ConnectedService {
 
     public parameters: Map<string, string> = new Map();
 
-    constructor() {
+    public constructor() {
         super(undefined, ServiceTypes.Generic);
     }
 }

--- a/lib/typescript/botbuilder-solutions/src/skills/skillRouter.ts
+++ b/lib/typescript/botbuilder-solutions/src/skills/skillRouter.ts
@@ -7,9 +7,9 @@ import { SkillDefinition } from './skillDefinition';
 
 export class SkillRouter {
 
-    private registeredSkills: SkillDefinition[];
+    private readonly registeredSkills: SkillDefinition[];
 
-    constructor(registeredSkills: SkillDefinition[]) {
+    public constructor(registeredSkills: SkillDefinition[]) {
         // Retrieve any Skills that have been registered with the Bot
         this.registeredSkills = registeredSkills;
     }
@@ -21,7 +21,7 @@ export class SkillRouter {
         if (this.registeredSkills !== undefined) {
             // Identify a skill by taking the LUIS model name identified by the dispatcher and matching to the skill luis model name
             // Bug raised on dispatcher to move towards LuisModelId instead perhaps?
-            matchedSkill = <SkillDefinition>this.registeredSkills.find((s: SkillDefinition) => s.dispatchIntent === skillName);
+            matchedSkill = <SkillDefinition>this.registeredSkills.find((s: SkillDefinition): boolean => s.dispatchIntent === skillName);
 
             return matchedSkill;
         } else {

--- a/lib/typescript/botbuilder-solutions/src/taskExtensions/backgroundTaskQueue.ts
+++ b/lib/typescript/botbuilder-solutions/src/taskExtensions/backgroundTaskQueue.ts
@@ -13,16 +13,16 @@ export interface IBackgroundTaskQueue {
 export class BackgroundTaskQueue implements IBackgroundTaskQueue {
     private readonly queueExecutor: PQueue;
 
-    constructor() {
+    public constructor() {
         this.queueExecutor = new PQueue({
             concurrency: 1,
             autoStart: true
         });
     }
 
-    public queueBackgroundWorkItem(workItem: WorkItemFunc): void {
-        if (!workItem) { throw new Error('Missing parameter.  workItem is required'); }
+    public async queueBackgroundWorkItem(workItem: WorkItemFunc): Promise<void> {
+        if (workItem === undefined) { throw new Error('Missing parameter.  workItem is required'); }
 
-        this.queueExecutor.add(workItem);
+        await this.queueExecutor.add(workItem);
     }
 }

--- a/lib/typescript/botbuilder-solutions/src/util/configData.ts
+++ b/lib/typescript/botbuilder-solutions/src/util/configData.ts
@@ -13,7 +13,7 @@ export class ConfigData {
 
     public static instance: ConfigData = new ConfigData();
 
-    constructor() {
+    public constructor() {
         this.maxReadSize = CommonUtil.maxReadSize;
         this.maxDisplaySize = CommonUtil.maxDisplaySize;
     }
@@ -33,4 +33,4 @@ export class ConfigData {
     public set maxDisplaySize(value: number) {
         this._maxDisplaySize = Math.min(value, CommonUtil.maxDisplaySize);
     }
- }
+}

--- a/lib/typescript/botbuilder-solutions/src/util/confirmRecognizerHelper.ts
+++ b/lib/typescript/botbuilder-solutions/src/util/confirmRecognizerHelper.ts
@@ -19,7 +19,7 @@ export namespace ConfirmRecognizerHelper {
 
             if (results.length > 0) {
                 const first: ModelResult = results[0];
-                const value: boolean = <boolean>first.resolution[valueKey].toString();
+                const value: boolean = <boolean>first.resolution[valueKey];
                 if (value !== undefined) {
                     result = {
                         succeeded: true,

--- a/lib/typescript/botbuilder-solutions/test/dateTimeExtensions.test.js
+++ b/lib/typescript/botbuilder-solutions/test/dateTimeExtensions.test.js
@@ -41,7 +41,7 @@ describe("date time extensions", function() {
     });
 
     describe("using explicit value", function() {
-        it("validate date time extension outputs from random dates", function(){
+        describe("validate date time extension outputs from random dates", function(){
             // Setup test data
             const today = new Date();
             const tomorrow = new Date();
@@ -144,18 +144,19 @@ describe("date time extensions", function() {
             testData.push(dateEsMxSpecificDatePluralHour);
             
             testData.forEach(data => {
-                i18next.changeLanguage(data.culture.substring(0, 2));
-
-                strictEqual(data.expectedDateSpeech, DateTimeExtensions.toSpeechDateString(data.inputDateTime));
-                strictEqual(data.expectedDateSpeechWithSuffix, DateTimeExtensions.toSpeechDateString(data.inputDateTime, true));
-                strictEqual(data.expectedTimeSpeech , DateTimeExtensions.toSpeechTimeString(data.inputDateTime));
-                strictEqual(data.expectedTimeSpeechWithSuffix, DateTimeExtensions.toSpeechTimeString(data.inputDateTime, true));
+                it(`should resolve ${data.expectedDateSpeech} ${data.expectedTimeSpeech} in ${data.culture}`, async function() {
+                    await i18next.changeLanguage(data.culture.substring(0, 2));
+                    strictEqual(data.expectedDateSpeech, await DateTimeExtensions.toSpeechDateString(data.inputDateTime));
+                    strictEqual(data.expectedDateSpeechWithSuffix, await DateTimeExtensions.toSpeechDateString(data.inputDateTime, true));
+                    strictEqual(data.expectedTimeSpeech , DateTimeExtensions.toSpeechTimeString(data.inputDateTime));
+                    strictEqual(data.expectedTimeSpeechWithSuffix, DateTimeExtensions.toSpeechTimeString(data.inputDateTime, true));
+                });
             });
         });
     });    
 
     describe("using resource values", function() {
-        it("validate the outputs for each culture", function(){
+        describe("validate the outputs for each culture", function(){
             const cultures = [
                 "en-US",
                 "es-ES",
@@ -166,22 +167,24 @@ describe("date time extensions", function() {
                 "fr"
             ];
             cultures.forEach(culture => {
-                i18next.changeLanguage(culture.substring(0, 2));
-                const locale = i18next.language;
-                const today = new Date();
-                const tomorrow = new Date();
-                tomorrow.setDate(today.getDate() + 1);
-                const otherDate = new Date();
-                otherDate.setDate(today.getDate() + 3);
-                
-                strictEqual(i18next.t("common:today"), DateTimeExtensions.toSpeechDateString(today));
-                strictEqual(i18next.t("common:tomorrow"), DateTimeExtensions.toSpeechDateString(tomorrow));
-                strictEqual(dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat")), DateTimeExtensions.toSpeechDateString(otherDate));
-                if(i18next.t("common:spokenDatePrefix") === ""){
-                    strictEqual(`${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
-                } else {
-                    strictEqual(`${i18next.t("common:spokenDatePrefix")} ${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, DateTimeExtensions.toSpeechDateString(otherDate, true));
-                }
+                it(`should resolve today and tomorrow in ${culture}`, async function() {
+                    await i18next.changeLanguage(culture.substring(0, 2));
+                    const locale = i18next.language;
+                    const today = new Date();
+                    const tomorrow = new Date();
+                    tomorrow.setDate(today.getDate() + 1);
+                    const otherDate = new Date();
+                    otherDate.setDate(today.getDate() + 3);
+                    
+                    strictEqual(i18next.t("common:today"), await DateTimeExtensions.toSpeechDateString(today));
+                    strictEqual(i18next.t("common:tomorrow"), await DateTimeExtensions.toSpeechDateString(tomorrow));
+                    strictEqual(dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat")), await DateTimeExtensions.toSpeechDateString(otherDate));
+                    if(i18next.t("common:spokenDatePrefix") === ""){
+                        strictEqual(`${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, await DateTimeExtensions.toSpeechDateString(otherDate, true));
+                    } else {
+                        strictEqual(`${i18next.t("common:spokenDatePrefix")} ${dayjs(otherDate).locale(locale).format(i18next.t("common:spokenDateFormat"))}`, await DateTimeExtensions.toSpeechDateString(otherDate, true));
+                    }
+                });
             });
         });
     });

--- a/lib/typescript/botbuilder-solutions/tslint.json
+++ b/lib/typescript/botbuilder-solutions/tslint.json
@@ -1,27 +1,41 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended",
-        "tslint-microsoft-contrib"
-    ],
-    "linterOptions":{
-      "exclude": [
-        "src/resources/*"
-      ]
-    },
-    "rules": {
-      "function-name": [ true,
-        {
-          "static-method-regex":"^[a-z][\\w\\d]+$"
-        }
-      ],
-      "linebreak-style": false,
-      "member-ordering": false,
-      "no-relative-imports": false,
-      "export-name": false,
-      "completed-docs": false
-    },
-    "rulesDirectory": [
-      "tslint-microsoft-contrib"
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-microsoft-contrib"
+  ],
+  "linterOptions": {
+    "exclude": [
+      "src/resources/*"
     ]
-  }
+  },
+  "rules": {
+    "function-name": [
+      true,
+      {
+        "static-method-regex": "^[a-z][\\w\\d]+$"
+      }
+    ],
+    "strict-boolean-expressions": [
+      true,
+      "allow-undefined-union",
+      "allow-null-union",
+      "allow-mix",
+      "allow-string",
+      "ignore-rhs"
+    ],
+    "linebreak-style": false,
+    "completed-docs": false,
+    "no-relative-imports": false,
+    "export-name": false,
+    "member-ordering": false,
+    "no-use-before-declare": false,
+    "no-function-constructor-with-string-args": false,
+    "no-reserved-keywords": false,
+    "no-increment-decrement": false,
+    "no-unnecessary-bind": false
+  },
+  "rulesDirectory": [
+    "tslint-microsoft-contrib"
+  ]
+}

--- a/lib/typescript/common/config/rush/npm-shrinkwrap.json
+++ b/lib/typescript/common/config/rush/npm-shrinkwrap.json
@@ -141,9 +141,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -248,13 +248,16 @@
     },
     "@rush-temp/botbuilder-skills": {
       "version": "file:projects/botbuilder-skills.tgz",
-      "integrity": "sha512-WzDU3i8/Fqf9XSFHF+AlfGSQ6cvbxlHvhjjoHlLOoPzGyX28SQgYEyOAL7B7uWp5vz1GpxaMrYfN7kGITG+C2w==",
+      "integrity": "sha512-e/49rLYEiC2SKmYq6ayHUw7JDVyCZVjDJV/fStxZqOTN5CZfhmkLU7p/47jhjIdmU+TcjfC6fiWjZYqbikoc0w==",
       "requires": {
         "@azure/cognitiveservices-luis-authoring": "^2.1.0",
         "@azure/ms-rest-js": "1.8.7",
         "@types/nock": "^10.0.3",
         "@types/restify": "^7.2.4",
         "@types/uuid": "^3.4.4",
+        "@typescript-eslint/eslint-plugin": "^1.10.2",
+        "@typescript-eslint/eslint-plugin-tslint": "^1.10.2",
+        "@typescript-eslint/parser": "^1.10.2",
         "botbuilder": "^4.4.0",
         "botbuilder-ai": "^4.4.0",
         "botbuilder-azure": "^4.4.0",
@@ -264,6 +267,7 @@
         "botframework-connector": "^4.4.0",
         "botframework-schema": "^4.4.0",
         "copyfiles": "^2.1.0",
+        "eslint": "^5.16.0",
         "i18n": "^0.8.3",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "1.5.0",
@@ -277,17 +281,20 @@
         "rimraf": "^2.6.2",
         "supertest": "^4.0.2",
         "tslint": "^5.12.1",
-        "tslint-microsoft-contrib": "6.0.0",
+        "tslint-microsoft-contrib": "^6.2.0",
         "typescript": "3.4.5",
         "uuid": "^3.3.2"
       }
     },
     "@rush-temp/botbuilder-solutions": {
       "version": "file:projects/botbuilder-solutions.tgz",
-      "integrity": "sha512-ttu5YZcV1xJ3uwgqBGc7ayFCPXaF3zIAy9CzNiQVD0TiJMsew/fTWl7BA6thBdzluRI9TGfVENuisMbwrjqmFA==",
+      "integrity": "sha512-wNGR6GaTOGO2Y7GQ5/tsxEAyhnzNiJHcXjt1LthuWJRgL71Tka6OUttDejLfLrXZC2P3GIHv+t/0WamMneqR1w==",
       "requires": {
         "@microsoft/recognizers-text": "^1.1.4",
         "@microsoft/recognizers-text-choice": "^1.1.4",
+        "@typescript-eslint/eslint-plugin": "^1.10.2",
+        "@typescript-eslint/eslint-plugin-tslint": "^1.10.2",
+        "@typescript-eslint/parser": "^1.10.2",
         "adaptivecards": "^1.1.3",
         "azure-cognitiveservices-contentmoderator": "^4.0.0",
         "botbuilder": "^4.4.0",
@@ -300,6 +307,7 @@
         "botframework-schema": "^4.4.0",
         "copyfiles": "^2.1.0",
         "dayjs": "^1.8.14",
+        "eslint": "^5.16.0",
         "i18next": "^15.0.6",
         "i18next-node-fs-backend": "^2.1.1",
         "mocha": "^6.1.4",
@@ -310,7 +318,7 @@
         "replace": "^1.0.0",
         "rimraf": "^2.6.2",
         "tslint": "^5.12.1",
-        "tslint-microsoft-contrib": "6.0.0",
+        "tslint-microsoft-contrib": "^6.2.0",
         "typescript": "3.4.5"
       }
     },
@@ -352,6 +360,11 @@
         "@types/node": "*"
       }
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/eslint-visitor-keys/-/@types/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0="
+    },
     "@types/express": {
       "version": "4.17.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.0.tgz",
@@ -372,9 +385,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.6",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.16.6.tgz",
-      "integrity": "sha1-ZtSyns4+L7blqsIjJyMAJCbmUb0=",
+      "version": "4.16.7",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha1-ULpvimkcCKPdn6f7ol7zEz0pgEk=",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -431,9 +444,9 @@
       }
     },
     "@types/node": {
-      "version": "10.14.8",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.8.tgz",
-      "integrity": "sha1-/kRCA+zvEWI0jNbet2xiR3ssxuk="
+      "version": "12.0.10",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-12.0.10.tgz",
+      "integrity": "sha1-Ubq/nH3q3VNDYgBV/Ir/eZXIsDE="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -507,10 +520,70 @@
         "@types/node": "*"
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.11.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/eslint-plugin/-/@typescript-eslint/eslint-plugin-1.11.0.tgz",
+      "integrity": "sha1-hw91LFINsE2202aK90eQJqby+5o=",
+      "requires": {
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/eslint-plugin-tslint": {
+      "version": "1.11.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/eslint-plugin-tslint/-/@typescript-eslint/eslint-plugin-tslint-1.11.0.tgz",
+      "integrity": "sha1-LYN+OpSs9d4MLPqt9mP92422zlw=",
+      "requires": {
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "lodash.memoize": "^4.1.2"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.11.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/experimental-utils/-/@typescript-eslint/experimental-utils-1.11.0.tgz",
+      "integrity": "sha1-WUq+RwkcvqusHW+c/tBtCtmet+M=",
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.11.0",
+        "eslint-scope": "^4.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.11.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/parser/-/@typescript-eslint/parser-1.11.0.tgz",
+      "integrity": "sha1-L21PfmTusefCW0IvjfFNDJ5QjjY=",
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "1.11.0",
+        "@typescript-eslint/typescript-estree": "1.11.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.11.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/typescript-estree/-/@typescript-eslint/typescript-estree-1.11.0.tgz",
+      "integrity": "sha1-t7V4Kqsi5LO22EYzZSyfQeYtN9U=",
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8="
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4="
     },
     "adal-node": {
       "version": "0.1.28",
@@ -560,6 +633,11 @@
         "typechecker": "^4.3.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        },
         "typechecker": {
           "version": "4.7.0",
           "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typechecker/-/typechecker-4.7.0.tgz",
@@ -585,6 +663,11 @@
       "version": "3.2.3",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM="
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -618,13 +701,6 @@
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        }
       }
     },
     "asn1": {
@@ -653,6 +729,11 @@
       "version": "1.1.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k="
     },
     "async": {
       "version": "1.5.2",
@@ -748,9 +829,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.43",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/big-integer/-/big-integer-1.6.43.tgz",
-      "integrity": "sha1-isFb8T6T5QlQCFkGEjPhnY0NmdE="
+      "version": "1.6.44",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/big-integer/-/big-integer-1.6.44.tgz",
+      "integrity": "sha1-TumuX1g5/BGt4zj+oha0UTRUpTk="
     },
     "bignumber.js": {
       "version": "7.2.1",
@@ -773,6 +854,13 @@
         "botframework-connector": "^4.4.0",
         "filenamify": "^2.0.0",
         "fs-extra": "^7.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.10",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.10.tgz",
+          "integrity": "sha1-5JFITGBgr41GHhLsgcDaijKCuN4="
+        }
       }
     },
     "botbuilder-ai": {
@@ -794,6 +882,11 @@
         "url-parse": "^1.4.4"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.14.10",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.10.tgz",
+          "integrity": "sha1-5JFITGBgr41GHhLsgcDaijKCuN4="
+        },
         "request-promise-native": {
           "version": "1.0.5",
           "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
@@ -818,6 +911,13 @@
         "documentdb": "1.14.5",
         "flat": "^4.0.0",
         "semaphore": "^1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.10",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.10.tgz",
+          "integrity": "sha1-5JFITGBgr41GHhLsgcDaijKCuN4="
+        }
       }
     },
     "botbuilder-core": {
@@ -862,6 +962,11 @@
             "lodash.sortby": "^4.7.0",
             "lodash.trimend": "^4.5.1"
           }
+        },
+        "@types/node": {
+          "version": "10.14.10",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.10.tgz",
+          "integrity": "sha1-5JFITGBgr41GHhLsgcDaijKCuN4="
         }
       }
     },
@@ -906,6 +1011,11 @@
             "uuid": "^3.2.1",
             "xml2js": "^0.4.19"
           }
+        },
+        "@types/node": {
+          "version": "10.14.10",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.14.10.tgz",
+          "integrity": "sha1-5JFITGBgr41GHhLsgcDaijKCuN4="
         },
         "jsonwebtoken": {
           "version": "8.0.1",
@@ -982,6 +1092,11 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M="
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/camelcase/-/camelcase-4.1.0.tgz",
@@ -1013,17 +1128,12 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4="
     },
     "charenc": {
       "version": "0.0.2",
@@ -1034,6 +1144,19 @@
       "version": "1.0.2",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "4.1.0",
@@ -1232,6 +1355,11 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -1272,6 +1400,14 @@
       "version": "3.5.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diff/-/diff-3.5.0.tgz",
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "documentdb": {
       "version": "1.14.5",
@@ -1381,6 +1517,11 @@
             "errlop": "^1.1.1",
             "semver": "^5.6.0"
           }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
         }
       }
     },
@@ -1435,10 +1576,135 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "5.16.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI="
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0="
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1497,6 +1763,16 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extract-opts": {
       "version": "2.2.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extract-opts/-/extract-opts-2.2.0.tgz",
@@ -1532,6 +1808,27 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -1558,9 +1855,9 @@
       }
     },
     "find-my-way": {
-      "version": "2.0.1",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.0.1.tgz",
-      "integrity": "sha1-llqnysrCNi1H1dfOIZ9Rv3Yhavc=",
+      "version": "2.1.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.1.0.tgz",
+      "integrity": "sha1-3Jv+KrEs6Pll9Il5QTR4no/VaIE=",
       "requires": {
         "fast-decode-uri-component": "^1.0.0",
         "safe-regex2": "^2.0.0",
@@ -1582,6 +1879,21 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha1-VRIrZTbqSWtLRIk+4mCBQdENmRY="
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -1617,9 +1929,9 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "version": "2.4.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-2.4.0.tgz",
+      "integrity": "sha1-SQK4MbBR4NtWEqNeGgmDdvexOtg=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1655,6 +1967,11 @@
       "version": "1.1.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -1881,6 +2198,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
+    },
     "ignorefs": {
       "version": "1.2.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorefs/-/ignorefs-1.2.0.tgz",
@@ -1894,6 +2216,15 @@
       "version": "1.1.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
       "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha1-o9iX9CDKsOZxI2iX91vBS0iFw5A=",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1913,6 +2244,41 @@
       "version": "2.0.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "inquirer": {
+      "version": "6.4.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inquirer/-/inquirer-6.4.1.tgz",
+      "integrity": "sha1-e9nlqwVnzSO0GwGAto4M+oL8PAs=",
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "int64-buffer": {
       "version": "0.1.10",
@@ -1948,6 +2314,11 @@
       "version": "2.0.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -2018,9 +2389,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.1.1.tgz",
-          "integrity": "sha1-U/U9qbMLIQPNTxXqs6GOy8shDJs="
+          "version": "6.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.1.2.tgz",
+          "integrity": "sha1-B5lgOBN2o9ti6y7cijv7EMfP4xg="
         }
       }
     },
@@ -2065,9 +2436,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "source-map": {
           "version": "0.6.1",
@@ -2136,6 +2507,11 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2187,9 +2563,14 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
         }
       }
     },
@@ -2252,6 +2633,15 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
         "invert-kv": "^1.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "limiter": {
@@ -2356,6 +2746,11 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.max/-/lodash.max-4.0.1.tgz",
       "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -2375,6 +2770,11 @@
       "version": "4.5.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
       "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2422,6 +2822,13 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        }
       }
     },
     "make-plural": {
@@ -2557,9 +2964,9 @@
       }
     },
     "mime": {
-      "version": "2.4.3",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.4.3.tgz",
-      "integrity": "sha1-IpaHMx6G9okk5stZ4c3ZN/GCdf4="
+      "version": "2.4.4",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -2809,6 +3216,14 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
@@ -2844,9 +3259,9 @@
       }
     },
     "mocha-junit-reporter": {
-      "version": "1.22.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha-junit-reporter/-/mocha-junit-reporter-1.22.0.tgz",
-      "integrity": "sha1-Tu4vMxg5i/Qkpkt1lMp6OdkkR5w=",
+      "version": "1.23.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mocha-junit-reporter/-/mocha-junit-reporter-1.23.0.tgz",
+      "integrity": "sha1-xa1/ELWqmnzG4Wm2vxW68nACZso=",
       "requires": {
         "debug": "^2.2.0",
         "md5": "^2.1.0",
@@ -2930,6 +3345,11 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mustache/-/mustache-3.0.1.tgz",
       "integrity": "sha1-hzhV8jqoqVsVD7ltmDbtvFodJIo="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
     "mv": {
       "version": "2.1.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mv/-/mv-2.1.1.tgz",
@@ -2969,6 +3389,11 @@
       "version": "2.14.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "ncp": {
       "version": "2.0.0",
@@ -3021,9 +3446,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -3034,6 +3459,13 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        }
       }
     },
     "node-fetch": {
@@ -3324,9 +3756,9 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.0",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-13.1.0.tgz",
-          "integrity": "sha1-cBa23QPijhQYpRDiWL5L/1oxE48=",
+          "version": "13.1.1",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -3390,6 +3822,14 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/optimist/-/optimist-0.6.1.tgz",
@@ -3397,6 +3837,26 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -3413,6 +3873,11 @@
         "lcid": "^1.0.0",
         "mem": "^1.1.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -3469,6 +3934,14 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-json/-/parse-json-4.0.0.tgz",
@@ -3487,6 +3960,11 @@
       "version": "1.0.1",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
@@ -3584,6 +4062,11 @@
         }
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
     "priorityqueuejs": {
       "version": "1.0.0",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
@@ -3598,6 +4081,11 @@
       "version": "1.0.7",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
     },
     "promise.prototype.finally": {
       "version": "3.1.0",
@@ -3620,9 +4108,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha1-PxMnF88vnBaXJLK2yvNzz2lBmNs="
+      "version": "1.1.33",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha1-VTPZOEynqrhkJRmOEOgFPr/qtmE="
     },
     "pump": {
       "version": "3.0.0",
@@ -3743,6 +4231,11 @@
       "version": "0.13.2",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
       "integrity": "sha1-MuWcmm+5saSv8JtJMMotRHc0NEc="
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8="
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -3934,6 +4427,16 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/punycode/-/punycode-1.4.1.tgz",
@@ -4012,9 +4515,9 @@
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
     },
     "restify": {
-      "version": "8.3.2",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify/-/restify-8.3.2.tgz",
-      "integrity": "sha1-nWNQBUn3ubaWnIqfRRPvIrTPA8E=",
+      "version": "8.3.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restify/-/restify-8.3.3.tgz",
+      "integrity": "sha1-nYm7biL+fH5MifxTggtIH+QcxEk=",
       "requires": {
         "assert-plus": "^1.0.0",
         "bunyan": "^1.8.12",
@@ -4027,16 +4530,16 @@
         "http-signature": "^1.2.0",
         "lodash": "^4.17.11",
         "lru-cache": "^5.1.1",
-        "mime": "^2.4.0",
-        "negotiator": "^0.6.1",
+        "mime": "^2.4.3",
+        "negotiator": "^0.6.2",
         "once": "^1.4.0",
         "pidusage": "^2.0.17",
-        "qs": "^6.5.2",
+        "qs": "^6.7.0",
         "restify-errors": "^8.0.0",
-        "semver": "^5.4.1",
+        "semver": "^6.1.1",
         "send": "^0.16.2",
         "spdy": "^4.0.0",
-        "uuid": "^3.1.0",
+        "uuid": "^3.3.2",
         "vasync": "^2.2.0"
       },
       "dependencies": {
@@ -4047,6 +4550,11 @@
           "requires": {
             "yallist": "^3.0.2"
           }
+        },
+        "semver": {
+          "version": "6.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.1.2.tgz",
+          "integrity": "sha1-B5lgOBN2o9ti6y7cijv7EMfP4xg="
         },
         "yallist": {
           "version": "3.0.3",
@@ -4066,6 +4574,15 @@
         "safe-json-stringify": "^1.0.4"
       }
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.2.2",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ret/-/ret-0.2.2.tgz",
@@ -4083,6 +4600,22 @@
       "version": "0.8.4",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -4142,9 +4675,9 @@
       "integrity": "sha1-qq2LhrIP6OmzKxbcLuaCqM0mqKo="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+      "version": "5.5.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "semver-store": {
       "version": "0.3.0",
@@ -4214,6 +4747,16 @@
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.5.7.tgz",
@@ -4281,9 +4824,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -4309,14 +4852,14 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.4",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.2",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "readable-stream": {
           "version": "3.4.0",
@@ -4339,9 +4882,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM="
+      "version": "1.0.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -4437,9 +4980,9 @@
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.4",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
         },
         "mime": {
           "version": "1.6.0",
@@ -4447,9 +4990,9 @@
           "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
         },
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+          "version": "2.0.1",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
         },
         "readable-stream": {
           "version": "2.3.6",
@@ -4485,11 +5028,47 @@
       }
     },
     "supports-color": {
-      "version": "6.0.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+      "version": "5.5.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.1",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/table/-/table-5.4.1.tgz",
+      "integrity": "sha1-BpGuLr6CWYWO+2PlULbV+TABceg=",
+      "requires": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "taskgroup": {
@@ -4519,6 +5098,11 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through/-/through-2.3.8.tgz",
@@ -4534,14 +5118,14 @@
       },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.4",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
         },
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+          "version": "2.0.1",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
         },
         "readable-stream": {
           "version": "2.3.6",
@@ -4565,6 +5149,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -4595,14 +5187,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+      "version": "1.10.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo="
     },
     "tslint": {
-      "version": "5.17.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint/-/tslint-5.17.0.tgz",
-      "integrity": "sha1-+fDOIBHY6Q3rqm6bSXXyTNFoUrg=",
+      "version": "5.18.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint/-/tslint-5.18.0.tgz",
+      "integrity": "sha1-9hpt3PNyNErF5BcICVu/BDoUesY=",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -4617,12 +5209,22 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "6.0.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.0.0.tgz",
-      "integrity": "sha1-e/9zya16C361zbBJBt5Y9Cor96I=",
+      "version": "6.2.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.2.0.tgz",
+      "integrity": "sha1-iqD0BYTQZtBeal55iNpRY7hfKtQ=",
       "requires": {
         "tsutils": "^2.27.2 <2.29.0"
       },
@@ -4638,9 +5240,9 @@
       }
     },
     "tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+      "version": "3.14.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-3.14.0.tgz",
+      "integrity": "sha1-v41ae65TaTMfoPKwpaEL1/c5bHc=",
       "requires": {
         "tslib": "^1.8.1"
       }
@@ -4662,6 +5264,14 @@
       "version": "0.14.5",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -4855,9 +5465,9 @@
       }
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -4905,6 +5515,14 @@
       "version": "1.0.2",
       "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/write/-/write-1.0.3.tgz",
+      "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.4.3",


### PR DESCRIPTION
## Purpose
*What is the context of this pull request? Why is it being done?*

The current implementation of TSLint will be deprecated (https://github.com/palantir/tslint/issues/4534).
This pull-request migrates from TSLint to ESLint the following projects:
- botbuilder-solutions
- botbuilder-skills

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

- Add `ESLint`
- Configure `ESLint` with the `TSLint` rules.
- Fix the new linting issues.

*Include illustrative screenshots for context if applicable.*
![image](https://user-images.githubusercontent.com/12394167/60470446-e07d8400-9c36-11e9-8bd2-dbf5fd028f5c.png)

## Tests
*Is this covered by existing tests or new ones? If no, why not?*

1. Go to `./lib/typescript` and open a PowerShell terminal.
1. Run `rush install`
1. Run `rush build`
1. Run `rush lint`
1. Run `rush test`
1. Check that the project doesn't have linting issues
