### PR TITLE
Use consistent header name for authorization header

### DIFF
--- a/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
@@ -1,3 +1,4 @@
+import { Constants } from '@azure/ms-rest-js';
 import { BotFrameworkAdapter, BotFrameworkAdapterSettings, BotTelemetryClient, InvokeResponse,
     Severity, TurnContext, WebRequest, WebResponse } from 'botbuilder';
 import { Activity } from 'botframework-schema';
@@ -12,7 +13,7 @@ import { SkillHttpBotAdapter } from './skillHttpBotAdapter';
  * 2. Call SkillHttpBotAdapter to process the incoming activity.
  */
 export class SkillHttpAdapter extends BotFrameworkAdapter {
-    private readonly authHeaderName: string = 'Authorization';
+    private readonly authHeaderName: string = Constants.HeaderConstants.AUTHORIZATION;
 
     private readonly botAdapter: IActivityHandler;
     private readonly authenticationProvider?: IAuthenticationProvider;

--- a/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
+++ b/lib/typescript/botbuilder-skills/src/http/skillHttpAdapter.ts
@@ -1,4 +1,3 @@
-import { Constants } from '@azure/ms-rest-js';
 import { BotFrameworkAdapter, BotFrameworkAdapterSettings, BotTelemetryClient, InvokeResponse,
     Severity, TurnContext, WebRequest, WebResponse } from 'botbuilder';
 import { Activity } from 'botframework-schema';
@@ -13,8 +12,6 @@ import { SkillHttpBotAdapter } from './skillHttpBotAdapter';
  * 2. Call SkillHttpBotAdapter to process the incoming activity.
  */
 export class SkillHttpAdapter extends BotFrameworkAdapter {
-    private readonly authHeaderName: string = Constants.HeaderConstants.AUTHORIZATION;
-
     private readonly botAdapter: IActivityHandler;
     private readonly authenticationProvider?: IAuthenticationProvider;
     private readonly telemetryClient?: BotTelemetryClient;
@@ -36,8 +33,7 @@ export class SkillHttpAdapter extends BotFrameworkAdapter {
         if (this.authenticationProvider) {
             // grab the auth header from the inbound http request
             // eslint-disable-next-line @typescript-eslint/tslint/config
-            const headers: { [header: string]: string | string[] | undefined } = req.headers;
-            const authHeader: string = <string> headers[this.authHeaderName];
+            const authHeader: string = req.headers.authorization || req.headers.Authorization || '';
             const authenticated: boolean = await this.authenticationProvider.authenticate(authHeader);
 
             if (!authenticated) {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Close #1947: Use the same capitalisation for authorization header to ensure that the VA can talk to an authenticated TypeScript skill
