### PR TITLE
[TypeScript][Generator] Add eslintignore file

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
@@ -70,6 +70,7 @@ class Copier {
   loadTemplatesFiles(newAssistant) {
     templateFiles.set(`_package.json`, `package.json`);
     templateFiles.set(`_.eslintrc.js`, `.eslintrc.js`);
+    templateFiles.set(`_.eslintignore`, `.eslintignore`);
     templateFiles.set(`_.gitignore`, `.gitignore`);
     templateFiles.set(`_.npmrc`, `.npmrc`);
     templateFiles.set(`_.nycrc`, `.nycrc`);

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/_.eslintignore
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/_.eslintignore
@@ -1,0 +1,2 @@
+// auto-generated files
+src/services/DispatchLuis.ts

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
@@ -11,7 +11,6 @@ const _kebabCase = require(`lodash/kebabCase`);
 const _camelCase = require(`lodash/camelCase`);
 const semver = require('semver');
 const someLanguages = [`zh`, `de`, `en`];
-const nonexistentLanguages = [`br`, `pt`];
 const sinon = require(`sinon`);
 
 describe(`The generator-botbuilder-assistant tests`, function() {
@@ -28,6 +27,7 @@ describe(`The generator-botbuilder-assistant tests`, function() {
     const templatesFiles = [
         `package.json`,
         `.eslintrc.js`,
+        `.eslintignore`,
         `.gitignore`,
         `.npmrc`,
         `.nycrc`,

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.eslintignore
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/.eslintignore
@@ -1,0 +1,2 @@
+// auto-generated files
+src/services/DispatchLuis.ts


### PR DESCRIPTION
## Purpose
*What is the context of this pull request? Why is it being done?*
We identified an issue building the `Virtual Assistant` after connect a `Skill`, because some auto-generated are created after connection and `ESLint` breaks in those files.

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

- Add `.eslintignore` file
- Ignore **auto-generated** files
- Add tests to validate the new file
- Update `Virtual Assistant Sample`

*Include illustrative screenshots for context if applicable.*
![image](https://user-images.githubusercontent.com/11904023/60683162-c1683780-9e6c-11e9-9c5b-e8ef1e0e3f3b.png)

## Tests
*Is this covered by existing tests or new ones? If no, why not?*
We added a new test to validate the creation of this file using the `generator-botbuilder-assistant`

### Testing Steps

1. Go to `botframework-solutions\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant`
1. Execute `npm install`
1. Execute `npm run test` and check that all the test are passing successfully

![image](https://user-images.githubusercontent.com/11904023/60683278-4a7f6e80-9e6d-11e9-9b65-d136ab2551a4.png)


## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-