### PR TITLE
[C#][DevOps] Add YAML file for Skill-Sample

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample.Tests/SkillSample.Tests.csproj
+++ b/templates/Skill-Template/csharp/Sample/SkillSample.Tests/SkillSample.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.6.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.5.1" />

--- a/yaml/csharp/skill-sample.yml
+++ b/yaml/csharp/skill-sample.yml
@@ -1,0 +1,63 @@
+# specific branch build
+trigger:
+  branches:  
+    include:
+    - master
+    - feature/*
+  
+  paths:
+    include:
+    - 'templates/Skill-Template/csharp/Sample/*'
+
+# By default will disable PR builds
+pr: none
+
+pool:
+   name: Hosted VS2017
+   demands:
+    - msbuild
+    - visualstudio
+
+variables:
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: DotNetCoreInstaller@0
+  displayName: 'Use .NET Core sdk 2.2.100'
+  inputs:
+    version: 2.2.100
+  continueOnError: true
+
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 4.9.1'
+  inputs:
+    versionSpec: 4.9.1
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: 'templates\Skill-Template\csharp\SkillTemplate.sln'
+
+- task: VSBuild@1
+  displayName: 'Build solution SkillTemplate.sln'
+  inputs:
+    solution: templates\Skill-Template\csharp\SkillTemplate.sln
+    vsVersion: '16.0'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'test results'
+  inputs:
+    command: test
+    projects: '$(System.DefaultWorkingDirectory)\templates\Skill-Template\csharp\Sample\SkillSample.Tests\SkillSample.Tests.csproj'
+    arguments: '-v n --configuration $(buildConfiguration) --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
+    workingDirectory: 'templates\Skill-Template\csharp\Sample\SkillSample.Tests'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.SourcesDirectory)\templates\Skill-Template\csharp\Sample\SkillSample.Tests\coverage.cobertura.xml'
+    reportDirectory: '$(Build.SourcesDirectory)\templates\Skill-Template\csharp\Sample\SkillSample.Tests'


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_

Add  `Skill-Sample` `YAML` file configuration into csharp folder. 
## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_

- Add  `YAML` file configuration.
- Add `coverlet` dependency to the project.

## Testing Steps
1. Go to `botframework-solutions\yaml\csharp`.
1. Check that the `YAML` files are in this location.
1. Review the readme in `YAML` folder.
1. Use the documentation to create a `pipeline`.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._

This is the last missing `YAML` file to add into `csharp` folder to have in each project the related configuration of `Pipelines`. 

## Checklist
*-*