### PR TITLE
[TypeScript][BotBuilder Libs] Update functionality of BotBuilder-Skills and BotBuilder-Solutions

### DIFF
--- a/lib/typescript/botbuilder-skills/package.json
+++ b/lib/typescript/botbuilder-skills/package.json
@@ -38,6 +38,7 @@
     },
     "devDependencies": {
         "@types/restify": "^7.2.4",
+        "@types/request-promise-native": "^1.0.7",
         "@types/uuid": "^3.4.4",
         "@typescript-eslint/eslint-plugin": "^1.10.2",
         "@typescript-eslint/eslint-plugin-tslint": "^1.10.2",

--- a/lib/typescript/botbuilder-skills/src/auth/microsoftAppCredentialsEx.ts
+++ b/lib/typescript/botbuilder-skills/src/auth/microsoftAppCredentialsEx.ts
@@ -4,8 +4,9 @@
  */
 
 import { MicrosoftAppCredentials } from 'botframework-connector';
+import { IServiceClientCredentials } from './serviceClientCredentials';
 
-export class MicrosoftAppCredentialsEx extends MicrosoftAppCredentials {
+export class MicrosoftAppCredentialsEx extends MicrosoftAppCredentials implements IServiceClientCredentials {
     public constructor(appId: string, password: string, oauthScope?: string) {
         super(appId, password);
         if (oauthScope) {

--- a/lib/typescript/botbuilder-skills/src/auth/serviceClientCredentials.ts
+++ b/lib/typescript/botbuilder-skills/src/auth/serviceClientCredentials.ts
@@ -7,5 +7,6 @@ import { WebResource } from '@azure/ms-rest-js';
 
 export interface IServiceClientCredentials {
     getToken(forceRefresh?: boolean): Promise<string>;
-    processHttpRequest(request: WebResource): Promise<void>;
+    // tslint:disable-next-line: no-any
+    signRequest(webResource: WebResource | any): Promise<WebResource | any>;
 }

--- a/lib/typescript/botbuilder-skills/src/auth/serviceClientCredentials.ts
+++ b/lib/typescript/botbuilder-skills/src/auth/serviceClientCredentials.ts
@@ -7,6 +7,6 @@ import { WebResource } from '@azure/ms-rest-js';
 
 export interface IServiceClientCredentials {
     getToken(forceRefresh?: boolean): Promise<string>;
-    // tslint:disable-next-line: no-any
+    // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
     signRequest(webResource: WebResource | any): Promise<WebResource | any>;
 }

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
@@ -52,8 +52,7 @@ export class SkillHttpTransport implements ISkillTransport {
         // - We have to cast "request as any" to avoid a build break relating to different versions
         //   of @azure/ms-rest-js being used by botframework-connector. This is just a build issue and
         //   shouldn't effect production bots.
-        // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
-        // tslint:disable-next-line: no-unsafe-any
+        // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-any
         const signedRequest: WebResource = await this.appCredentials.signRequest(<any>request);
 
         const response: HttpOperationResponse = await this.httpClient.sendRequest(signedRequest);

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpTransport.ts
@@ -53,9 +53,10 @@ export class SkillHttpTransport implements ISkillTransport {
         //   of @azure/ms-rest-js being used by botframework-connector. This is just a build issue and
         //   shouldn't effect production bots.
         // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
-        await this.appCredentials.processHttpRequest(<any>request);
+        // tslint:disable-next-line: no-unsafe-any
+        const signedRequest: WebResource = await this.appCredentials.signRequest(<any>request);
 
-        const response: HttpOperationResponse = await this.httpClient.sendRequest(request);
+        const response: HttpOperationResponse = await this.httpClient.sendRequest(signedRequest);
 
         if (response.status < 200 || response.status >= 300) {
             const result: string = `HTTP error when forwarding activity to the skill: Status Code:${

--- a/lib/typescript/botbuilder-skills/src/skillDialog.ts
+++ b/lib/typescript/botbuilder-skills/src/skillDialog.ts
@@ -3,7 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityTypes, BotTelemetryClient, Entity, StatePropertyAccessor, TurnContext } from 'botbuilder';
+import {
+    Activity,
+    ActivityTypes,
+    BotTelemetryClient,
+    Entity,
+    SemanticActionStateTypes,
+    StatePropertyAccessor,
+    TurnContext } from 'botbuilder';
 import { ComponentDialog, DialogContext, DialogInstance, DialogReason, DialogTurnResult,
     DialogTurnStatus } from 'botbuilder-dialogs';
 import { ActivityExtensions, isProviderTokenResponse, MultiProviderAuthDialog, TokenEvents } from 'botbuilder-solutions';
@@ -149,6 +156,7 @@ export class SkillDialog extends ComponentDialog {
 
         activity.semanticAction = {
             id: '',
+            state: SemanticActionStateTypes.Continue,
             entities: entities
         };
 

--- a/lib/typescript/botbuilder-solutions/src/botSettings.ts
+++ b/lib/typescript/botbuilder-solutions/src/botSettings.ts
@@ -67,7 +67,6 @@ export interface IBotSettingsBase {
 }
 
 export interface ITelemetryConfiguration {
-    appId: string;
     instrumentationKey: string;
 }
 

--- a/lib/typescript/botbuilder-solutions/src/extensions/activityExtensions.ts
+++ b/lib/typescript/botbuilder-solutions/src/extensions/activityExtensions.ts
@@ -15,6 +15,7 @@ export namespace ActivityExtensions {
             from: source.recipient,
             label: source.label,
             locale: local,
+            callerId: source.callerId,
             recipient: source.from,
             replyToId: source.id,
             serviceUrl: source.serviceUrl,


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_

Update `BotBuilder-Libs` to Increase the parity between `C#` and `TypeScript`:
- `BotBuilder-Solutions`
- `BotBuilder-Skills`

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_

- Fix `EsLint` issues in `BotBuilder-Libs`

Changes in `BotBuilder-Skills`:
- `microsoftAppCredentialsEx`
- `IServiceClientCredentials`
- `skillDialog`
- `skillHttpTransport`
- `activityExtensions`
- Add missing dependency `@types/request-promise-native` in `package.json`

Changes in `BotBuilder-Solutions`:
- `activityExtensions`

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._

We updated `BotBuilder-Libs` to have a better functionality and increase the parity with `C#`. The next step will be to update `Virtual-Assistant-Sample` and `Skill-Sample` to continue increasing the parity

## Checklist
*-*
