### PR TITLE
[Botskills] Handle the version of Azure CLI during the execution of the tool

### DIFF
--- a/docs/howto/skills/botskills.md
+++ b/docs/howto/skills/botskills.md
@@ -24,6 +24,7 @@ The CLI performs the following operations on your behalf:
 > Your Virtual Assistant must have been deployed using the [deployment tutorial](/docs/tutorials/assistantandskilldeploymentsteps.md) before using the `botskills` CLI as it relies on the Dispatch models being available and a deployed Bot for authentication connection information.
 
 ## Prerequisites
+- Install the [Azure Command Line Tools (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-windows?view=azure-cli-latest)
 - [Node.js](https://nodejs.org/) version 10.8 or higher
 - Install the Dispatch, LUDown and LUISGen CLI tools
 

--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -14,7 +14,7 @@ import {
     IOauthConnection,
     IScopeManifest,
     ISkillManifest } from '../models';
-import { ChildProcessUtils } from './';
+import { ChildProcessUtils, isValidAzVersion } from './';
 
 export class AuthenticationUtils {
     public childProcessUtils: ChildProcessUtils;
@@ -105,6 +105,10 @@ export class AuthenticationUtils {
                 const aadConfig: IAuthenticationConnection | undefined = manifest.authenticationConnections.find(
                     (connection: IAuthenticationConnection) => connection.serviceProviderId === 'Azure Active Directory v2');
                 if (aadConfig) {
+                    // Validating the version of az that the user has (due to preview tag issue)
+                    if (await isValidAzVersion()) {
+                        logger.warning(`This az version may contain issues during the execution of internal az commands`);
+                    }
                     logger.message('Configuring Azure AD connection ...');
 
                     let connectionName: string = aadConfig.id;

--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -95,6 +95,13 @@ export class AuthenticationUtils {
         }];
     }
 
+    private async validateAzVersion(logger: ILogger): Promise<void> {
+        // Validating the version of az that the user has (due to preview tag issue)
+        if (await isValidAzVersion()) {
+            logger.warning(`This az version may contain issues during the execution of internal az commands`);
+        }
+    }
+
     // tslint:disable-next-line:max-func-body-length export-name
     public async authenticate(configuration: IConnectConfiguration, manifest: ISkillManifest, logger: ILogger): Promise<boolean> {
         let currentCommand: string[] = [];
@@ -105,10 +112,7 @@ export class AuthenticationUtils {
                 const aadConfig: IAuthenticationConnection | undefined = manifest.authenticationConnections.find(
                     (connection: IAuthenticationConnection) => connection.serviceProviderId === 'Azure Active Directory v2');
                 if (aadConfig) {
-                    // Validating the version of az that the user has (due to preview tag issue)
-                    if (await isValidAzVersion()) {
-                        logger.warning(`This az version may contain issues during the execution of internal az commands`);
-                    }
+                    this.validateAzVersion(logger);
                     logger.message('Configuring Azure AD connection ...');
 
                     let connectionName: string = aadConfig.id;

--- a/tools/botskills/src/utils/azUtils.ts
+++ b/tools/botskills/src/utils/azUtils.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { gte } from 'semver';
+import { ChildProcessUtils } from './childProcessUtils';
+
+const azPreviewMessage: string = `Command group 'bot' is in preview. It may be changed/removed in a future release.\r\n`;
+
+/**
+ * @returns Returns if it is a preview message (az version greater than 2.0.66)
+ */
+export function isAzPreviewMessage(message: string): boolean {
+    return message === azPreviewMessage;
+}
+
+/**
+ * @returns Returns if it is a valid azure-cli version (lower than 2.0.66)
+ */
+const childProcess: ChildProcessUtils = new ChildProcessUtils();
+// tslint:disable-next-line:export-name
+export async function isValidAzVersion(): Promise<boolean> {
+    const azVersionCommand: string[] = ['az', '--version'];
+    const azVersion: string = await childProcess.tryExecute(azVersionCommand);
+    const azVersionArr: string | undefined = azVersion.split('\r\n')
+    .find((val: string) => {
+        return val.includes('azure-cli');
+    });
+    if (azVersionArr) {
+        const azVersionNum: string = azVersionArr.split(' ')
+        .filter((elem: string) => elem)[1];
+
+        return gte(azVersionNum, '2.0.67');
+    }
+
+    return false;
+}

--- a/tools/botskills/src/utils/childProcessUtils.ts
+++ b/tools/botskills/src/utils/childProcessUtils.ts
@@ -5,6 +5,7 @@
 
 import * as child_process from 'child_process';
 import { join } from 'path';
+import { isAzPreviewMessage } from './';
 
 export class ChildProcessUtils {
 
@@ -48,7 +49,7 @@ export class ChildProcessUtils {
                 child_process.exec(
                     `${command.join(' ')}`,
                     (err: child_process.ExecException | null, stdout: string, stderr: string) => {
-                        if (stderr) {
+                        if (stderr && !isAzPreviewMessage(stderr)) {
                             pReject(stderr);
                         }
                         pResolve(stdout);

--- a/tools/botskills/src/utils/index.ts
+++ b/tools/botskills/src/utils/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export { isAzPreviewMessage, isValidAzVersion } from './azUtils';
 export { ChildProcessUtils } from './childProcessUtils';
 export { AuthenticationUtils } from './authenticationUtils';
 export { sanitizePath, wrapPathWithQuotes } from './sanitizationUtils';

--- a/tools/botskills/test/authentication.test.js
+++ b/tools/botskills/test/authentication.test.js
@@ -129,6 +129,7 @@ https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assis
                 logger: new TestLogger()
             };
 
+            sandbox.replace(authenticationUtils, "validateAzVersion", (logger) => {});
             // Mock the execution of az bot authsetting list (listAuthSettingsCommand)
             this.callback.onCall(0).returns(Promise.resolve(emptyAzureAuthSettings));
             // Mock the execution of az ad app show (azureAppShowCommand)


### PR DESCRIPTION
Close #1863

### Purpose
*What is the context of this pull request? Why is it being done?*
Using an `az` version greater than `2.0.67`, the `authentication` process throws an error in the `botskills` cli tool

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Add a warning validating the **az version** of the user
- Update `Prerequisites` section
- Update `authentication` tests

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes, we updated `authentication` test

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will take into account the `az` releases with the preview tag in internal commands.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [X] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
