### PR TITLE
[TypeScript][Templates/Samples] Replace the placeholder's paths with the root of the project

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/pipeline/_sample-assistant.yml
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/pipeline/_sample-assistant.yml
@@ -17,7 +17,7 @@ steps:
   displayName: 'npm install'
   inputs:
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=assistantName%>'
+    workingDir: './'
     verbose: false
 
 - task: Npm@1
@@ -25,7 +25,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=assistantName%>'
+    workingDir: './'
     verbose: false
     customCommand: 'run build'
 
@@ -34,7 +34,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=assistantName%>'
+    workingDir: './'
     verbose: false
     customCommand: 'run test-coverage-ci'
 
@@ -43,7 +43,7 @@ steps:
   inputs:
     testResultsFiles: 'test-results.xml'
     # if your working directory is not root, you may change the following path
-    searchFolder: '<%=assistantName%>'
+    searchFolder: './'
     failTaskOnFailedTests: true
 
 - task: PublishCodeCoverageResults@1
@@ -51,5 +51,5 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     # if your working directory is not root, you may change the following paths
-    summaryFileLocation: '<%=assistantName%>/coverage/cobertura-coverage.xml'
-    reportDirectory: '<%=assistantName%>/coverage/'
+    summaryFileLocation: './coverage/cobertura-coverage.xml'
+    reportDirectory: './coverage/'

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/pipeline/_sample-skill.yml
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/pipeline/_sample-skill.yml
@@ -18,7 +18,7 @@ steps:
   displayName: 'npm install'
   inputs:
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=skillName%>'
+    workingDir: './'
     verbose: false
 
 - task: Npm@1
@@ -26,7 +26,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=skillName%>'
+    workingDir: './'
     verbose: false
     customCommand: 'run build'
 
@@ -35,7 +35,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: '<%=skillName%>'
+    workingDir: './'
     verbose: false
     customCommand: 'run test-coverage-ci'
 
@@ -44,7 +44,7 @@ steps:
   inputs:
     testResultsFiles: 'test-results.xml'
     # if your working directory is not root, you may change the following path
-    searchFolder: '<%=skillName%>'
+    searchFolder: './'
     failTaskOnFailedTests: true
 
 - task: PublishCodeCoverageResults@1
@@ -52,5 +52,5 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     # if your working directory is not root, you may change the following paths
-    summaryFileLocation: '<%=skillName%>/coverage/cobertura-coverage.xml'
-    reportDirectory: '<%=skillName%>/coverage/'
+    summaryFileLocation: './coverage/cobertura-coverage.xml'
+    reportDirectory: './coverage/'

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/pipeline/sample-assistant.yml
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/pipeline/sample-assistant.yml
@@ -17,7 +17,7 @@ steps:
   displayName: 'npm install'
   inputs:
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-assistant'
+    workingDir: './'
     verbose: false
 
 - task: Npm@1
@@ -25,7 +25,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-assistant'
+    workingDir: './'
     verbose: false
     customCommand: 'run build'
 
@@ -34,7 +34,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-assistant'
+    workingDir: './'
     verbose: false
     customCommand: 'run test-coverage-ci'
 
@@ -43,7 +43,7 @@ steps:
   inputs:
     testResultsFiles: 'test-results.xml'
     # if your working directory is not root, you may change the following path
-    searchFolder: 'sample-assistant'
+    searchFolder: './'
     failTaskOnFailedTests: true
 
 - task: PublishCodeCoverageResults@1
@@ -51,5 +51,5 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     # if your working directory is not root, you may change the following paths
-    summaryFileLocation: 'sample-assistant/coverage/cobertura-coverage.xml'
-    reportDirectory: 'sample-assistant/coverage/'
+    summaryFileLocation: './coverage/cobertura-coverage.xml'
+    reportDirectory: './coverage/'

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/pipeline/sample-skill.yml
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/pipeline/sample-skill.yml
@@ -18,7 +18,7 @@ steps:
   displayName: 'npm install'
   inputs:
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-skill'
+    workingDir: './'
     verbose: false
 
 - task: Npm@1
@@ -26,7 +26,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-skill'
+    workingDir: './'
     verbose: false
     customCommand: 'run build'
 
@@ -35,7 +35,7 @@ steps:
   inputs:
     command: custom
     # if your working directory is not root, you may change the following path
-    workingDir: 'sample-skill'
+    workingDir: './'
     verbose: false
     customCommand: 'run test-coverage-ci'
 
@@ -44,7 +44,7 @@ steps:
   inputs:
     testResultsFiles: 'test-results.xml'
     # if your working directory is not root, you may change the following path
-    searchFolder: 'sample-skill'
+    searchFolder: './'
     failTaskOnFailedTests: true
 
 - task: PublishCodeCoverageResults@1
@@ -52,5 +52,5 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     # if your working directory is not root, you may change the following paths
-    summaryFileLocation: 'sample-skill/coverage/cobertura-coverage.xml'
-    reportDirectory: 'sample-skill/coverage/'
+    summaryFileLocation: './coverage/cobertura-coverage.xml'
+    reportDirectory: './coverage/'


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The paths of the `.yml` files were changed so that it points to the root of the generated bot project.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update the paths for the `.yml` files to the root of the generated bot.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
The generator contains the related tests to validate the generated files.

### Testing Steps

**Using the `generator-botbuilder-assistant`**
1. Execute  `yo botbuilder-assistant` or `yo botbuilder-assistant:skill` and follow the prompts
1. Go to the `pipeline` folder and open `<BOT_NAME>.yml` file
1. Check that the paths for the `.yml` file are referenced to the root by default, verify that matches with the following image

![image](https://user-images.githubusercontent.com/11904023/61154185-ce67d500-a4c3-11e9-92a9-99ce7a86c205.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
