### PR TITLE
remove event triggering for action from documentation

### DIFF
--- a/docs/_docs/reference/skills/skillmanifest.md
+++ b/docs/_docs/reference/skills/skillmanifest.md
@@ -35,7 +35,6 @@ A manifest is made up of the following structure:
   - Trigger
     - UtteranceSources
     - Utterance
-    - Events
 
 ### Manifest Header
 
@@ -116,7 +115,7 @@ Parameter  | Description | Required
 
 ### Trigger
 
-A given action can be trigged through different mechanisms, an utterance or an event. Example triggering utterances must be provided by a skill to enable a caller to train a natural language dispatcher so it can identify utterances that should be routed to a skill.
+A given action can be trigged through different mechanisms or an utterance. Example triggering utterances must be provided by a skill to enable a caller to train a natural language dispatcher so it can identify utterances that should be routed to a skill.
 
 References to an source of utterances can be provided through the (`utteranceSource`) element.
 
@@ -149,17 +148,6 @@ Utterances can also be provided in-line with the skill manifest as shown below. 
 ```
 
 Both `utteranceSources` and `utterances` support multiple-locales enabling you to express the locales your Skill supports.
-
-Actions can also be invoked through an event mechanism. The event trigger specifies the name of an Activity which will trigger a given action to be performed. In this case retrieve a meeting summary for today.
-
-```json
- "triggers": {
-    "events": [
-    {
-        "name": "summaryEvent"
-    }]
-}
-```
 
 ### Example Skill Manifest
 
@@ -286,20 +274,6 @@ Actions can also be invoked through an event mechanism. The event trigger specif
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "calendarskill_summary",
-      "definition": {
-        "description": "Retrieve a summary of meetings through an event invocation.",
-        "slots": [],
-        "triggers": {
-          "events": [
-            {
-              "name": "summaryEvent"
             }
           ]
         }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Remove event triggering for actions from documentation since we're not allowing event triggering for actions any more. 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
