### PR TITLE
[Botskills] Implement logger tests

### DIFF
--- a/tools/botskills/test/logger.test.js
+++ b/tools/botskills/test/logger.test.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const { strictEqual, ok } = require("assert");
+const { ok } = require("assert");
 const { ConsoleLogger } = require("../lib/logger");
 const sandbox = require("sinon").createSandbox();
 const logger = new ConsoleLogger();

--- a/tools/botskills/test/logger.test.js
+++ b/tools/botskills/test/logger.test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const { strictEqual, ok } = require("assert");
+const { ConsoleLogger } = require("../lib/logger");
+const sandbox = require("sinon").createSandbox();
+const logger = new ConsoleLogger();
+const message = "Custom Message";
+const command = "Custom Command";
+
+describe("The logger", function () {
+    beforeEach(function () {
+        this.stubError = sandbox.spy(console, 'error');
+        this.stubMessage = sandbox.spy(console, 'log');
+    });
+
+    afterEach(function() {
+        this.stubError.restore();
+        this.stubMessage.restore();
+    });
+
+    describe("should print", function(){
+        it("the custom error message", function() {
+            logger.error(message);
+            ok(this.stubError.called);
+            ok(logger.isError);
+        });
+
+        it("the custom informative message", function() {
+            logger.message(message);
+            ok(this.stubMessage.called);
+        });
+
+        it("the custom success message", function() {
+            logger.success(message);
+            ok(this.stubMessage.called);
+        });
+
+        it("the custom warning message", function() {
+            logger.warning(message);
+            ok(this.stubMessage.called);
+        });
+
+        describe("the custom command message without verbose flag", function() {
+            it("without verbose flag", function() {
+                logger.isVerbose = undefined;
+                logger.command(message, command);
+                ok(this.stubMessage.called);
+            });
+
+            it("with verbose flag", function() {
+                logger.isVerbose = true;
+                logger.command(message, command);
+                ok(this.stubMessage.called);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
There were no tests for `logger` implementation in `Botskills` cli tool

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Implement new tests which validate the `logger` implementation

![image](https://user-images.githubusercontent.com/11904023/61650951-446df800-ac8b-11e9-846a-78f17b0b1531.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
We added the `logger.test.js` file

### Testing Steps

1. Go to `.\botframework-solutions\tools\botskills`
2. Execute `npm install`
3. Execute `npm run build`
4. Execute `npm run test`
5. Check that all the tests are passing successfully

![image](https://user-images.githubusercontent.com/11904023/61651052-741d0000-ac8b-11e9-8421-a228a970f11f.png)


### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
