### PR TITLE
 [Skills] Should use score threshold to filter general intent in OnInterruptDialogAsync

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/MainDialog.cs
@@ -149,22 +149,25 @@ namespace AutomotiveSkill.Dialogs
                 else
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
                     // check intent
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    result = await OnHelp(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
@@ -275,28 +275,31 @@ namespace CalendarSkill.Dialogs
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
                     state.GeneralLuisResult = luisResult;
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
-                    // check intent
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        // check intent
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/skills/src/csharp/emailskill/emailskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/emailskill/emailskill/Dialogs/MainDialog.cs
@@ -256,27 +256,30 @@ namespace EmailSkill.Dialogs
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
                     state.GeneralLuisResult = luisResult;
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/skills/src/csharp/experimental/newsskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/newsskill/Dialogs/MainDialog.cs
@@ -155,21 +155,18 @@ namespace NewsSkill.Dialogs
                 else
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
-
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/skills/src/csharp/experimental/restaurantbooking/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/restaurantbooking/Dialogs/MainDialog.cs
@@ -174,27 +174,30 @@ namespace RestaurantBooking.Dialogs
                     else
                     {
                         var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
-                        var topIntent = luisResult.TopIntent().intent;
+                        var topIntent = luisResult.TopIntent();
 
-                        switch (topIntent)
+                        if (topIntent.score > 0.5)
                         {
-                            case General.Intent.Cancel:
-                                {
-                                    result = await OnCancel(dc);
-                                    break;
-                                }
+                            switch (topIntent.intent)
+                            {
+                                case General.Intent.Cancel:
+                                    {
+                                        result = await OnCancel(dc);
+                                        break;
+                                    }
 
-                            case General.Intent.Help:
-                                {
-                                    result = await OnHelp(dc);
-                                    break;
-                                }
+                                case General.Intent.Help:
+                                    {
+                                        result = await OnHelp(dc);
+                                        break;
+                                    }
 
-                            case General.Intent.Logout:
-                                {
-                                    result = await OnLogout(dc);
-                                    break;
-                                }
+                                case General.Intent.Logout:
+                                    {
+                                        result = await OnLogout(dc);
+                                        break;
+                                    }
+                            }
                         }
                     }
                 }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
@@ -256,27 +256,30 @@ namespace PointOfInterestSkill.Dialogs
                 else
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }

--- a/skills/src/csharp/todoskill/todoskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/todoskill/todoskill/Dialogs/MainDialog.cs
@@ -211,27 +211,30 @@ namespace ToDoSkill.Dialogs
                 {
                     var luisResult = await luisService.RecognizeAsync<General>(dc.Context, cancellationToken);
                     state.GeneralLuisResult = luisResult;
-                    var topIntent = luisResult.TopIntent().intent;
+                    var topIntent = luisResult.TopIntent();
 
-                    switch (topIntent)
+                    if (topIntent.score > 0.5)
                     {
-                        case General.Intent.Cancel:
-                            {
-                                result = await OnCancel(dc);
-                                break;
-                            }
+                        switch (topIntent.intent)
+                        {
+                            case General.Intent.Cancel:
+                                {
+                                    result = await OnCancel(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Help:
-                            {
-                                // result = await OnHelp(dc);
-                                break;
-                            }
+                            case General.Intent.Help:
+                                {
+                                    // result = await OnHelp(dc);
+                                    break;
+                                }
 
-                        case General.Intent.Logout:
-                            {
-                                result = await OnLogout(dc);
-                                break;
-                            }
+                            case General.Intent.Logout:
+                                {
+                                    result = await OnLogout(dc);
+                                    break;
+                                }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2094 [Skills] Should use score threshold to filter general intent in OnInterruptDialogAsync

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Add threshold.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
