### PR TITLE
Add GenericOauth2 to OAuthProvider (#2062)

### DIFF
--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/OAuthProvider.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/OAuthProvider.cs
@@ -16,5 +16,10 @@
         /// Todoist authentication provider.
         /// </summary>
         Todoist,
+
+        /// <summary>
+        /// Generic Oauth 2 provider.
+        /// </summary>
+        GenericOauth2,
     }
 }

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/OAuthProviderExtensions.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Authentication/OAuthProviderExtensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Bot.Builder.Solutions.Authentication
                     return OAuthProvider.Google;
                 case "Todoist":
                     return OAuthProvider.Todoist;
+                case "Generic Oauth 2":
+                case "Oauth 2 Generic Provider":
+                    return OAuthProvider.GenericOauth2;
                 default:
                     throw new Exception($"The given provider {providerString} could not be parsed.");
             }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2062 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Add OAuthProvider.GenericOauth2 temporarily for IT Service Management skill until #1916

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

Yes with Service Now

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
