### PR TITLE
[TypeScript][Samples/Template] Add UTF8 default encoding for deployment scripts 

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -293,4 +293,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json") -Encoding utf8

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -293,4 +293,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Add needed deployment configuration
-	Add-Content -Path -Encoding utf8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
+	Add-Content -Path $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true") -Encoding utf8
 }
 
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Add needed deployment configuration
-	Add-Content -Path $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
+	Add-Content -Path -Encoding utf8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
 }
 
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -292,4 +292,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -292,4 +292,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json") -Encoding utf8

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding uft8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding uft8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -293,4 +293,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json") -Encoding utf8

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -293,4 +293,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Add needed deployment configuration
-	Add-Content -Path -Encoding utf8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
+	Add-Content -Path $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true") -Encoding utf8
 }
 
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Add needed deployment configuration
-	Add-Content -Path $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
+	Add-Content -Path -Encoding UTF8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
 }
 
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
 	# Add needed deployment configuration
-	Add-Content -Path -Encoding UTF8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
+	Add-Content -Path -Encoding utf8 $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true")
 }
 
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding UTF8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -179,7 +179,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -292,4 +292,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -292,4 +292,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json") -Encoding utf8


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
Solve the issue that the user had deploying a `VA/Skill` which updates the `appsettings.json` and `cognitivemodels.json` with Encoding in `UTF-16` in `macOS`.

Fix  #2007 

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp?_ (Include illustrative screenshots for context if applicable.)

We added the argument `-Encoding utf8` for some cmdlets like `Out-File` and `Get-Content`.
The scripts that we updated in the `Templates` and `Samples`, are the following:
* `deploy.ps1`
* `deploy_cognitive_models.ps1`
* `publish.ps1`

![image](https://user-images.githubusercontent.com/40918752/63108864-45c6d380-bf5e-11e9-8fba-868f472ba944.png)

## Testing Steps
1. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant`
1. Open a terminal in that location and execute `pwsh.exe -File deployment\scripts\deploy.ps1`.
1. Execute `npm install` to install the dependencies.
1. Execute `npm run build`.
1. Verify that the `Enconding` in `appsettings.json` and `cognitivemodels.json` is `UTF8`.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

## Checklist
