### PR TITLE
[Script] cognitive model args should be camelCased

### DIFF
--- a/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/cognitivemodels.json
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/cognitivemodels.json
@@ -4,22 +4,22 @@
       "languageModels": [
         {
           "id": "BingSearchSkill",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": "",
+          "subscriptionKey": "",
           "region": "",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": ""
         },
         {
           "id": "General",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": "",
+          "subscriptionKey": "",
           "region": "",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": ""
         }
       ]

--- a/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/hospitalityskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/newsskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/newsskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/experimental/newsskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/newsskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/experimental/weatherskill/cognitivemodels.json
+++ b/skills/src/csharp/experimental/weatherskill/cognitivemodels.json
@@ -4,22 +4,22 @@
       "languageModels": [
         {
           "version": "",
-          "appid": "",
+          "appId": "",
           "id": "General",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
           "region": "",
-          "subscriptionkey": "",
+          "subscriptionKey": "",
           "name": ""
         },
         {
           "version": "",
-          "appid": "",
+          "appId": "",
           "id": "WeatherSkill",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
           "region": "",
-          "subscriptionkey": "",
+          "subscriptionKey": "",
           "name": ""
         }
       ]

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/templates/Skill-Template/csharp/Sample/SkillSample/cognitivemodels.json
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/cognitivemodels.json
@@ -5,22 +5,22 @@
         {
           "id": "general",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": "0.1",
           "region": "",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": ""
+          "subscriptionKey": ""
         },
         {
           "id": "skill",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": "0.1",
           "region": "",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": ""
+          "subscriptionKey": ""
         }
       ]
     }

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -181,10 +181,10 @@ foreach ($language in $languageArr)
 				$config.languageModels += @{
 					id = $lu.BaseName
 					name = $luisApp.name
-					appid = $luisApp.id
-					authoringkey = $luisAuthoringKey
+					appId = $luisApp.id
+					authoringKey = $luisAuthoringKey
                     authoringRegion = $luisAuthoringRegion
-					subscriptionkey = $luisSubscriptionKey
+					subscriptionKey = $luisSubscriptionKey
 					version = $luisApp.activeVersion
 					region = $luisAccountRegion
 				}
@@ -283,10 +283,10 @@ foreach ($language in $languageArr)
 			$config.dispatchModel = @{
 				type = "dispatch"
 				name = $dispatchApp.name
-				appid = $dispatchApp.appId
-				authoringkey = $luisauthoringkey
+				appId = $dispatchApp.appId
+				authoringKey = $luisauthoringkey
                 authoringRegion = $luisAuthoringRegion
-				subscriptionkey = $luisSubscriptionKey
+				subscriptionKey = $luisSubscriptionKey
 				region = $luisAccountRegion
 			}
 		}

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
@@ -42,7 +42,7 @@ foreach ($langCode in $languageMap.Keys) {
 
             Write-Host "> Updating local $($luisApp.id).lu file ..."
             luis export version `
-                --appId $luisApp.appid `
+                --appId $luisApp.appId `
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --authoringKey $luisApp.authoringKey | ludown refresh `
@@ -76,7 +76,7 @@ foreach ($langCode in $languageMap.Keys) {
                 (dispatch add `
                         --type "luis" `
                         --name $luisApp.name `
-                        --id $luisApp.appid  `
+                        --id $luisApp.appId  `
                         --region $luisApp.authoringRegion `
                         --intentName "l_$($luisApp.id)" `
                         --dispatch $(Join-Path $dispatchFolder $langCode "$($dispatch.name).dispatch") `
@@ -117,7 +117,7 @@ foreach ($langCode in $languageMap.Keys) {
             $lu = Get-Item -Path $(Join-Path $luisFolder $langCode "$($luisApp.id).lu")
             UpdateLUIS `
                 -lu_file $lu `
-                -appId $luisApp.appid `
+                -appId $luisApp.appId `
                 -version $luisApp.version `
                 -region $luisApp.authoringRegion `
                 -authoringKey $luisApp.authoringKey `

--- a/templates/Skill-Template/csharp/Template/Skill/cognitivemodels.json
+++ b/templates/Skill-Template/csharp/Template/Skill/cognitivemodels.json
@@ -5,22 +5,22 @@
         {
           "id": "general",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": "0.1",
           "region": "",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": ""
+          "subscriptionKey": ""
         },
         {
           "id": "skill",
           "name": "",
-          "appid": "",
+          "appId": "",
           "version": "0.1",
           "region": "",
-          "authoringkey": "",
+          "authoringKey": "",
           "authoringRegion": "",
-          "subscriptionkey": ""
+          "subscriptionKey": ""
         }
       ]
     }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #2140 [Script] cognitive model args should be camelCased

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Change to camel case

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
