### PR TITLE
Danalb/doc fix

### DIFF
--- a/docs/tutorials/assistantandskilldeploymentsteps.md
+++ b/docs/tutorials/assistantandskilldeploymentsteps.md
@@ -28,6 +28,7 @@ Create a Virtual Assistant or a Bot Framework Skill
     `location` | The region for your Azure Resources. By default, this will be the location for all your Azure Resources | **Yes**
     `appPassword` | The password for the [Azure Active Directory App](https://ms.portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview) that will be used by your bot. It must be at least 16 characters long, contain at least 1 special character, and contain at least 1 numeric character. If using an existing app, this must be the existing password. | **Yes**
     `luisAuthoringKey` | The authoring key for your LUIS account. It can be found at https://www.luis.ai/user/settings or https://eu.luis.ai/user/settings | **Yes**
+    `luisAuthoringRegion` | The authoring region of your LUIC account. It can be found at https://www.luis.ai/user/settings or https://eu.luis.ai/user/settings | **Yes**
     `resourceGroup` | Name of the Azure Resource Group. Default value is name parameter. | No
     `appId` | The appId of an existing MSA App Registration. If left blank, a new app will be provisioned automatically. | No
     `parametersFile` | A .json file that can overwrite the default values of the Azure Resource Manager template. | No

--- a/docs/tutorials/csharp/virtualassistant.md
+++ b/docs/tutorials/csharp/virtualassistant.md
@@ -96,6 +96,7 @@ The Virtual Assistant requires the following Azure dependencies to run correctly
     `location` | The region for your Azure Resources. By default, this will be the location for all your Azure Resources | **Yes**
     `appPassword` | The password for the [Azure Active Directory App](https://ms.portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview) that will be used by your bot. It must be at least 16 characters long, contain at least 1 special character, and contain at least 1 numeric character. If using an existing app, this must be the existing password. | **Yes**
     `luisAuthoringKey` | The authoring key for your LUIS account. It can be found at https://www.luis.ai/user/settings or https://eu.luis.ai/user/settings | **Yes**
+    `luisAuthoringRegion` | The authoring region of your LUIC account. It can be found at https://www.luis.ai/user/settings or https://eu.luis.ai/user/settings | **Yes**
 
 You can find more detailed deployment steps including customization in the [Virtual Assistant and Skill Template deployment](/docs/tutorials/assistantandskilldeploymentsteps.md) page.
 


### PR DESCRIPTION
Close #1748: Add documentation on required parameter

## Purpose
Adds the parameter luisAuthoringRegion to the docs about deploy.ps1.

## Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp?*

N/A

## Tests
*Is this covered by existing tests or new ones? If no, why not?*

No. Doc change.

## Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

No.