### PR TITLE
use OpenDefaultApp instead of ActiveRoute.Directions (#1443) (#1864)

### DIFF
--- a/docs/reference/skills/pointofinterest.md
+++ b/docs/reference/skills/pointofinterest.md
@@ -61,41 +61,21 @@ LUIS models for the Skill are provided in .LU file format as part of the Skill. 
 |KEYWORD| Simple entity matching point of interest keywords and categories |
 |ROUTE_TYPE| Phrase list entity mapping route descriptors to `eco`,`fastest`,`shortest`,`thrilling`|
 |number| Prebuilt entity|
+|geographyV2| Prebuilt entity|
 
 ## Event Responses
 
-The Point of Interest Skill surfaces a users request to navigate to a new destination through an event returned to the client. The event is called `ActiveRoute.Directions" has contains a series of Points for the Route along with a summary of the route information. A simplified example is shown below
+The Point of Interest Skill surfaces a users request to navigate to a new destination through an event returned to the client. The event is called `OpenDefaultApp` which contains the coordinates of the destination. The format is shown below:
 
 ```json
 {
-  "name": "ActiveRoute.Directions",
+  "name": "OpenDefaultApp",
   "type": "event",
-  "value": [
-    {
-      "points": [
-        {
-          "latitude": 47.64056,
-          "longitude": -122.129372
-        },
-        {
-          "latitude": 47.64053,
-          "longitude": -122.129387
-        },
-
-        ...
-
-      ],
-      "summary": {
-        "arrivalTime": "2018-09-18T04:17:25Z",
-        "departureTime": "2018-09-18T03:54:35Z",
-        "lengthInMeters": 20742,
-        "trafficDelayInSeconds": 0,
-        "travelTimeInSeconds": 1370
-      }
-    }
-  ]
+  "value": "geo:latitude,longitude"
 }
 ```
+
+This event can be customized to return whatever route data is required for your client's needs.
 
 ## Configuration
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
@@ -228,12 +228,7 @@ namespace PointOfInterestSkill.Dialogs
                         var replyMessage = _responseManager.GetResponse(RouteResponses.SendingRouteDetails);
                         await dc.Context.SendActivityAsync(replyMessage);
 
-                        // Send event with active route data
-                        var replyEvent = dc.Context.Activity.CreateReply();
-                        replyEvent.Type = ActivityTypes.Event;
-                        replyEvent.Name = "ActiveRoute.Directions";
-                        replyEvent.Value = state.ActiveRoute.Legs;
-                        await dc.Context.SendActivityAsync(replyEvent);
+                        await dc.Context.SendActivityAsync(PointOfInterestDialogBase.CreateOpenDefaultAppReply(dc.Context.Activity, state.Destination));
                         break;
                     }
             }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
@@ -87,6 +87,15 @@ namespace PointOfInterestSkill.Dialogs
 
         protected ResponseManager ResponseManager { get; set; }
 
+        public static Activity CreateOpenDefaultAppReply(Activity activity, PointOfInterestModel destination)
+        {
+            var replyEvent = activity.CreateReply();
+            replyEvent.Type = ActivityTypes.Event;
+            replyEvent.Name = "OpenDefaultApp";
+            replyEvent.Value = $"geo:{destination.Geolocation.Latitude},{destination.Geolocation.Longitude}";
+            return replyEvent;
+        }
+
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await base.OnBeginDialogAsync(dc, options, cancellationToken);
@@ -626,7 +635,7 @@ namespace PointOfInterestSkill.Dialogs
 
             if (routes != null)
             {
-                state.FoundRoutes = routes.ToList();
+                state.FoundRoutes = routes.Select(route => route.Summary).ToList();
 
                 var destination = state.Destination;
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/RouteDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/RouteDialog.cs
@@ -301,19 +301,7 @@ namespace PointOfInterestSkill.Dialogs
                     // workaround. if connect skill directly to teams, the following response does not work.
                     if (sc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(sc.Context) != Channels.Msteams)
                     {
-                        // Send event with active route data
-                        var replyEvent = sc.Context.Activity.CreateReply();
-                        replyEvent.Type = ActivityTypes.Event;
-                        replyEvent.Name = "ActiveRoute.Directions";
-
-                        var eventPayload = new DirectionsEventResponse
-                        {
-                            Destination = state.Destination,
-                            Route = state.ActiveRoute
-                        };
-                        replyEvent.Value = eventPayload;
-
-                        await sc.Context.SendActivityAsync(replyEvent);
+                        await sc.Context.SendActivityAsync(CreateOpenDefaultAppReply(sc.Context.Activity, state.Destination));
                     }
                 }
                 else

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointOfInterestSkillState.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/PointOfInterestSkillState.cs
@@ -27,9 +27,9 @@ namespace PointOfInterestSkill.Models
 
         public List<PointOfInterestModel> LastFoundPointOfInterests { get; set; }
 
-        public RouteDirections.Route ActiveRoute { get; set; }
+        public RouteDirections.Summary ActiveRoute { get; set; }
 
-        public List<RouteDirections.Route> FoundRoutes { get; set; }
+        public List<RouteDirections.Summary> FoundRoutes { get; set; }
 
         public string DialogName { get; set; }
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/AzureMapsGeoSpatialService.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Services/AzureMapsGeoSpatialService.cs
@@ -28,8 +28,8 @@ namespace PointOfInterestSkill.Services
         private static readonly string ImageUrlByPoint = $"https://atlas.microsoft.com/map/static/png?api-version=1.0&layer=basic&style=main&zoom={{2}}&center={{1}},{{0}}&width={ImageWidth}&height={ImageHeight}";
         private static readonly string ImageUrlForRoute = $"https://atlas.microsoft.com/map/static/png?api-version=1.0&layer=basic&style=main&zoom={{0}}&center={{1}},{{2}}&width={ImageWidth}&height={ImageHeight}&pins={{3}}&path=lw2|lc0078d4|{{4}}";
         private static readonly string RoutePins = "default|la15+50|al0.75|cod83b01||'{0}'{1} {2}|'{3}'{4} {5}";
-        private static readonly string GetRouteDirections = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}";
-        private static readonly string GetRouteDirectionsWithRouteType = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}&&routeType={{1}}";
+        private static readonly string GetRouteDirections = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}&maxAlternatives=2";
+        private static readonly string GetRouteDirectionsWithRouteType = $"https://atlas.microsoft.com/route/directions/json?&api-version=1.0&instructionsType=text&query={{0}}&&routeType={{1}}&maxAlternatives=2";
         private static string apiKey;
         private static string userLocale;
         private static HttpClient httpClient;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #1443 and close #1864 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* Use OpenDefaultApp instead of ActiveRoute.Directions by CreateOpenDefaultAppReply
* Save RouteDirections.Summary instead of RouteDirections.Route in PointOfInterestSkillState
* Provide maximum 2 alternatives in routes

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

Need test in android.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
