### PR TITLE
Fix datetime to string conversion

### DIFF
--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/ConnectToMeetingDialog.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/ConnectToMeetingDialog.cs
@@ -290,7 +290,7 @@ namespace CalendarSkill.Dialogs
                                         if (meeting.StartTime.TimeOfDay == utcStartTime.TimeOfDay)
                                         {
                                             showMeetingReason = ShowMeetingReason.ShowFilteredByTimeMeetings;
-                                            filterKeyWord = string.Format("H:mm", dateTime);
+                                            filterKeyWord = dateTime.ToString("H:mm");
                                             filteredMeetingList.Add(meeting);
                                         }
                                     }


### PR DESCRIPTION
The old code
```csharp
string.Format("H:mm", dateTime)
```
always return the same result: "**H:mm**"
For correct conversion can be used
```csharp
dateTime.ToString("H:mm")
```