### PR TITLE
fix speech auth

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
@@ -12,7 +12,6 @@ using Microsoft.Bot.Builder.Solutions.Authentication;
 using Microsoft.Bot.Builder.Solutions.Dialogs;
 using Microsoft.Bot.Builder.Solutions.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.Rest;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills
@@ -24,7 +23,6 @@ namespace Microsoft.Bot.Builder.Skills
     {
         private readonly MultiProviderAuthDialog _authDialog;
         private IServiceClientCredentials _serviceClientCredentials;
-        private IBotTelemetryClient _telemetryClient;
         private UserState _userState;
 
         private SkillManifest _skillManifest;
@@ -34,6 +32,8 @@ namespace Microsoft.Bot.Builder.Skills
         private object _lockObject = new object();
 
         private ISkillIntentRecognizer _skillIntentRecognizer;
+
+        private bool _authDialogCancelled = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SkillDialog"/> class.
@@ -58,7 +58,6 @@ namespace Microsoft.Bot.Builder.Skills
         {
             _skillManifest = skillManifest ?? throw new ArgumentNullException(nameof(SkillManifest));
             _serviceClientCredentials = serviceClientCredentials ?? throw new ArgumentNullException(nameof(serviceClientCredentials));
-            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _userState = userState;
             _skillTransport = skillTransport ?? new SkillWebSocketTransport(telemetryClient);
             _skillIntentRecognizer = skillIntentRecognizer;
@@ -213,7 +212,11 @@ namespace Microsoft.Bot.Builder.Skills
 
             await innerDc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"-->Handing off to the {_skillManifest.Name} skill."));
 
-            return await ForwardToSkillAsync(innerDc, activity);
+            var dialogResult = await ForwardToSkillAsync(innerDc, activity);
+
+            _skillTransport.Disconnect();
+
+            return dialogResult;
         }
 
         /// <summary>
@@ -325,13 +328,21 @@ namespace Microsoft.Bot.Builder.Skills
                     await innerDc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"<--Ending the skill conversation with the {_skillManifest.Name} Skill and handing off to Parent Bot."));
                     return await innerDc.EndDialogAsync(endOfConversationActivity.SemanticAction?.Entities);
                 }
+                else if (_authDialogCancelled)
+                {
+                    // cancel remote skill dialog if AuthDialog is cancelled
+                    await _skillTransport.CancelRemoteDialogsAsync(_skillManifest, _serviceClientCredentials, innerDc.Context);
+
+                    await innerDc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"<--Ending the skill conversation with the {_skillManifest.Name} Skill and handing off to Parent Bot due to unable to obtain token for user."));
+                    return await innerDc.EndDialogAsync();
+                }
                 else
                 {
                     var dialogResult = new DialogTurnResult(DialogTurnStatus.Waiting);
 
                     // if there's any response we need to send to the skill queued
                     // forward to skill and start a new turn
-                    while (_queuedResponses.Count > 0 && dialogResult.Status != DialogTurnStatus.Complete && dialogResult.Status != DialogTurnStatus.Cancelled)
+                    while (_queuedResponses.Count > 0)
                     {
                         var lastEvent = _queuedResponses.Dequeue();
 
@@ -391,19 +402,27 @@ namespace Microsoft.Bot.Builder.Skills
                 // Send trace to emulator
                 dialogContext.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"<--Received a Token Request from a skill")).GetAwaiter().GetResult();
 
-                var authResult = dialogContext.BeginDialogAsync(_authDialog.Id).GetAwaiter().GetResult();
+                var result = dialogContext.BeginDialogAsync(_authDialog.Id).GetAwaiter().GetResult();
 
-                if (authResult.Result?.GetType() == typeof(ProviderTokenResponse))
+                if (result.Status == DialogTurnStatus.Complete)
                 {
-                    var tokenEvent = activity.CreateReply();
-                    tokenEvent.Type = ActivityTypes.Event;
-                    tokenEvent.Name = TokenEvents.TokenResponseEventName;
-                    tokenEvent.Value = authResult.Result as ProviderTokenResponse;
-                    tokenEvent.SemanticAction = activity.SemanticAction;
-
-                    lock (_lockObject)
+                    var resultObj = result.Result;
+                    if (resultObj != null && resultObj is ProviderTokenResponse tokenResponse)
                     {
-                        _queuedResponses.Enqueue(tokenEvent);
+                        var tokenEvent = activity.CreateReply();
+                        tokenEvent.Type = ActivityTypes.Event;
+                        tokenEvent.Name = TokenEvents.TokenResponseEventName;
+                        tokenEvent.Value = tokenResponse;
+                        tokenEvent.SemanticAction = activity.SemanticAction;
+
+                        lock (_lockObject)
+                        {
+                            _queuedResponses.Enqueue(tokenEvent);
+                        }
+                    }
+                    else
+                    {
+                        _authDialogCancelled = true;
                     }
                 }
             };


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

close #2073 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

In speech scenario, when Auth fails the dialog doesn't end properly. This PR is to fix that.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
