### PR TITLE
inject all body items in GetCardResponse (#1710)

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/ResponseManager.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Responses/ResponseManager.cs
@@ -171,24 +171,25 @@ namespace Microsoft.Bot.Builder.Solutions.Responses
             var assembly = Assembly.GetCallingAssembly();
             var json = LoadCardJson(card.Name, locale, assembly);
 
-            var emailOverviewCard = BuildCard(json, card.Data);
+            var mainCard = BuildCard(json, card.Data);
             if (!string.IsNullOrEmpty(containerName))
             {
-                var itemsContainer = emailOverviewCard.Body.Find(item => item.Id == containerName);
-                if ((itemsContainer != null) && itemsContainer is AdaptiveContainer)
+                var itemsContainer = mainCard.Body.Find(item => item.Id == containerName);
+                if (itemsContainer is AdaptiveContainer itemsAdaptiveContainer)
                 {
                     foreach (var cardItem in containerItems)
                     {
                         var itemJson = LoadCardJson(cardItem.Name, locale, assembly);
                         var itemCard = BuildCard(itemJson, cardItem.Data);
-                        var itemContainer = itemCard.Body[0] as AdaptiveContainer;
-
-                        (itemsContainer as AdaptiveContainer).Items.Add(itemContainer);
+                        foreach (var body in itemCard.Body)
+                        {
+                            itemsAdaptiveContainer.Items.Add(body);
+                        }
                     }
                 }
             }
 
-            var cardObj = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(emailOverviewCard));
+            var cardObj = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(mainCard));
             var attachment = new Attachment(AdaptiveCard.ContentType, content: cardObj);
 
             if (templateId != null)


### PR DESCRIPTION
<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...

-->

## Purpose
*What is the context of this pull request? Why is it being done?*

Close #1710 .
All body items should be injected.
If AdaptiveCard could be converted to AdaptiveContainer, the injection could be more consistent..

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

*Include illustrative screenshots for context if applicable.*

Inject all body items with any type (formerly only AdaptiveContainer). It should work with supported item types listed in [schema](https://adaptivecards.io/explorer/Container.html).

## Tests
*Is this covered by existing tests or new ones? If no, why not?*

Manually test with single/multiple allowed types.

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

N/A.