### PR TITLE
add health check to SkillController

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Skills.Auth;
 using Microsoft.Bot.Builder.Skills.Models.Manifest;
 using Microsoft.Bot.Builder.Skills.Tests.Mocks;
 using Microsoft.Bot.Builder.Solutions;
@@ -54,6 +55,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             _services = new ServiceCollection();
 
             _services.AddSingleton(_botSettings);
+            _services.AddSingleton<IWhitelistAuthenticationProvider, MockWhitelistAuthenticationProvider>();
             _services.AddSingleton<SkillWebSocketAdapter, MockSkillWebSocketAdapter>();
 			_services.AddSingleton<SkillWebSocketBotAdapter>();
             _services.AddSingleton<IBotFrameworkHttpAdapter, MockBotFrameworkHttpAdapter>();
@@ -290,8 +292,9 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 			var sp = _services.BuildServiceProvider();
 			var botFrameworkHttpAdapter = sp.GetService<IBotFrameworkHttpAdapter>();
 			var skillWebSocketAdapter = sp.GetService<SkillWebSocketAdapter>();
+            var whitelistAuthenticationProvider = sp.GetService<IWhitelistAuthenticationProvider>();
 			var bot = sp.GetService<IBot>();
-			var controller = new MockSkillController(bot, _botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter, _mockHttp.ToHttpClient(), manifestFileOverride);
+			var controller = new MockSkillController(bot, _botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter, whitelistAuthenticationProvider, _mockHttp.ToHttpClient(), manifestFileOverride);
 
 			controller.ControllerContext = new ControllerContext();
 			controller.ControllerContext.HttpContext = new DefaultHttpContext();

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/ManifestTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             _services.AddSingleton(_botSettings);
             _services.AddSingleton<IWhitelistAuthenticationProvider, MockWhitelistAuthenticationProvider>();
             _services.AddSingleton<SkillWebSocketAdapter, MockSkillWebSocketAdapter>();
-			_services.AddSingleton<SkillWebSocketBotAdapter>();
+            _services.AddSingleton<SkillWebSocketBotAdapter>();
             _services.AddSingleton<IBotFrameworkHttpAdapter, MockBotFrameworkHttpAdapter>();
             _services.AddSingleton<IBot, MockBot>();
         }
@@ -288,20 +288,20 @@ namespace Microsoft.Bot.Builder.Skills.Tests
         }
 
         private MockSkillController CreateMockSkillController(string manifestFileOverride = null)
-		{
-			var sp = _services.BuildServiceProvider();
-			var botFrameworkHttpAdapter = sp.GetService<IBotFrameworkHttpAdapter>();
-			var skillWebSocketAdapter = sp.GetService<SkillWebSocketAdapter>();
+        {
+            var sp = _services.BuildServiceProvider();
+            var botFrameworkHttpAdapter = sp.GetService<IBotFrameworkHttpAdapter>();
+            var skillWebSocketAdapter = sp.GetService<SkillWebSocketAdapter>();
             var whitelistAuthenticationProvider = sp.GetService<IWhitelistAuthenticationProvider>();
-			var bot = sp.GetService<IBot>();
-			var controller = new MockSkillController(bot, _botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter, whitelistAuthenticationProvider, _mockHttp.ToHttpClient(), manifestFileOverride);
+            var bot = sp.GetService<IBot>();
+            var controller = new MockSkillController(bot, _botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter, whitelistAuthenticationProvider, _mockHttp.ToHttpClient(), manifestFileOverride);
 
-			controller.ControllerContext = new ControllerContext();
-			controller.ControllerContext.HttpContext = new DefaultHttpContext();
-			controller.ControllerContext.HttpContext.Request.Scheme = "https";
-			controller.ControllerContext.HttpContext.Request.Host = new HostString("virtualassistant.azurewebsites.net");
+            controller.ControllerContext = new ControllerContext();
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+            controller.ControllerContext.HttpContext.Request.Scheme = "https";
+            controller.ControllerContext.HttpContext.Request.Host = new HostString("virtualassistant.azurewebsites.net");
 
-			return controller;
-		}
-	}
+            return controller;
+        }
+    }
 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillController.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Skills.Auth;
 using Microsoft.Bot.Builder.Solutions;
 
 namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
