### PR TITLE
Remove a possible recursive property call

### DIFF
--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/Foursquare/Photo.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/Foursquare/Photo.cs
@@ -37,11 +37,6 @@ namespace PointOfInterestSkill.Models.Foursquare
             {
                 return string.Format($"{{0}}{{1}}x{{2}}{{3}}", Prefix, Width, Height, Suffix);
             }
-
-            set
-            {
-                AbsoluteUrl = value;
-            }
         }
     }
 }


### PR DESCRIPTION
If you try to write the value in **AbsoluteUrl**, then there will be a recursive call. Changing the value of this property is not necessary, the ability to change the value is better to remove.