### PR TITLE
[Virtual Assistant] Remove Linked Accounts action in IntroCards

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.de.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.de.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Verbundene Konten",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Kompetenzen",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.es.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.es.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Cuentas vinculadas",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Habilidades",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.fr.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.fr.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Comptes liés",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Compétences",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.it.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.it.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Account collegati",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Abilità",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.zh.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Content/NewUserGreeting.zh.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "关联账户",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "技能",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.de.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.de.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Verbundene Konten",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Kompetenzen",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.es.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.es.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Cuentas vinculadas",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Habilidades",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.fr.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.fr.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Comptes liés",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Compétences",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.it.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.it.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Account collegati",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Abilità",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.zh.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Content/NewUserGreeting.zh.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "关联账户",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "技能",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.de.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.de.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Verbundene Konten",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Kompetenzen",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.es.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.es.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Cuentas vinculadas",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Habilidades",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.fr.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.fr.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Comptes liés",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Compétences",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.it.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.it.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Account collegati",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Abilità",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.zh.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/src/content/NewUserGreeting.zh.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "关联账户",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "技能",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.de.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.de.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Verbundene Konten",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Kompetenzen",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.es.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.es.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Cuentas vinculadas",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Habilidades",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.fr.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.fr.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Comptes liés",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Compétences",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.it.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.it.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "Account collegati",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "Abilità",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.zh.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/content/NewUserGreeting.zh.json
@@ -54,13 +54,8 @@
     },
     {
       "type": "Action.OpenUrl",
-      "title": "关联账户",
-      "url": "https://aka.ms/linkedaccountsdocs"
-    },
-    {
-      "type": "Action.OpenUrl",
       "title": "技能",
-      "url": "https://aka.ms/ConversationalAISkills"
+      "url": "https://aka.ms/botframeworkskills"
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",


### PR DESCRIPTION
Fix #1824 

### Purpose
*What is the context of this pull request? Why is it being done?*
There was an inconsistence in the `IntroCards` between all the languages for TypeScript and C#

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Remove `Linked Accounts` action for all the languages in TypeScript and C# (for Virtual Assistant Template and Virtual Assistant Sample)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
