### PR TITLE
Ensure semantic action in every turn

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Builder.Skills.Auth;
 using Microsoft.Bot.Builder.Skills.Models;
 using Microsoft.Bot.Builder.Skills.Models.Manifest;
@@ -13,7 +12,6 @@ using Microsoft.Bot.Builder.Solutions.Authentication;
 using Microsoft.Bot.Builder.Solutions.Dialogs;
 using Microsoft.Bot.Builder.Solutions.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.Recognizers.Text;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills
@@ -397,6 +395,7 @@ namespace Microsoft.Bot.Builder.Skills
                     tokenEvent.Type = ActivityTypes.Event;
                     tokenEvent.Name = TokenEvents.TokenResponseEventName;
                     tokenEvent.Value = authResult.Result as ProviderTokenResponse;
+                    tokenEvent.SemanticAction = activity.SemanticAction;
 
                     lock (_lockObject)
                     {

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Bot.Builder.Skills
                     // No need to create a response. One will be created below.
                 }
 
+                // set SemanticAction property of the activity properly
+                EnsureActivitySemanticAction(turnContext, activity);
+
                 if (activity.Type != ActivityTypes.Trace ||
                     (activity.Type == ActivityTypes.Trace && activity.ChannelId == "emulator"))
                 {
@@ -229,6 +232,9 @@ namespace Microsoft.Bot.Builder.Skills
             response.Type = ActivityTypes.Event;
             response.Name = TokenEvents.TokenRequestEventName;
 
+            // set SemanticAction property of the activity properly
+            EnsureActivitySemanticAction(turnContext, response);
+
             // Send the tokens/request Event
             await SendActivitiesAsync(turnContext, new Activity[] { response }, cancellationToken).ConfigureAwait(false);
         }
@@ -240,8 +246,41 @@ namespace Microsoft.Bot.Builder.Skills
             response.Type = ActivityTypes.Event;
             response.Name = SkillEvents.FallbackEventName;
 
+            // set SemanticAction property of the activity properly
+            EnsureActivitySemanticAction(turnContext, response);
+
             // Send the fallback Event
             await SendActivitiesAsync(turnContext, new Activity[] { response }, cancellationToken).ConfigureAwait(false);
+        }
+
+        private void EnsureActivitySemanticAction(ITurnContext turnContext, Activity activity)
+        {
+            if (activity == null || turnContext == null || turnContext.Activity == null)
+            {
+                return;
+            }
+
+            // set state of semantic action based on the activity type
+            if (activity.Type != ActivityTypes.Trace
+                && turnContext.Activity.SemanticAction != null
+                && !string.IsNullOrWhiteSpace(turnContext.Activity.SemanticAction.Id))
+            {
+                // if Skill's dialog didn't set SemanticAction property
+                // simply copy over from the incoming activity
+                if (activity.SemanticAction == null)
+                {
+                    activity.SemanticAction = turnContext.Activity.SemanticAction;
+                }
+
+                if (activity.Type == ActivityTypes.EndOfConversation)
+                {
+                    activity.SemanticAction.State = SkillConstants.SkillDone;
+                }
+                else
+                {
+                    activity.SemanticAction.State = SkillConstants.SkillContinue;
+                }
+            }
         }
 
         private async Task<T> SendRequestAsync<T>(StreamingRequest request, CancellationToken cancellation = default(CancellationToken))
@@ -263,20 +302,6 @@ namespace Microsoft.Bot.Builder.Skills
             }
 
             return default(T);
-        }
-
-        private async Task SendRequestAsync(StreamingRequest request, CancellationToken cancellation = default(CancellationToken))
-        {
-            try
-            {
-                var serverResponse = await this.Server.SendAsync(request, cancellation).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _botTelemetryClient.TrackException(ex);
-
-                throw ex;
-            }
         }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

For semantic action, ensure state is set correctly in every turn

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
