### PR TITLE
enable JWTToken auth by default

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
             _services = new ServiceCollection();
 
+            _services.AddSingleton(_botSettings);
             _services.AddSingleton<SkillWebSocketAdapter, MockSkillWebSocketAdapter>();
 			_services.AddSingleton<SkillWebSocketBotAdapter>();
             _services.AddSingleton<IBotFrameworkHttpAdapter, MockBotFrameworkHttpAdapter>();
             _services.AddSingleton<IBot, MockBot>();
-            _services.AddSingleton(_botSettings);
         }
 
         [TestMethod]

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillWebSocketAdapter.cs
@@ -1,9 +1,11 @@
-﻿namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
+﻿using Microsoft.Bot.Builder.Solutions;
+
+namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
 {
     public class MockSkillWebSocketAdapter : SkillWebSocketAdapter
     {
-        public MockSkillWebSocketAdapter(SkillWebSocketBotAdapter skillWebSocketBotAdapter)
-            : base(skillWebSocketBotAdapter)
+        public MockSkillWebSocketAdapter(SkillWebSocketBotAdapter skillWebSocketBotAdapter, BotSettingsBase botSettingsBase)
+            : base(skillWebSocketBotAdapter, botSettingsBase)
         {
         }
     }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/MsJWTAuthenticationProvider.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/MsJWTAuthenticationProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading;
 using Microsoft.IdentityModel.Protocols;
@@ -10,25 +9,20 @@ namespace Microsoft.Bot.Builder.Skills.Auth
 {
     public class MsJWTAuthenticationProvider : IAuthenticationProvider
     {
-        private const string OpenIdMetadataUrl = "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
-
         private static OpenIdConnectConfiguration openIdConfig;
         private readonly string _microsoftAppId;
-        private List<string> _jwtIssuers = new List<string>
-        {
-            "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0",
-            "https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/",
-        };
+        private readonly string _openIdMetadataUrl = "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
 
-        static MsJWTAuthenticationProvider()
-        {
-            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(OpenIdMetadataUrl, new OpenIdConnectConfigurationRetriever());
-            openIdConfig = configurationManager.GetConfigurationAsync(CancellationToken.None).GetAwaiter().GetResult();
-        }
-
-        public MsJWTAuthenticationProvider(string microsoftAppId)
+        public MsJWTAuthenticationProvider(string microsoftAppId, string openIdMetadataUrl = null)
         {
             _microsoftAppId = !string.IsNullOrWhiteSpace(microsoftAppId) ? microsoftAppId : throw new ArgumentNullException(nameof(microsoftAppId));
+            if (!string.IsNullOrWhiteSpace(openIdMetadataUrl))
+            {
+                _openIdMetadataUrl = openIdMetadataUrl;
+            }
+
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(_openIdMetadataUrl, new OpenIdConnectConfigurationRetriever());
+            openIdConfig = configurationManager.GetConfigurationAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public bool Authenticate(string authHeader)
@@ -38,7 +32,6 @@ namespace Microsoft.Bot.Builder.Skills.Auth
                 var validationParameters =
                     new TokenValidationParameters
                     {
-                        ValidIssuers = _jwtIssuers,
                         ValidAudiences = new[] { _microsoftAppId },
                         IssuerSigningKeys = openIdConfig.SigningKeys,
                     };

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/MsJWTAuthenticationProvider.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/MsJWTAuthenticationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading;
 using Microsoft.IdentityModel.Protocols;
@@ -10,10 +11,14 @@ namespace Microsoft.Bot.Builder.Skills.Auth
     public class MsJWTAuthenticationProvider : IAuthenticationProvider
     {
         private const string OpenIdMetadataUrl = "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
-        private const string JwtIssuer = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0";
 
         private static OpenIdConnectConfiguration openIdConfig;
         private readonly string _microsoftAppId;
+        private List<string> _jwtIssuers = new List<string>
+        {
+            "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0",
+            "https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/",
+        };
 
         static MsJWTAuthenticationProvider()
         {
@@ -33,7 +38,7 @@ namespace Microsoft.Bot.Builder.Skills.Auth
                 var validationParameters =
                     new TokenValidationParameters
                     {
-                        ValidIssuer = JwtIssuer,
+                        ValidIssuers = _jwtIssuers,
                         ValidAudiences = new[] { _microsoftAppId },
                         IssuerSigningKeys = openIdConfig.SigningKeys,
                     };

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/SkillSettings.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/SkillSettings.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Skills.Models
+{
+    // Temporary class to represent settings for skill
+    // Should be part of Manifest
+    public class SkillSettings
+    {
+        [JsonProperty("Skill")]
+        public SkillConfiguration SkillConfig { get; set; }
+
+        public class SkillConfiguration
+        {
+            public bool IsMsJWTAuthenticationEnabled { get; set; }
+        }
+    }
+}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
@@ -69,15 +69,12 @@ namespace Microsoft.Bot.Builder.Skills
                 return;
             }
 
-            if (_skillSettings != null && _skillSettings.SkillConfig != null && _skillSettings.SkillConfig.IsMsJWTAuthenticationEnabled)
-            {
-                var authenticated = _authenticationProvider.Authenticate(httpRequest.Headers["Authorization"]);
+            var authenticated = _authenticationProvider.Authenticate(httpRequest.Headers["Authorization"]);
 
-                if (!authenticated)
-                {
-                    httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
-                    return;
-                }
+            if (!authenticated)
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return;
             }
 
             await CreateWebSocketConnectionAsync(httpRequest.HttpContext, bot).ConfigureAwait(false);

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
@@ -7,8 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Skills.Auth;
-using Microsoft.Bot.Builder.Skills.Models;
-using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Builder.Solutions;
 using Microsoft.Bot.StreamingExtensions.Transport;
 using Microsoft.Bot.StreamingExtensions.Transport.WebSockets;
 
@@ -25,19 +24,19 @@ namespace Microsoft.Bot.Builder.Skills
     {
         private readonly IBotTelemetryClient _botTelemetryClient;
         private readonly SkillWebSocketBotAdapter _skillWebSocketBotAdapter;
-        private readonly MicrosoftAppCredentials _microsoftAppCredentials;
+        private readonly BotSettingsBase _botSettingsBase;
         private readonly IAuthenticationProvider _authenticationProvider;
 		private readonly Stopwatch _stopWatch;
 
         public SkillWebSocketAdapter(
             SkillWebSocketBotAdapter skillWebSocketBotAdapter,
-            MicrosoftAppCredentials microsoftAppCredentials,
+            BotSettingsBase botSettingsBase,
             IAuthenticationProvider authenticationProvider = null,
             IBotTelemetryClient botTelemetryClient = null)
         {
             _skillWebSocketBotAdapter = skillWebSocketBotAdapter ?? throw new ArgumentNullException(nameof(skillWebSocketBotAdapter));
-            _microsoftAppCredentials = microsoftAppCredentials ?? throw new ArgumentNullException(nameof(microsoftAppCredentials));
-            _authenticationProvider = authenticationProvider ?? new MsJWTAuthenticationProvider(_microsoftAppCredentials.MicrosoftAppId);
+            _botSettingsBase = botSettingsBase ?? throw new ArgumentNullException(nameof(botSettingsBase));
+            _authenticationProvider = authenticationProvider ?? new MsJWTAuthenticationProvider(_botSettingsBase.MicrosoftAppId);
             _botTelemetryClient = botTelemetryClient ?? NullBotTelemetryClient.Instance;
 			_stopWatch = new Stopwatch();
         }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
@@ -33,13 +33,11 @@ namespace Microsoft.Bot.Builder.Skills
         public SkillWebSocketAdapter(
             SkillWebSocketBotAdapter skillWebSocketBotAdapter,
             MicrosoftAppCredentials microsoftAppCredentials,
-            SkillSettings skillSettings,
             IAuthenticationProvider authenticationProvider = null,
             IBotTelemetryClient botTelemetryClient = null)
         {
             _skillWebSocketBotAdapter = skillWebSocketBotAdapter ?? throw new ArgumentNullException(nameof(skillWebSocketBotAdapter));
             _microsoftAppCredentials = microsoftAppCredentials ?? throw new ArgumentNullException(nameof(microsoftAppCredentials));
-            _skillSettings = skillSettings;
             _authenticationProvider = authenticationProvider ?? new MsJWTAuthenticationProvider(_microsoftAppCredentials.MicrosoftAppId);
             _botTelemetryClient = botTelemetryClient ?? NullBotTelemetryClient.Instance;
 			_stopWatch = new Stopwatch();

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketAdapter.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Bot.Builder.Skills
         private readonly SkillWebSocketBotAdapter _skillWebSocketBotAdapter;
         private readonly MicrosoftAppCredentials _microsoftAppCredentials;
         private readonly IAuthenticationProvider _authenticationProvider;
-        private readonly SkillSettings _skillSettings;
 		private readonly Stopwatch _stopWatch;
 
         public SkillWebSocketAdapter(


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

enable JWTToken auth by default and add 1.0 issuer

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