@@ -11,9 +12,10 @@ namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
             BotSettingsBase botSettings,
             IBotFrameworkHttpAdapter botFrameworkHttpAdapter,
             SkillWebSocketAdapter skillWebSocketAdapter,
+            IWhitelistAuthenticationProvider whitelistAuthenticationProvider,
             HttpClient httpClient,
             string manifestFileOverride = null)
-            : base(bot, botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter)
+            : base(bot, botSettings, botFrameworkHttpAdapter, skillWebSocketAdapter, whitelistAuthenticationProvider)
         {
 			HttpClient = httpClient;
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillWebSocketAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills.Tests/Mocks/MockSkillWebSocketAdapter.cs
@@ -1,11 +1,15 @@
-﻿using Microsoft.Bot.Builder.Solutions;
+﻿using Microsoft.Bot.Builder.Skills.Auth;
+using Microsoft.Bot.Builder.Solutions;
 
 namespace Microsoft.Bot.Builder.Skills.Tests.Mocks
 {
     public class MockSkillWebSocketAdapter : SkillWebSocketAdapter
     {
-        public MockSkillWebSocketAdapter(SkillWebSocketBotAdapter skillWebSocketBotAdapter, BotSettingsBase botSettingsBase)
-            : base(skillWebSocketBotAdapter, botSettingsBase, new MockWhitelistAuthenticationProvider())
+        public MockSkillWebSocketAdapter(
+            SkillWebSocketBotAdapter skillWebSocketBotAdapter,
+            BotSettingsBase botSettingsBase,
+            IWhitelistAuthenticationProvider whitelistAuthenticationProvider)
+            : base(skillWebSocketBotAdapter, botSettingsBase, whitelistAuthenticationProvider)
         {
         }
     }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/Authenticator.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/Authenticator.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Bot.Builder.Skills.Auth
+{
+    public class Authenticator : IAuthenticator
+    {
+        private readonly IAuthenticationProvider _authenticationProvider;
+        private readonly IWhitelistAuthenticationProvider _whitelistAuthenticationProvider;
+
+        public Authenticator(IAuthenticationProvider authenticationProvider, IWhitelistAuthenticationProvider whitelistAuthenticationProvider)
+        {
+            _authenticationProvider = authenticationProvider ?? throw new ArgumentNullException(nameof(authenticationProvider));
+            _whitelistAuthenticationProvider = whitelistAuthenticationProvider ?? throw new ArgumentNullException(nameof(whitelistAuthenticationProvider));
+        }
+
+        public async Task<ClaimsIdentity> Authenticate(HttpRequest httpRequest, HttpResponse httpResponse)
+        {
+            if (httpRequest == null)
+            {
+                throw new ArgumentNullException(nameof(httpRequest));
+            }
+
+            if (httpResponse == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponse));
+            }
+
+            var authorizationHeader = httpRequest.Headers["Authorization"];
+            if (string.IsNullOrWhiteSpace(authorizationHeader))
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return null;
+            }
+
+            var claimsIdentity = _authenticationProvider.Authenticate(authorizationHeader);
+            if (claimsIdentity == null)
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return null;
+            }
+
+            var appIdClaimName = AuthHelpers.GetAppIdClaimName(claimsIdentity);
+            var appId = claimsIdentity.Claims.FirstOrDefault(c => c.Type == appIdClaimName)?.Value;
+            if (_whitelistAuthenticationProvider.AppsWhitelist == null
+                || _whitelistAuthenticationProvider.AppsWhitelist.Count == 0
+                || !_whitelistAuthenticationProvider.AppsWhitelist.Contains(appId))
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+                await httpResponse.WriteAsync("Skill could not allow access from calling bot.").ConfigureAwait(false);
+            }
+
+            return claimsIdentity;
+        }
+    }
+}

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/IAuthenticator.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Auth/IAuthenticator.cs
@@ -1,0 +1,11 @@
+﻿using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Bot.Builder.Skills.Auth
+{
+    public interface IAuthenticator
+    {
+        Task<ClaimsIdentity> Authenticate(HttpRequest httpRequest, HttpResponse httpResponse);
+    }
+}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Added ping API into SkillController so VA can use it to ping to see if a skill is live as well as testing out the Auth token

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
