### PR TITLE
[Botskills] Support of path with spaces in the execution of external commands

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -142,9 +142,9 @@ Make sure to use the argument '--dispatchName' for your Assistant's Dispatch fil
                 // Parse LU file
                 this.logger.message(`Parsing ${luisApp} LU file...`);
                 const ludownParseCommand: string[] = ['ludown', 'parse', 'toluis'];
-                ludownParseCommand.push(...['--in', luFilePath]);
+                ludownParseCommand.push(...['--in', `"${luFilePath}"`]);
                 ludownParseCommand.push(...['--luis_culture', configuration.language]);
-                ludownParseCommand.push(...['--out_folder', configuration.luisFolder]);
+                ludownParseCommand.push(...['--out_folder', `"${configuration.luisFolder}"`]);
                 ludownParseCommand.push(...['--out', `"${luisFile}"`]);
 
                 await this.runCommand(ludownParseCommand, `Parsing ${luisApp} LU file`);

--- a/tools/botskills/src/functionality/refreshSkill.ts
+++ b/tools/botskills/src/functionality/refreshSkill.ts
@@ -59,9 +59,9 @@ export class RefreshSkill {
         try {
             this.logger.message('Running LuisGen...');
 
-            luisgenCommand.push(this.dispatchJsonFilePath);
+            luisgenCommand.push(`"${this.dispatchJsonFilePath}"`);
             luisgenCommand.push(...[`-${configuration.lgLanguage}`, `"DispatchLuis"`]);
-            luisgenCommand.push(...['-o', configuration.lgOutFolder]);
+            luisgenCommand.push(...['-o', `"${configuration.lgOutFolder}"`]);
 
             await this.runCommand(luisgenCommand, `Executing luisgen for the ${configuration.dispatchName} file`);
         } catch (err) {

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -315,7 +315,7 @@ Make sure to use the argument '--dispatchName' for your Assistant's Dispatch fil
             strictEqual(errorList[errorList.length - 1], `There was an error while connecting the Skill to the Assistant:
 Error: An error ocurred while updating the Dispatch model:
 Error: Path to ${config.dispatchName}.luis (${join(config.luisFolder, config.dispatchName)}.luis) leads to a nonexistent file. This may be due to a problem with the 'ludown' command.
-Command: ludown parse toluis --in ${join(config.luisFolder, config.dispatchName)}.lu --luis_culture en --out_folder ${config.luisFolder} --out "${config.dispatchName}.luis"`);
+Command: ludown parse toluis --in "${join(config.luisFolder, config.dispatchName)}.lu" --luis_culture en --out_folder "${config.luisFolder}" --out "${config.dispatchName}.luis"`);
         });
 
         it("when the refreshSkill fails", async function () {

--- a/tools/botskills/test/refresh.test.js
+++ b/tools/botskills/test/refresh.test.js
@@ -83,7 +83,7 @@ Make sure to use the argument '--dispatchName' for your Assistant's Dispatch fil
 
             strictEqual(errorList[errorList.length - 1], `There was an error while refreshing any Skill from the Assistant:
 Error: There was an error in the luisgen command:
-Command: luisgen ${join(config.dispatchFolder, config.dispatchName)}.json -cs "DispatchLuis" -o 
+Command: luisgen "${join(config.dispatchFolder, config.dispatchName)}.json" -cs "DispatchLuis" -o ""
 Error: Mocked function throws an Error`);
         });
     });


### PR DESCRIPTION
Fix #1883 

### Purpose
*What is the context of this pull request? Why is it being done?*
Using a path with spaces, the tool fails during the execution of the external commands, we implemented the support for that cases.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Support of path with spaces in the execution of the external commands
- Update tests

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes, the `connect.test.js` and `refresh.test.js` were updated to cover the changes.

### Testing Steps
**Using the botskills cli tool**
1. **Use a path with spaces** which contains the `Virtual Assistant` or `Skill`
1. Connect a Skill to the Virtual Assistant
1. Check the connection between them finished successfully

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
