### PR TITLE
[TypeScript][Generator] Update the replacement of template's files

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
@@ -256,8 +256,8 @@ module.exports = class extends Generator {
       /([^a-z0-9-]+)/gi,
       ``
     );
-    
-    if (this.props.assistantName != assistantName) {
+
+    if (this.props.assistantName !== assistantName) {
       finalAssistantName = assistantName;
       containsSpecialCharacter = true;
     }
@@ -290,7 +290,7 @@ module.exports = class extends Generator {
 
     // Start the copy of the template
     this.copier.selectLanguages(assistantLang);
-    this.copier.copyIgnoringTemplateFiles(
+    this.copier.copyTemplate(
       templateName,
       assistantGenerationPath
     );
@@ -336,8 +336,13 @@ module.exports = class extends Generator {
       } else {
         this.spawnCommandSync("npm run build", []);
         if (containsSpecialCharacter) {
-          this.log(chalk.yellow(`\nYour virtual assistant name (${this.props.assistantName}) had special characters, it was changed to '${finalAssistantName}'`));
+          this.log(
+            chalk.yellow(
+              `\nYour virtual assistant name (${this.props.assistantName}) had special characters, it was changed to '${finalAssistantName}'`
+            )
+          );
         }
+
         this.log(chalk.green(`------------------------ `));
         this.log(chalk.green(` Your new assistant is ready!  `));
         this.log(chalk.green(`------------------------ `));
@@ -351,11 +356,7 @@ module.exports = class extends Generator {
             `\nNext step - being in the root of your generated assistant, to deploy it execute the following command:`
           )
         );
-        this.log(
-          chalk.blue(
-            `pwsh -File deployment\\scripts\\deploy.ps1`
-          )
-        );
+        this.log(chalk.blue(`pwsh -File deployment\\scripts\\deploy.ps1`));
       }
     } else {
       this.log(chalk.red.bold(`-------------------------------- `));

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/index.js
@@ -18,6 +18,7 @@ let skillGenerationPath = process.cwd();
 let isAlreadyCreated = false;
 let containsSpecialCharacter = false;
 let finalSkillName = "";
+
 const languagesChoice = [
   {
     name: "Chinese",
@@ -257,8 +258,8 @@ module.exports = class extends Generator {
         skillName
       );
     }
-    
-    if (this.props.skillName != skillName) {
+
+    if (this.props.skillName !== skillName) {
       finalSkillName = skillName;
       containsSpecialCharacter = true;
     }
@@ -288,8 +289,12 @@ module.exports = class extends Generator {
 
     // Start the copy of the template
     this.copier.selectLanguages(skillLang);
-    this.copier.copyIgnoringTemplateFiles(templateName, skillGenerationPath);
-    this.copier.copyTemplateFiles(templateName, skillGenerationPath, newSkill);
+    this.copier.copyTemplate(templateName, skillGenerationPath);
+    this.copier.copyTemplateFiles(
+      templateName,
+      skillGenerationPath,
+      newSkill
+    );
   }
 
   install() {
@@ -327,8 +332,13 @@ module.exports = class extends Generator {
       } else {
         this.spawnCommandSync("npm run build", []);
         if (containsSpecialCharacter) {
-          this.log(chalk.yellow(`\nYour skill name (${this.props.skillName}) had special characters, it was changed to '${finalSkillName}'`));
+          this.log(
+            chalk.yellow(
+              `\nYour skill name (${this.props.skillName}) had special characters, it was changed to '${finalSkillName}'`
+            )
+          );
         }
+
         this.log(chalk.green(`------------------------ `));
         this.log(chalk.green(` Your new skill is ready!  `));
         this.log(chalk.green(`------------------------ `));
@@ -342,11 +352,7 @@ module.exports = class extends Generator {
             `\nNext step - being in the root of your generated skill, to deploy it execute the following command:`
           )
         );
-        this.log(
-          chalk.blue(
-            `pwsh -File deployment\\scripts\\deploy.ps1`
-          )
-        );
+        this.log(chalk.blue(`pwsh -File deployment\\scripts\\deploy.ps1`));
       }
     } else {
       this.log(chalk.red.bold(`-------------------------------- `));

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
@@ -5,6 +5,7 @@
 "use strict";
 const { join } = require(`path`);
 const templateFiles = new Map();
+const deploymentTemplateFiles = new Map();
 const allLanguages = [`zh`, `de`, `en`, `fr`, `it`, `es`];
 let ignoredLanguages = [];
 let selectedLanguages = [];
@@ -16,22 +17,30 @@ class Copier {
   }
 
   // Copy the template ignoring the templates files, those that starts with _ character
-  copyIgnoringTemplateFiles(srcFolder, dstFolder) {
+  copyTemplate(srcFolder, dstFolder) {
     this.generator.fs.copy(
       this.generator.templatePath(srcFolder),
       this.generator.destinationPath(dstFolder),
       {
         globOptions: {
-          ignore: ["**/_*.*", ...ignoredLanguages]
+          ignore: [...ignoredLanguages]
         }
       }
     );
   }
 
-  // Copy the templates files passing the attributes of the new skill
+  // Copy the templates files passing the attributes of the new assistant and remove the files starting with character "_"
   copyTemplateFiles(srcFolder, dstFolder, newSkill) {
     this.loadTemplatesFiles(newSkill);
     templateFiles.forEach((dstFile, srcFile) => {
+      this.generator.fs.copyTpl(
+        this.generator.templatePath(srcFolder, srcFile),
+        this.generator.destinationPath(dstFolder, dstFile),
+        newSkill
+      );
+      this.generator.fs.delete(join(dstFolder, srcFile));
+    });
+    deploymentTemplateFiles.forEach((dstFile, srcFile) => {
       this.generator.fs.copyTpl(
         this.generator.templatePath(srcFolder, srcFile),
         this.generator.destinationPath(dstFolder, dstFile),
@@ -52,8 +61,8 @@ class Copier {
       });
 
     // Add the paths of the deployment languages
-    selectedLanguages.forEach(language => {
-      templateFiles.set(
+    languages.forEach(language => {
+      deploymentTemplateFiles.set(
         join(`deployment`, `resources`, `LU`, language, `general.lu`),
         join(`deployment`, `resources`, `LU`, language, `general.lu`)
       );

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
@@ -29,7 +29,7 @@ class Copier {
     );
   }
 
-  // Copy the templates files passing the attributes of the new assistant and remove the files starting with character "_"
+  // Copy the templates files passing the attributes of the new skill
   copyTemplateFiles(srcFolder, dstFolder, newSkill) {
     this.loadTemplatesFiles(newSkill);
     templateFiles.forEach((dstFile, srcFile) => {


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_

Update the replacement of templates files in order to have the same behavior between different Operating Systems.
Fix #2059

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_

Add into `generator-botbuilder` a logic to remove the files starting with character `_` after generating the `VA`/`Skill`.

![image](https://user-images.githubusercontent.com/40918752/62898810-c69e8900-bd2c-11e9-9a86-3cdb4e72905e.png)


## Testing Steps
1. Go to `.\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant`
1. Open a terminal in that location and execute `npm link` to link the package to the global `node_modules`  folder.
1. Open a terminal in a new folder outside the repository and execute `yo botbuilder-assistant` or `yo botbuilder-assistant:skill`.
1. Verify that everything is ok

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

## Checklist