### PR TITLE
Fix LUIS id mismatch issue

### DIFF
--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
@@ -92,7 +92,7 @@ namespace CalendarSkill.Dialogs
             InitializeConfig(state);
 
             // If dispatch result is general luis model
-            localeConfig.LuisServices.TryGetValue("Calendar", out var luisService);
+            localeConfig.LuisServices.TryGetValue("calendar", out var luisService);
 
             if (luisService == null)
             {
@@ -259,12 +259,12 @@ namespace CalendarSkill.Dialogs
                 var localeConfig = _services.CognitiveModelSets[locale];
 
                 // Update state with email luis result and entities
-                var calendarLuisResult = await localeConfig.LuisServices["Calendar"].RecognizeAsync<CalendarLuis>(dc.Context, cancellationToken);
+                var calendarLuisResult = await localeConfig.LuisServices["calendar"].RecognizeAsync<CalendarLuis>(dc.Context, cancellationToken);
                 var state = await _stateAccessor.GetAsync(dc.Context, () => new CalendarSkillState());
                 state.LuisResult = calendarLuisResult;
 
                 // check luis intent
-                localeConfig.LuisServices.TryGetValue("General", out var luisService);
+                localeConfig.LuisServices.TryGetValue("general", out var luisService);
 
                 if (luisService == null)
                 {

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/ConnectToMeetingFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/ConnectToMeetingFlowTests.cs
@@ -25,8 +25,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new ConnectToMeetingUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new ConnectToMeetingUtterances()) }
                 }
             });
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
@@ -27,8 +27,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new CreateMeetingTestUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new CreateMeetingTestUtterances()) }
                 }
             });
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
@@ -26,8 +26,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new DeleteMeetingTestUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new DeleteMeetingTestUtterances()) }
                 }
             });
 

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/NextCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/NextCalendarFlowTests.cs
@@ -25,8 +25,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }
                 }
             });
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
@@ -28,8 +28,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new FindMeetingTestUtterances()) }
                 }
             });
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/TimeRemainingFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/TimeRemainingFlowTests.cs
@@ -26,8 +26,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new TimeRemainingUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new TimeRemainingUtterances()) }
                 }
             });
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
@@ -26,8 +26,8 @@ namespace CalendarSkillTest.Flow
             {
                 LuisServices = new Dictionary<string, ITelemetryRecognizer>()
                 {
-                    { "General", new MockLuisRecognizer() },
-                    { "Calendar", new MockLuisRecognizer(new UpdateMeetingTestUtterances()) }
+                    { "general", new MockLuisRecognizer() },
+                    { "calendar", new MockLuisRecognizer(new UpdateMeetingTestUtterances()) }
                 }
             });
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
@@ -76,7 +76,7 @@ namespace PointOfInterestSkill.Dialogs
             await PopulateStateFromSemanticAction(dc.Context);
 
             // If dispatch result is General luis model
-            localeConfig.LuisServices.TryGetValue("PointOfInterest", out var luisService);
+            localeConfig.LuisServices.TryGetValue("pointofinterest", out var luisService);
 
             if (luisService == null)
             {
@@ -249,7 +249,7 @@ namespace PointOfInterestSkill.Dialogs
                 var localeConfig = _services.CognitiveModelSets[locale];
 
                 // check luis intent
-                localeConfig.LuisServices.TryGetValue("General", out var luisService);
+                localeConfig.LuisServices.TryGetValue("general", out var luisService);
 
                 if (luisService == null)
                 {

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/PointOfInterestTestBase.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/PointOfInterestTestBase.cs
@@ -46,8 +46,8 @@ namespace PointOfInterestSkillTests.Flow
                         {
                             LuisServices = new Dictionary<string, ITelemetryRecognizer>
                             {
-                                { "General", new Fakes.MockLuisRecognizer() },
-                                { "PointOfInterest", new Fakes.MockLuisRecognizer() }
+                                { "general", new Fakes.MockLuisRecognizer() },
+                                { "pointofinterest", new Fakes.MockLuisRecognizer() }
                             }
                         }
                     }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Update the luis model ID in the calendar and POI skill. The calendar and POI not work due to the mismatch of luis id in code and config file.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Update the luis id.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Manually test

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
No

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
