### PR TITLE
[TypeScript][BotBuilder-Libs] Fix issue with test and code coverage tasks in YAML files

### DIFF
--- a/yaml/typescript/botbuilder-skills.yml
+++ b/yaml/typescript/botbuilder-skills.yml
@@ -32,11 +32,11 @@ steps:
   workingDirectory: lib/typescript
   displayName: 'rush build'
 
-- pwsh: 'node ./common/scripts/install-run-rush.js test-coverage-ci'
+- pwsh: 'npm run test-coverage-ci'
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
-  workingDirectory: lib/typescript
-  displayName: 'rush test coverage'
+  workingDirectory: lib/typescript/botbuilder-skills
+  displayName: 'npm test coverage'
 
 - task: PublishTestResults@2
   displayName: 'publish test results'
@@ -47,6 +47,7 @@ steps:
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage'
+  condition: succeededOrFailed()
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: 'lib/typescript/botbuilder-skills/coverage/cobertura-coverage.xml'

--- a/yaml/typescript/botbuilder-solutions.yml
+++ b/yaml/typescript/botbuilder-solutions.yml
@@ -32,11 +32,11 @@ steps:
   workingDirectory: lib/typescript
   displayName: 'rush build'
 
-- pwsh: 'node .\common\scripts\install-run-rush.js test-coverage-ci'
+- pwsh: 'npm run test-coverage-ci'
   errorActionPreference: continue
   ignoreLASTEXITCODE: 'true'
-  workingDirectory: lib/typescript
-  displayName: 'rush test coverage'
+  workingDirectory: lib/typescript/botbuilder-solutions
+  displayName: 'npm test coverage'
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results '
@@ -47,6 +47,7 @@ steps:
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage '
+  condition: succeededOrFailed()
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: 'lib/typescript/botbuilder-solutions/coverage/cobertura-coverage.xml'


### PR DESCRIPTION
## Purpose
Update `YAML` files to have the tests separated in `BotBuilder-Skills` and `BotBuilder-Solutions`

## Changes
- Add a condition to the `code coverage` task that will publish the `coverage` report even if any test of the solution fails.
- Use `NPM` command to execute test separately in the task.
- Fix working directory on pipeline files.

## Testing Steps
1. Go to `YAML` folder in the root of the project.
1. Check that the `Pipeline` is working successfully.
