### PR TITLE
Change sample from Skills to Virtual Assistant

### DIFF
--- a/docs/tutorials/csharp/virtualassistant.md
+++ b/docs/tutorials/csharp/virtualassistant.md
@@ -38,7 +38,7 @@ A Virtual Assistant app (in C#) that greets a new user.
 > It's important to ensure all of the following prerequisites are installed on your machine prior to attempting deployment otherwise you may run into deployment issues.
 
 1. Download and install Visual Studio (2017 or 2019) for PC or Mac
-1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). *Note that Visual Studio on Mac doesn't support VSIX packages, instead [clone the Skill Template sample from our repository](https://github.com/microsoft/botframework-solutions/tree/master/templates/Skill-Template/csharp/Sample).*
+1. Download and install the [Virtual Assistant Template](https://marketplace.visualstudio.com/items?itemName=BotBuilder.VirtualAssistantTemplate). *Note that Visual Studio on Mac doesn't support VSIX packages, instead [clone the Virtual Assistant sample from our repository](https://github.com/microsoft/botframework-solutions/tree/master/templates/Virtual-Assistant-Template/csharp/Sample).*
 2. Ensure you have updated [.NET Core](https://www.microsoft.com/net/download) to the **latest** version.  
 3. Download and install [Node Package manager](https://nodejs.org/en/).
 4. Download and install PowerShell Core version 6 (required for cross platform deployment support):


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Current documentation for macOS links to the 'Skill template', while the guide mentions the Virtual Assistant template. 