### PR TITLE
[CI] Script issue which cause failed to run update_cognitive_models.ps1 in DevOps

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/experimental/newsskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/experimental/newsskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {
@@ -108,5 +108,6 @@ function RunLuisGen($lu_file, $outName, $outFolder) {
 	$luisFolder = $lu_file.DirectoryName
 	$luisFile = Join-Path $luisFolder "$($id).luis"
 
-	luisgen $luisFile -cs "$($outName)Luis" -o $outFolder
+    # Disabled due to issue https://github.com/microsoft/botbuilder-tools/issues/1260
+	#luisgen $luisFile -cs "$($outName)Luis" -o $outFolder
 }

--- a/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {
@@ -108,5 +108,6 @@ function RunLuisGen($lu_file, $outName, $outFolder) {
 	$luisFolder = $lu_file.DirectoryName
 	$luisFile = Join-Path $luisFolder "$($id).luis"
 
-	luisgen $luisFile -cs "$($outName)Luis" -o $outFolder
+    # Disabled due to issue https://github.com/microsoft/botbuilder-tools/issues/1260
+	#luisgen $luisFile -cs "$($outName)Luis" -o $outFolder
 }

--- a/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/luis_functions.ps1
+++ b/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+		luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+        luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/luis_functions.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+            luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+            luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+        luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/luis_functions.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+	    luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+            luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+            luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+            luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/luis_functions.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/luis_functions.ps1
@@ -30,8 +30,8 @@ function DeployLUIS ($name, $lu_file, $region, $luisAuthoringKey, $language, $lo
 	}
 	else {
 	    # train and publish luis app
-		$(luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
-        & luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait) 2>> $log | Out-Null
+            luis train version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait 
+            luis publish version --appId $luisApp.id --region $region --authoringKey $luisAuthoringKey --versionId $luisApp.activeVersion --wait
 
 		Return $luisApp
 	}
@@ -99,8 +99,8 @@ function UpdateLUIS ($lu_file, $appId, $version, $region, $authoringKey, $subscr
         --wait | ConvertFrom-Json
     
     # train and publish luis app
-    $(luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
-    & luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait) 2>> $log | Out-Null
+    luis train version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait 
+    luis publish version --appId $appId --region $region --authoringKey $authoringKey --versionId $version --wait
 }
 
 function RunLuisGen($lu_file, $outName, $outFolder) {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #2117 [CI] Script issue which cause failed to run update_cognitive_models.ps1 in DevOps

### Changes
Fix issue which cause failed to run update_cognitive_models.ps1 in DevOps
Disable luisgen for poi skill due to issue microsoft/botbuilder-tools#1260

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
