### PR TITLE
[Automotive] Fix LU file reference in manifest

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/manifestTemplate.json
+++ b/skills/src/csharp/automotiveskill/automotiveskill/manifestTemplate.json
@@ -15,7 +15,7 @@
             {
               "locale": "en",
               "source": [
-                "settings_dispatch#VEHICLE_SETTINGS_CHANGE"
+                "SettingsDispatch#VEHICLE_SETTINGS_CHANGE"
               ]
             }
           ]


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Fixed utterance source for automotive skill to reflect new naming scheme from settings_dispatch to SettingsDispatch (match LU file)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Fixed bug introduced when remotely adding skill from PR #1799 

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
n/a

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
n/a
