### PR TITLE
[Automotive Skill] Replace event name with settings name

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/VehicleSettingsDialog.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/VehicleSettingsDialog.cs
@@ -544,7 +544,7 @@ namespace AutomotiveSkill.Dialogs
             actionEvent.Type = ActivityTypes.Event;
 
             // The name of the event is the intent (changing vs checking, the latter of which is not yet supported).
-            actionEvent.Name = "AutomotiveSkill.SettingChange";
+            actionEvent.Name = $"AutomotiveSkill.{change.SettingName}";
             actionEvent.Value = change;
 
             await sc.Context.SendActivityAsync(actionEvent);

--- a/skills/src/csharp/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using AdaptiveCards;
 using AutomotiveSkill.Models;
@@ -325,7 +326,7 @@ namespace AutomotiveSkillTest.Flow
             {
                 var eventReceived = activity.AsEventActivity();
                 Assert.IsNotNull(eventReceived, "Activity received is not an Event as expected");
-                Assert.AreEqual<string>("AutomotiveSkill.SettingChange", eventReceived.Name);
+                Assert.IsTrue((eventReceived.Name ?? string.Empty).Contains("AutomotiveSkill."));
                 Assert.IsInstanceOfType(eventReceived.Value, typeof(SettingChange));
                 Assert.AreEqual<SettingChange>(expectedChange, (SettingChange)eventReceived.Value);
             };


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #2044 to rename the events sent back from the Automotive Skill so that they are unique to the specific setting change

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
n/a

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
n/a

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
n/a

### Checklist
#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
