### PR TITLE
unify name of DialogState

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/Adapters/AutomotiveSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Adapters/AutomotiveSkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace AutomotiveSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(AutomotiveSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/calendarskill/calendarskill/Adapters/CalendarSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Adapters/CalendarSkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace CalendarSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(CalendarSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/emailskill/emailskill/Adapters/EmailSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/emailskill/emailskill/Adapters/EmailSkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace EmailSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(EmailSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Adapters/CustomSkillAdapter.cs
@@ -33,7 +33,7 @@ namespace BingSearchSkill.Adapters
             Use(new ShowTypingMiddleware());
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(BingSearchSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/experimental/hospitalityskill/Adapters/HospitalitySkillAdapter.cs
+++ b/skills/src/csharp/experimental/hospitalityskill/Adapters/HospitalitySkillAdapter.cs
@@ -35,7 +35,7 @@ namespace HospitalitySkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(HospitalitySkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/experimental/newsskill/Adapters/NewsSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/experimental/newsskill/Adapters/NewsSkillWebSocketBotAdapter.cs
@@ -30,7 +30,7 @@ namespace NewsSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(NewsSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/experimental/restaurantbooking/Adapters/RestaurantSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/experimental/restaurantbooking/Adapters/RestaurantSkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace RestaurantBooking.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(RestaurantBooking))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/experimental/weatherskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/src/csharp/experimental/weatherskill/Adapters/CustomSkillAdapter.cs
@@ -33,7 +33,7 @@ namespace WeatherSkill.Adapters
             Use(new ShowTypingMiddleware());
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(WeatherSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Adapters/POISkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Adapters/POISkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace PointOfInterestSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(PointOfInterestSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }

--- a/skills/src/csharp/todoskill/todoskill/Adapters/ToDoSkillWebSocketBotAdapter.cs
+++ b/skills/src/csharp/todoskill/todoskill/Adapters/ToDoSkillWebSocketBotAdapter.cs
@@ -32,7 +32,7 @@ namespace ToDoSkill.Adapters
             Use(new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation: true));
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
-            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(ToDoSkill))));
+            Use(new SkillMiddleware(userState, conversationState, conversationState.CreateProperty<DialogState>(nameof(DialogState))));
         }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2135

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Change name of DialogState in SkillMiddleware

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
