### PR TITLE
Fix test for Virtual Assistant on non-Windows machines

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/ChitchatTestUtil.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/ChitchatTestUtil.cs
@@ -14,12 +14,12 @@ namespace VirtualAssistantSample.Tests.Utilities
     {
         private static Dictionary<string, QueryResult[]> _utterances = new Dictionary<string, QueryResult[]>
         {
-            { ChitchatUtterances.Greeting, CreateAnswer(@"Resources\chitchat_greeting.json") },
+            { ChitchatUtterances.Greeting, CreateAnswer(Path.Combine("Resources\chitchat_greeting.json")) },
         };
 
         public static MockQnAMaker CreateRecognizer()
         {
-            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(@"Resources\chitchat_default.json"));
+            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(Path.Combine("Resources", "chitchat_default.json")));
             recognizer.RegisterAnswers(_utterances);
             return recognizer;
         }

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/ChitchatTestUtil.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/ChitchatTestUtil.cs
@@ -14,7 +14,7 @@ namespace VirtualAssistantSample.Tests.Utilities
     {
         private static Dictionary<string, QueryResult[]> _utterances = new Dictionary<string, QueryResult[]>
         {
-            { ChitchatUtterances.Greeting, CreateAnswer(Path.Combine("Resources\chitchat_greeting.json")) },
+            { ChitchatUtterances.Greeting, CreateAnswer(Path.Combine("Resources", "chitchat_greeting.json")) },
         };
 
         public static MockQnAMaker CreateRecognizer()

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/FaqTestUtil.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/Utilities/FaqTestUtil.cs
@@ -14,12 +14,12 @@ namespace VirtualAssistantSample.Tests.Utilities
     {
         private static Dictionary<string, QueryResult[]> _utterances = new Dictionary<string, QueryResult[]>
         {
-            { FaqUtterances.Overview, CreateAnswer(@"Resources\faq_overview.json") },
+            { FaqUtterances.Overview, CreateAnswer(Path.Combine("Resources", "faq_overview.json")) },
         };
 
         public static MockQnAMaker CreateRecognizer()
         {
-            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(@"Resources\faq_default.json"));
+            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(Path.Combine("Resources" ,"faq_default.json")));
             recognizer.RegisterAnswers(_utterances);
             return recognizer;
         }

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA.Tests/Utilities/ChitchatTestUtil.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA.Tests/Utilities/ChitchatTestUtil.cs
@@ -14,12 +14,12 @@ namespace $safeprojectname$.Utilities
     {
         private static Dictionary<string, QueryResult[]> _utterances = new Dictionary<string, QueryResult[]>
         {
-            { ChitchatUtterances.Greeting, CreateAnswer(@"Resources\chitchat_greeting.json") },
+            { ChitchatUtterances.Greeting, CreateAnswer(Path.Combine("Resources", "chitchat_greeting.json")) },
         };
 
         public static MockQnAMaker CreateRecognizer()
         {
-            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(@"Resources\chitchat_default.json"));
+            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(Path.Combine("Resources", "chitchat_default.json")));
             recognizer.RegisterAnswers(_utterances);
             return recognizer;
         }

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA.Tests/Utilities/FaqTestUtil.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA.Tests/Utilities/FaqTestUtil.cs
@@ -14,12 +14,12 @@ namespace $safeprojectname$.Utilities
     {
         private static Dictionary<string, QueryResult[]> _utterances = new Dictionary<string, QueryResult[]>
         {
-            { FaqUtterances.Overview, CreateAnswer(@"Resources\faq_overview.json") },
+            { FaqUtterances.Overview, CreateAnswer(Path.Combine("Resources", "faq_overview.json")) },
         };
 
         public static MockQnAMaker CreateRecognizer()
         {
-            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(@"Resources\faq_default.json"));
+            var recognizer = new MockQnAMaker(defaultAnswer: CreateAnswer(Path.Combine("Resources", "faq_default.json")));
             recognizer.RegisterAnswers(_utterances);
             return recognizer;
         }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Close #1880

### Changes
n/a

### Tests
n/a

### Feature Plan
n/a
### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
