### PR TITLE
BingSearchSkill uses thumbnail in Teams

### DIFF
--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Dialogs/SearchDialog.cs
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Dialogs/SearchDialog.cs
@@ -11,6 +11,8 @@ using BingSearchSkill.Models.Cards;
 using Microsoft.Bot.Schema;
 using System;
 using BingSearchSkill.Utilities;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Connector;
 
 namespace BingSearchSkill.Dialogs
 {
@@ -120,6 +122,11 @@ namespace BingSearchSkill.Dialogs
                         Link_View = entitiesResult[0].Url,
                         EntityTypeDisplayHint = entitiesResult[0].EntityTypeDisplayHint
                     };
+
+                    if (Channel.GetChannelId(stepContext.Context) == Channels.Msteams && !string.IsNullOrEmpty(entitiesResult[0].ThumbnailUrl))
+                    {
+                        celebrityData.IconPath = entitiesResult[0].ThumbnailUrl;
+                    }
 
                     tokens.Add("Speak", entitiesResult[0].Description);
 

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Models/SearchResultModel.cs
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Models/SearchResultModel.cs
@@ -35,6 +35,7 @@ namespace BingSearchSkill.Models
 
             Description = thing?.Description;
             ImageUrl = thing?.Image?.HostPageUrl;
+            ThumbnailUrl = thing?.Image?.ThumbnailUrl;
             EntityTypeDisplayHint = thing?.EntityPresentationInfo?.EntityTypeDisplayHint;
             Url = thing?.Url ?? thing?.WebSearchUrl;
             Name = thing?.Name;
@@ -72,6 +73,8 @@ namespace BingSearchSkill.Models
         public string ImageUrl { get; set; }
 
         public string Url { get; set; }
+
+        public string ThumbnailUrl { get; set; }
 
         public string Name { get; set; }
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2090

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

BingSearchSkill uses thumbnail in Teams temporarily until it is fixed in Teams

Comparison:
![Untitled](https://user-images.githubusercontent.com/2876650/62754847-21717f80-baa4-11e9-85a9-64dc64c4000a.png)

![Untitled](https://user-images.githubusercontent.com/2876650/62754867-31895f00-baa4-11e9-9680-fbe0aa28c167.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
