### PR TITLE
Remove hardcoded values in ARM template

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
@@ -41,7 +41,7 @@
     },
     "appInsightsLocation": {
       "type": "string",
-      "defaultValue": "westus2"
+      "defaultValue": "[resourceGroup().location]"
     },
     "botWebAppName": {
       "type": "string",
@@ -243,7 +243,7 @@
       "kind": "QnAMaker",
       "apiVersion": "2017-04-18",
       "name": "[parameters('qnaMakerServiceName')]",
-      "location": "westus",
+      "location": "[parameters('qnaServiceLocation')]",
       "sku": {
         "name": "[parameters('qnaMakerServiceSku')]"
       },

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
@@ -243,7 +243,7 @@
       "kind": "QnAMaker",
       "apiVersion": "2017-04-18",
       "name": "[parameters('qnaMakerServiceName')]",
-      "location": "[parameters('qnaServiceLocation')]",
+      "location": "westus",
       "sku": {
         "name": "[parameters('qnaMakerServiceSku')]"
       },


### PR DESCRIPTION
- Default value for parameters "appInsightsLocation"
- Use parameter value for QnAMaker service

<!--- 
This repository only accepts pull requests related to open issues, please link the open issue in description below. 
See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example...
Close #123: Description for this goes here.
-->
Close #1812 : template.json contains hard-coded values

## Purpose
The deployment template file contains hard-coded values that force the creation of resources in westus2 instead of either the Resource Group location or the value passed in parameter.

## Changes
Fixed the template.json file

## Tests
n/a

## Feature Plan
n/a