### PR TITLE
[TypeScript][Botskills] Implement sanitization path

### DIFF
--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -9,7 +9,7 @@ import { extname, isAbsolute, join, resolve } from 'path';
 import { ConnectSkill } from './functionality';
 import { ConsoleLogger, ILogger } from './logger';
 import { ICognitiveModelFile, IConnectConfiguration } from './models';
-import { validatePairOfArgs } from './utils';
+import { sanitizePath, validatePairOfArgs } from './utils';
 
 function showErrorHelp(): void {
     program.outputHelp((str: string) => {
@@ -108,7 +108,7 @@ const configuration: Partial<IConnectConfiguration> = {
 };
 
 // outFolder validation -- the const is needed for reassuring 'configuration.outFolder' is not undefined
-const outFolder: string = args.outFolder || resolve('./');
+const outFolder: string = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
 configuration.outFolder = outFolder;
 
 // skillsFile validation
@@ -143,13 +143,13 @@ configuration.language = language;
 const languageCode: string = (language.split('-'))[0];
 
 // luisFolder validation
-configuration.luisFolder = args.luisFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
+configuration.luisFolder = args.luisFolder ? sanitizePath(args.luisFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
 
 // dispatchFolder validation
-configuration.dispatchFolder = args.dispatchFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
+configuration.dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
 
 // lgOutFolder validation
-configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+configuration.lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
 
 // dispatchName validation
 if (!args.dispatchName) {

--- a/tools/botskills/src/botskills-disconnect.ts
+++ b/tools/botskills/src/botskills-disconnect.ts
@@ -9,7 +9,7 @@ import { extname, isAbsolute, join, resolve } from 'path';
 import { DisconnectSkill } from './functionality';
 import { ConsoleLogger, ILogger} from './logger';
 import { ICognitiveModelFile, IDisconnectConfiguration } from './models';
-import { validatePairOfArgs } from './utils';
+import { sanitizePath, validatePairOfArgs } from './utils';
 
 function showErrorHelp(): void {
     program.outputHelp((str: string) => {
@@ -85,7 +85,7 @@ const configuration: Partial<IDisconnectConfiguration> = {
 };
 
 // outFolder validation -- the const is needed for reassuring 'configuration.outFolder' is not undefined
-const outFolder: string = args.outFolder || resolve('./');
+const outFolder: string = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
 configuration.outFolder = outFolder;
 
 // skillsFile validation
@@ -115,10 +115,12 @@ configuration.language = language;
 const languageCode: string = (language.split('-'))[0];
 
 // dispatchFolder validation
-configuration.dispatchFolder = args.dispatchFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
+configuration.dispatchFolder = args.dispatchFolder ?
+    sanitizePath(args.dispatchFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
 
 // lgOutFolder validation
-configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+configuration.lgOutFolder = args.lgOutFolder ?
+    sanitizePath(args.lgOutFolder) : join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
 
 // dispatchName validation
 if (!args.dispatchName) {

--- a/tools/botskills/src/botskills-refresh.ts
+++ b/tools/botskills/src/botskills-refresh.ts
@@ -9,7 +9,7 @@ import { join, resolve } from 'path';
 import { RefreshSkill } from './functionality';
 import { ConsoleLogger, ILogger} from './logger';
 import { ICognitiveModelFile, IRefreshConfiguration } from './models';
-import { validatePairOfArgs } from './utils';
+import { sanitizePath, validatePairOfArgs } from './utils';
 
 function showErrorHelp(): void {
     program.outputHelp((str: string) => {
@@ -74,20 +74,20 @@ configuration.language = language;
 const languageCode: string = (language.split('-'))[0];
 
 // outFolder validation -- the const is needed for reassuring 'configuration.outFolder' is not undefined
-const outFolder: string = args.outFolder || resolve('./');
+const outFolder: string = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
 configuration.outFolder = outFolder;
 
 // cognitiveModelsFile validation
 const cognitiveModelsFilePath: string = args.cognitiveModelsFile || join(configuration.outFolder, (args.ts ? join('src', 'cognitivemodels.json') : 'cognitivemodels.json'));
 configuration.cognitiveModelsFile = cognitiveModelsFilePath;
 // luisFolder validation
-configuration.luisFolder = args.luisFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
+configuration.luisFolder = args.luisFolder ? sanitizePath(args.luisFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
 
 // dispatchFolder validation
-configuration.dispatchFolder = args.dispatchFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
+configuration.dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
 
 // lgOutFolder validation
-configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+configuration.lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
 
 // dispatchName validation
 if (!args.dispatchName) {

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -8,8 +8,8 @@ import { existsSync, readFileSync } from 'fs';
 import { extname, isAbsolute, join, resolve } from 'path';
 import { UpdateSkill } from './functionality';
 import { ConsoleLogger, ILogger } from './logger';
-import { ICognitiveModelFile, IConnectConfiguration, IUpdateConfiguration } from './models';
-import { validatePairOfArgs } from './utils';
+import { ICognitiveModelFile, IUpdateConfiguration } from './models';
+import { sanitizePath, validatePairOfArgs } from './utils';
 
 function showErrorHelp(): void {
     program.outputHelp((str: string) => {
@@ -103,7 +103,7 @@ const configuration: Partial<IUpdateConfiguration> = {
 };
 
 // outFolder validation -- the const is needed for reassuring 'configuration.outFolder' is not undefined
-const outFolder: string = args.outFolder || resolve('./');
+const outFolder: string = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
 configuration.outFolder = outFolder;
 
 // skillsFile validation
@@ -138,13 +138,13 @@ configuration.language = language;
 const languageCode: string = (language.split('-'))[0];
 
 // luisFolder validation
-configuration.luisFolder = args.luisFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
+configuration.luisFolder = args.luisFolder ? sanitizePath(args.luisFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Skills', languageCode);
 
 // dispatchFolder validation
-configuration.dispatchFolder = args.dispatchFolder || join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
+configuration.dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(configuration.outFolder, 'Deployment', 'Resources', 'Dispatch', languageCode);
 
 // lgOutFolder validation
-configuration.lgOutFolder = args.lgOutFolder || join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+configuration.lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(configuration.outFolder, (args.ts ? join('src', 'Services') : 'Services'));
 
 // dispatchName validation
 if (!args.dispatchName) {

--- a/tools/botskills/src/utils/index.ts
+++ b/tools/botskills/src/utils/index.ts
@@ -5,4 +5,5 @@
 
 export { ChildProcessUtils } from './childProcessUtils';
 export { AuthenticationUtils } from './authenticationUtils';
+export { sanitizePath } from './sanitizationUtils';
 export { validatePairOfArgs } from './validationUtils';

--- a/tools/botskills/src/utils/sanitizationUtils.ts
+++ b/tools/botskills/src/utils/sanitizationUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const regexTrailingBackslash: RegExp = /.*?(\\)+$/;
+
+/**
+ * @param path Path to sanitize.
+ * @returns Returns a path which is sanitized
+ */
+// tslint:disable-next-line:export-name
+export function sanitizePath(path: string): string {
+    if (regexTrailingBackslash.test(path)) {
+        return path.substring(0, path.length - 1);
+    }
+
+    return path;
+}

--- a/tools/botskills/test/sanitization.test.js
+++ b/tools/botskills/test/sanitization.test.js
@@ -1,0 +1,22 @@
+
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const { strictEqual } = require("assert");
+const sanitizePath = require("../lib/utils/sanitizationUtils").sanitizePath;
+
+describe("The sanitization path util", function () {
+    describe("should return a path without trailing backslash", function () {
+        it("when a path does not contain a trailing backslash", async function() {
+            const path = "this\\is\my\\path";
+            strictEqual(sanitizePath(path), path);
+        });
+        
+        it("when a path contains a trailing backslash", async function() {
+            const path = "this\\is\my\\path\\";
+            strictEqual(sanitizePath(path), path.substring(0, path.length - 1));
+        });
+    })
+})

--- a/tools/botskills/test/sanitization.test.js
+++ b/tools/botskills/test/sanitization.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.


### PR DESCRIPTION
Fix #1717 

## Purpose
*What is the context of this pull request? Why is it being done?*
We implemented a sanitization of the paths to remove trailing backslash in the **path arguments** of the `botskills` cli tool

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

- Implement **sanitization path functionality**
- Add the sanitization for the paths of related commands
- Add new tests

*Include illustrative screenshots for context if applicable.*

![image](https://user-images.githubusercontent.com/11904023/60674541-bc958a80-9e50-11e9-8179-0eb5bdf6eb24.png)


## Tests
*Is this covered by existing tests or new ones? If no, why not?*
We added `sanitization-test.js` which includes the related tests for that functionality

### Testing Steps

- Go to `botframework-solutions\tools\botskills`
- Execute `npm install`
- Execute `npm run build`
- Execute `npm run test`
- Check that all the tests are passing successfully (also you can see the new `sanitization path util` tests)

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-