### PR TITLE
[TypeScript][Botskills] Fix dispatchName argument

### DIFF
--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -156,6 +156,8 @@ if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
+} else {
+    configuration.dispatchName = args.dispatchName;
 }
 
 configuration.logger = logger;

--- a/tools/botskills/src/botskills-disconnect.ts
+++ b/tools/botskills/src/botskills-disconnect.ts
@@ -128,6 +128,8 @@ if (!args.dispatchName) {
     // tslint:disable-next-line
     const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
+} else {
+    configuration.dispatchName = args.dispatchName;
 }
 
 new DisconnectSkill(logger).disconnectSkill(<IDisconnectConfiguration> configuration);

--- a/tools/botskills/src/botskills-refresh.ts
+++ b/tools/botskills/src/botskills-refresh.ts
@@ -94,6 +94,8 @@ if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
+} else {
+    configuration.dispatchName = args.dispatchName;
 }
 
 configuration.logger = logger;

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -151,6 +151,8 @@ if (!args.dispatchName) {
     // try get the dispatch name from the cognitiveModels file
     const cognitiveModelsFile: ICognitiveModelFile = JSON.parse(readFileSync(cognitiveModelsFilePath, 'UTF8'));
     configuration.dispatchName = cognitiveModelsFile.cognitiveModels[languageCode].dispatchModel.name;
+} else {
+    configuration.dispatchName = args.dispatchName;
 }
 
 configuration.logger = logger;


### PR DESCRIPTION
## Purpose
Fix the `dispatch name` value that was `undefined` in the moment of connect the `Skill` with the `VA`.

Fix #1873

## Changes
-  Add a condition to verify if the `dispatchName` is not `undefined` assigned the value 

## Testing Steps
1. Go to `.\tools\botskills\`.
1. Open a terminal in that location.
1. Run the command `npm install` to install dependencies.
1. Run the command `npm run build` to build the project.
1. Run the command `npm link` to symlink the package folder.
1. Run the command `botskills connect` with the `dispatchName` argument and any other necessary arguments.
1. Verify that matches with the following image.
![image](https://user-images.githubusercontent.com/42946572/61409412-8f1cf800-a8b8-11e9-885e-a953f30e9f97.png)

