### PR TITLE
use image with route (#1332)

### DIFF
--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
@@ -605,7 +605,7 @@ namespace PointOfInterestSkill.Dialogs
             return timeString.ToString();
         }
 
-        protected async Task<List<Card>> GetRouteDirectionsViewCards(DialogContext sc, RouteDirections routeDirections)
+        protected async Task<List<Card>> GetRouteDirectionsViewCards(DialogContext sc, RouteDirections routeDirections, IGeoSpatialService service)
         {
             var routes = routeDirections.Routes;
             var state = await Accessor.GetAsync(sc.Context);
@@ -633,7 +633,7 @@ namespace PointOfInterestSkill.Dialogs
                         Address = destination.Address,
                         AvailableDetails = destination.AvailableDetails,
                         Hours = destination.Hours,
-                        PointOfInterestImageUrl = destination.PointOfInterestImageUrl,
+                        PointOfInterestImageUrl = await service.GetRouteImageAsync(destination, route),
                         TravelTime = GetShortTravelTimespanString(travelTimeSpan),
                         DelayStatus = GetFormattedTrafficDelayString(trafficTimeSpan),
                         Distance = $"{(route.Summary.LengthInMeters / 1609.344).ToString("N1")} {PointOfInterestSharedStrings.MILES_ABBREVIATION}",

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/RouteDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/RouteDialog.cs
@@ -228,13 +228,13 @@ namespace PointOfInterestSkill.Dialogs
                 {
                     routeDirections = await service.GetRouteDirectionsToDestinationAsync(state.CurrentCoordinates.Latitude, state.CurrentCoordinates.Longitude, state.Destination.Geolocation.Latitude, state.Destination.Geolocation.Longitude, state.RouteType);
 
-                    cards = await GetRouteDirectionsViewCards(sc, routeDirections);
+                    cards = await GetRouteDirectionsViewCards(sc, routeDirections, service);
                 }
                 else
                 {
                     routeDirections = await service.GetRouteDirectionsToDestinationAsync(state.CurrentCoordinates.Latitude, state.CurrentCoordinates.Longitude, state.Destination.Geolocation.Latitude, state.Destination.Geolocation.Longitude);
 
-                    cards = await GetRouteDirectionsViewCards(sc, routeDirections);
+                    cards = await GetRouteDirectionsViewCards(sc, routeDirections, service);
                 }
 
                 if (cards.Count() == 0)

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.Designer.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace PointOfInterestSkill.Responses.Shared {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PointOfInterestSharedStrings {
@@ -57,6 +57,15 @@ namespace PointOfInterestSkill.Responses.Shared {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to End.
+        /// </summary>
+        public static string END {
+            get {
+                return ResourceManager.GetString("END", resourceCulture);
             }
         }
         
@@ -165,6 +174,15 @@ namespace PointOfInterestSkill.Responses.Shared {
         public static string POWERED_BY {
             get {
                 return ResourceManager.GetString("POWERED_BY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start.
+        /// </summary>
+        public static string START {
+            get {
+                return ResourceManager.GetString("START", resourceCulture);
             }
         }
     }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.de.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.de.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>ende</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>hour</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>Powered by</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>aufbrechen</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.es.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.es.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>Final</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>hora</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>Funciona con</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>Empezar</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.fr.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.fr.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>fin</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>heure</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>Alimenté par</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>commencer</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.it.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.it.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>fine</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>ora</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>Promosso da</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>cominciare</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>End</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>hour</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>Powered by</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>Start</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.zh.resx
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Responses/Shared/PointOfInterestSharedStrings.zh.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="END" xml:space="preserve">
+    <value>结束</value>
+  </data>
   <data name="HOUR" xml:space="preserve">
     <value>小时</value>
   </data>
@@ -152,5 +155,8 @@
   </data>
   <data name="POWERED_BY" xml:space="preserve">
     <value>提供者</value>
+  </data>
+  <data name="START" xml:space="preserve">
+    <value>开始</value>
   </data>
 </root>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/AzureMapsGeoSpatialService.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/AzureMapsGeoSpatialService.cs
@@ -6,14 +6,18 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PointOfInterestSkill.Models;
+using PointOfInterestSkill.Responses.Shared;
 
 namespace PointOfInterestSkill.Services
 {
     public sealed class AzureMapsGeoSpatialService : IGeoSpatialService
     {
+        private static readonly int ImageWidth = 440;
+        private static readonly int ImageHeight = 240;
         private static readonly string FindByFuzzyQueryNoCoordinatesApiUrl = $"https://atlas.microsoft.com/search/fuzzy/json?api-version=1.0&query={{0}}&limit={{1}}";
         private static readonly string FindByFuzzyQueryApiUrl = $"https://atlas.microsoft.com/search/fuzzy/json?api-version=1.0&lat={{0}}&lon={{1}}&query={{2}}&radius={{3}}&limit={{4}}";
         private static readonly string FindByAddressQueryUrl = $"https://atlas.microsoft.com/search/address/json?api-version=1.0&lat={{0}}&lon={{1}}&query={{2}}&radius={{3}}&limit={{4}}";
@@ -21,7 +25,9 @@ namespace PointOfInterestSkill.Services
         private static readonly string FindAddressByCoordinateUrl = $"https://atlas.microsoft.com/search/address/reverse/json?api-version=1.0&query={{0}},{{1}}";
         private static readonly string FindNearbyUrl = $"https://atlas.microsoft.com/search/nearby/json?api-version=1.0&lat={{0}}&lon={{1}}&radius={{2}}&limit={{3}}";
         private static readonly string FindByCategoryUrl = $"https://atlas.microsoft.com/search/poi/category/json?api-version=1.0&query={{2}}&lat={{0}}&lon={{1}}&radius={{3}}&limit={{4}}";
-        private static readonly string ImageUrlByPoint = $"https://atlas.microsoft.com/map/static/png?api-version=1.0&layer=basic&style=main&zoom={{2}}&center={{1}},{{0}}&width=440&height=240";
+        private static readonly string ImageUrlByPoint = $"https://atlas.microsoft.com/map/static/png?api-version=1.0&layer=basic&style=main&zoom={{2}}&center={{1}},{{0}}&width={ImageWidth}&height={ImageHeight}";
+        private static readonly string ImageUrlForRoute = $"https://atlas.microsoft.com/map/static/png?api-version=1.0&layer=basic&style=main&zoom={{0}}&center={{1}},{{2}}&width={ImageWidth}&height={ImageHeight}&pins={{3}}&path=lw2|lc0078d4|{{4}}";
+        private static readonly string RoutePins = "default|la15+50|al0.75|cod83b01||'{0}'{1} {2}|'{3}'{4} {5}";
         private static readonly string GetRouteDirections = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}";
         private static readonly string GetRouteDirectionsWithRouteType = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}&&routeType={{1}}";
         private static string apiKey;
@@ -192,6 +198,64 @@ namespace PointOfInterestSkill.Services
             else
             {
                 return await GetRouteDirectionsAsync(string.Format(CultureInfo.InvariantCulture, GetRouteDirectionsWithRouteType, currentLatitude + "," + currentLongitude + ":" + destinationLatitude + "," + destinationLongitude, routeType) + "&subscription-key=" + apiKey);
+            }
+        }
+
+        public async Task<string> GetRouteImageAsync(PointOfInterestModel destination, RouteDirections.Route route)
+        {
+            double maxLongitude = -180;
+            double minLongitude = 180;
+            double maxLatitude = -90;
+            double minLatitude = 90;
+
+            // TODO or we could use Data in Azure Maps Service to store the whole path
+            var sb = new StringBuilder();
+            int pointsTotal = route.Legs.Sum(leg => leg.Points.Length);
+            int step = Math.Max(1, pointsTotal / 10);
+            int id = 0;
+            foreach (var leg in route.Legs)
+            {
+                while (true)
+                {
+                    if (id >= leg.Points.Length)
+                    {
+                        id -= leg.Points.Length;
+                        break;
+                    }
+
+                    AddPoint(leg.Points[id].Longitude, leg.Points[id].Latitude);
+                    id += step;
+                }
+            }
+
+            AddPoint(destination.Geolocation.Longitude, destination.Geolocation.Latitude);
+
+            double centerLongitude = (maxLongitude + minLongitude) * 0.5;
+            double longitudeDifference = maxLongitude - minLongitude;
+            if (longitudeDifference > 180)
+            {
+                centerLongitude = centerLongitude >= 0 ? centerLongitude - 180 : centerLongitude + 180;
+                longitudeDifference = 180 - longitudeDifference;
+            }
+
+            double centerLatitude = (maxLatitude + minLatitude) * 0.5;
+            double latitudeDifference = maxLatitude - minLatitude;
+            int pinBuffer = 10;
+            double longitudeZoom = Math.Log((ImageWidth - (2 * pinBuffer)) * 360.0 / 512.0 / longitudeDifference, 2);
+            double latitudeZoom = Math.Log((ImageHeight - (2 * pinBuffer)) * 180.0 / 512.0 / latitudeDifference, 2);
+            int zoom = (int)Math.Min(longitudeZoom, latitudeZoom);
+
+            string pins = string.Format(CultureInfo.InvariantCulture, RoutePins, PointOfInterestSharedStrings.START, route.Legs[0].Points[0].Longitude, route.Legs[0].Points[0].Latitude, PointOfInterestSharedStrings.END, destination.Geolocation.Longitude, destination.Geolocation.Latitude);
+
+            return string.Format(CultureInfo.InvariantCulture, ImageUrlForRoute, zoom, centerLongitude, centerLatitude, pins, sb.ToString()) + "&subscription-key=" + apiKey;
+
+            void AddPoint(double longitude, double latitude)
+            {
+                sb.Append($"|{longitude} {latitude}");
+                maxLongitude = Math.Max(maxLongitude, longitude);
+                minLongitude = Math.Min(minLongitude, longitude);
+                maxLatitude = Math.Max(maxLatitude, latitude);
+                minLatitude = Math.Min(minLatitude, latitude);
             }
         }
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/FoursquareGeoSpatialService.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/FoursquareGeoSpatialService.cs
@@ -78,6 +78,11 @@ namespace PointOfInterestSkill.Services
             throw new NotSupportedException();
         }
 
+        public Task<string> GetRouteImageAsync(PointOfInterestModel destination, RouteDirections.Route route)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <summary>
         /// Returns a list of venues near the provided coordinates, matching a search term.
         /// </summary>

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/IGeoSpatialService.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/IGeoSpatialService.cs
@@ -25,6 +25,14 @@ namespace PointOfInterestSkill.Services
         Task<RouteDirections> GetRouteDirectionsToDestinationAsync(double currentLatitude, double currentLongitude, double destinationLatitude, double destinationLongitude, string routeType = null);
 
         /// <summary>
+        /// Get image for route to destination
+        /// </summary>
+        /// <param name="destination">The destination</param>
+        /// <param name="route">The route</param>
+        /// <returns>The image url</returns>
+        Task<string> GetRouteImageAsync(PointOfInterestModel destination, RouteDirections.Route route);
+
+        /// <summary>
         /// Gets the points of interest by a fuzzy search.
         /// </summary>
         /// <param name="latitude">The point latitude.</param>


### PR DESCRIPTION
<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...
-->

## Purpose
*What is the context of this pull request? Why is it being done?*

Close #1332.

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

*Include illustrative screenshots for context if applicable.*

Use a static map image with route.
![response](https://user-images.githubusercontent.com/2876650/60704616-8f6fd780-9f37-11e9-9eec-7cfe5f7a88ab.png)

In AzureMapsGeoSpatialService.GetRouteImageAsync, it only returns a string now. If one wants to render a more detailed path, one could make use of [Data in Azure Maps Service](https://docs.microsoft.com/en-us/rest/api/maps/data). However, it is a little complicated to delete data after use.

## Tests
*Is this covered by existing tests or new ones? If no, why not?*

Manually test several routes on different zooms.

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

N/A.