### PR TITLE
[Documentation] Fix broken links

### DIFF
--- a/docs/reference/skills/architecture.md
+++ b/docs/reference/skills/architecture.md
@@ -23,7 +23,7 @@ A key design goal for Skills was to maintain the consistent Activity protocol an
 
 ### Dispatcher
 
-The [Dispatcher](/docs/reference/assistant/dispatcher.md) plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/reference/assistant/skillcli.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
+The Dispatcher plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/howto/skills/botskills.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
 
 ![Dispatch with Skill Example](/docs/media/skillarchitecturedispatchexample.png)
 
@@ -72,7 +72,7 @@ This dialog remains active on the Virtual Assistant's `DialogStack`, ensuring th
 
 When an `EndOfConversation` event is sent from the Skill, it tears down the `SkillDialog` and returns control back to the Virtual Assistant.
 
-See the [SkillAuthentication](/docs/reference/assistant/skillauthentication.md) section for information on how Bot->Skill invocation is secured.
+See the [SkillAuthentication](/docs/reference/skills/skillauthentication.md) section for information on how Bot->Skill invocation is secured.
 
 ## Skill Middleware
 


### PR DESCRIPTION
## Purpose
*What is the context of this pull request? Why is it being done?*
Some broken links were detected in [docs/reference/skills/architecture.md](https://github.com/microsoft/botframework-solutions/blob/master/docs/reference/skills/architecture.md).

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*
- `Skill CLI` link changed from [`/docs/reference/assistant/skillcli.md`] to [`/docs/howto/skills/botskills.md`].
- `SkillAuthentication` link changed from [`/docs/reference/assistant/skillauthentication.md`] to [`/docs/reference/skills/skillauthentication.md`].
- Remove `Dispatcher` link as the file pointed has been removed.

*Include illustrative screenshots for context if applicable.*

## Tests
*Is this covered by existing tests or new ones? If no, why not?*
1. Go to `./docs/reference/skills/architecture.md`.
1. Read and check that the documentation links are working successfully.

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
N/A