### PR TITLE
[Botskills] Prevent LUDown from breaking Botskills process

### DIFF
--- a/tools/botskills/src/utils/childProcessUtils.ts
+++ b/tools/botskills/src/utils/childProcessUtils.ts
@@ -34,7 +34,7 @@ export class ChildProcessUtils {
             child_process.exec(
                 `${command} ${args.join(' ')}`,
                 (err: child_process.ExecException | null, stdout: string, stderr: string) => {
-                    if (stderr) {
+                    if (stderr && !stderr.includes('Update available')) {
                         pReject(stderr);
                     }
                     pResolve(stdout);


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
Close #1963
### Purpose
*What is the context of this pull request? Why is it being done?*

The `LUDown` tool is making the `Botskills` process to break when the user has available updates.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Add a validation in `childProcessUtils.ts` to prevent the `Botskills` process from breaking.
