### PR TITLE
[TypeScript][BotBuilder Skills] Rename property msAppId to msaAppId

### DIFF
--- a/lib/typescript/botbuilder-skills/src/models/skillManifest.ts
+++ b/lib/typescript/botbuilder-skills/src/models/skillManifest.ts
@@ -9,7 +9,7 @@
  */
 export interface ISkillManifest {
     id: string;
-    msAppId: string;
+    msaAppId: string;
     name: string;
     endpoint: string;
     description: string;

--- a/lib/typescript/botbuilder-skills/src/skillManifestGenerator.ts
+++ b/lib/typescript/botbuilder-skills/src/skillManifestGenerator.ts
@@ -34,7 +34,7 @@ export class SkillManifestGenerator {
         if (!skillManifest.id) { throw new Error('Skill manifest ID property was not present in the template manifest file.'); }
         if (!skillManifest.name) { throw new Error('Skill manifest Name property was not present in the template manifest file.'); }
 
-        skillManifest.msAppId = appId;
+        skillManifest.msaAppId = appId;
         skillManifest.endpoint = `${uriBase}${this.skillRoute}`;
 
         if (skillManifest.iconUrl !== undefined) {

--- a/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketTransport.ts
+++ b/lib/typescript/botbuilder-skills/src/websocket/skillWebSocketTransport.ts
@@ -62,7 +62,7 @@ export class SkillWebSocketTransport implements ISkillTransport {
         // set recipient to the skill
         if (activity !== undefined && activity.recipient !== undefined) {
             const recipientId: string = activity.recipient.id;
-            activity.recipient.id = this.skillManifest.msAppId;
+            activity.recipient.id = this.skillManifest.msaAppId;
 
             // Serialize the activity and POST to the Skill endpoint
             const request: Request = Request.create('POST', '');

--- a/lib/typescript/botbuilder-skills/test/manifest.test.js
+++ b/lib/typescript/botbuilder-skills/test/manifest.test.js
@@ -18,7 +18,7 @@ describe("manifest", function() {
             .expect(200)
             .expect(function(res) {
 
-                assert.strictEqual(res.body.msAppId, botSettings.microsoftAppId, "Skill Manifest msaAppId not set correctly");
+                assert.strictEqual(res.body.msaAppId, botSettings.microsoftAppId, "Skill Manifest msaAppId not set correctly");
                 assert.strictEqual(res.body.endpoint, `http://${res.req.getHeaders().host}/api/skill/messages`, "Skill Manifest endpoint not set correctly");
                 assert.strictEqual(res.body.iconUrl, `http://${res.req.getHeaders().host}/calendarSkill.png`, "Skill Manifest iconUrl not set correctly");
                 assert.strictEqual(res.body.actions[0].definition.triggers.utteranceSources.length, 3);
@@ -35,7 +35,7 @@ describe("manifest", function() {
             .expect(200)
             .expect(function(res) {
 
-                assert.strictEqual(res.body.msAppId, botSettings.microsoftAppId, "Skill Manifest msaAppId not set correctly");
+                assert.strictEqual(res.body.msaAppId, botSettings.microsoftAppId, "Skill Manifest msaAppId not set correctly");
                 assert.strictEqual(res.body.endpoint, `http://${res.req.getHeaders().host}/api/skill/messages`, "Skill Manifest endpoint not set correctly");
                 assert.strictEqual(res.body.iconUrl, `http://${res.req.getHeaders().host}/calendarSkill.png`, "Skill Manifest iconUrl not set correctly");
                 // Ensure each of the registered actions has triggering utterances added

--- a/lib/typescript/botbuilder-skills/test/mocks/fixtures/manifest_with_utterances.json
+++ b/lib/typescript/botbuilder-skills/test/mocks/fixtures/manifest_with_utterances.json
@@ -35906,7 +35906,7 @@
                     }
                 }
             ],
-            "msAppId": "9afc4045-b3f3-4106-80be-d152d8821879",
+            "msaAppId": "9afc4045-b3f3-4106-80be-d152d8821879",
             "endpoint": "http://127.0.0.1:3980/api/skill/messages"
         },
         "rawHeaders": [

--- a/lib/typescript/botbuilder-skills/test/mocks/fixtures/manifest_without_utterances.json
+++ b/lib/typescript/botbuilder-skills/test/mocks/fixtures/manifest_without_utterances.json
@@ -351,7 +351,7 @@
                     }
                 }
             ],
-            "msAppId": "9afc4045-b3f3-4106-80be-d152d8821879",
+            "msaAppId": "9afc4045-b3f3-4106-80be-d152d8821879",
             "endpoint": "http://127.0.0.1:3980/api/skill/messages"
         },
         "rawHeaders": [


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_

Rename the property `msAppId` to `msaAppId` to have the same consistency between `C#` and `TypeScript`

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_

- Rename `msAppId` property in the following files:
	- skillManifest
	- skillManifestGenerator
	- skillWebSocketTransport
	- manifest.test
	
## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
*-*

## Checklist
*-*