### PR TITLE
remove obsolete event from doc

### DIFF
--- a/docs/reference/skills/pointofinterest.md
+++ b/docs/reference/skills/pointofinterest.md
@@ -110,16 +110,6 @@ The Point of Interest Skill surfaces a users request to navigate to a new destin
 
 > No Authentication is required for this skill
 
-### Skill Parameters
-
-The following Parameters are accepted by the Skill and enable additional personalization of responses to a given user:
-
-- `IPA.Location` (*The skill will fail without this as it is missing a user's current coordinates*)
-- To ease testing scenarios you can send the following message to pass a location enabling you to test the POI skill and adjust the location
-  - `/event:{ "Name": "IPA.Location", "Value": "34.05222222222222,-118.24277777777778" }`
-
-Read [Handling Events With Your Virtual Assistant](../../virtual-assistant/csharp/events.md) to learn how to manage events within a Skill.
-
 ### Configuration File Information
 
 The following Configuration entries are required to be passed to the Skill and are provided through the Virtual Assistant appSettings.json file. These should be updated to reflect your LUIS deployment.


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Since POI skill does not handle IPA.Location event (at least now as per what's recommended in our implementation) any more (Skill takes in the slots from semantic action field from the activity), removing this part from the doc

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
