### PR TITLE
Add version and privacyPolicy to manifest

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Manifest/SkillManifestGenerator.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Manifest/SkillManifestGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Skills
             _httpClient = httpClient;
         }
 
-        public async Task<SkillManifest> GenerateManifest(string manifestFile, string appId, Dictionary<string, BotSettingsBase.CognitiveModelConfiguration> cognitiveModels, string uriBase, bool inlineTriggerUtterances = false)
+        public async Task<SkillManifest> GenerateManifest(string manifestFile, string appId, Dictionary<string, BotSettingsBase.CognitiveModelConfiguration> cognitiveModels, string uriBase, bool inlineTriggerUtterances = false, string version = null, string privacyPolicy = null)
         {
             SkillManifest skillManifest = null;
 
@@ -62,6 +62,8 @@ namespace Microsoft.Bot.Builder.Skills
                 }
 
                 skillManifest.MSAappId = appId;
+                skillManifest.Version = version;
+                skillManifest.PrivacyPolicy = privacyPolicy;
                 skillManifest.Endpoint = new Uri($"{uriBase}{_skillRoute}");
 
                 if (skillManifest.IconUrl != null)

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/SkillManifest.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/Models/Manifest/SkillManifest.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Bot.Builder.Skills.Models.Manifest
         [JsonProperty(PropertyName = "description")]
         public string Description { get; set; }
 
+        [JsonProperty(PropertyName = "privacyPolicy")]
+        public string PrivacyPolicy { get; set; }
+
+        [JsonProperty(PropertyName = "version")]
+        public string Version { get; set; }
+
         [JsonProperty(PropertyName = "iconUrl")]
         public Uri IconUrl { get; set; }
 

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillController.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillController.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Skills
                 string skillUriBase = $"{HttpContext.Request.Scheme}://{HttpContext.Request.Host}";
 
                 SkillManifestGenerator manifestGenerator = new SkillManifestGenerator(HttpClient);
-                var skillManifest = await manifestGenerator.GenerateManifest(ManifestTemplateFilename, _botSettings.MicrosoftAppId, _botSettings.CognitiveModels, skillUriBase, inlineTriggerUtterances);
+                var skillManifest = await manifestGenerator.GenerateManifest(ManifestTemplateFilename, _botSettings.MicrosoftAppId, _botSettings.CognitiveModels, skillUriBase, inlineTriggerUtterances, _botSettings.Version, _botSettings.PrivacyPolicy);
 
                 Response.ContentType = "application/json";
                 Response.StatusCode = 200;

--- a/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/BotSettingsBase.cs
+++ b/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/BotSettingsBase.cs
@@ -28,6 +28,22 @@
         public string MicrosoftAppPassword { get; set; }
 
         /// <summary>
+        /// Gets or sets the skill version.
+        /// </summary>
+        /// <value>
+        /// The skill version.
+        /// </value>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the privacy policy.
+        /// </summary>
+        /// <value>
+        /// The privacy policy.
+        /// </value>
+        public string PrivacyPolicy { get; set; }
+
+        /// <summary>
         /// Gets or sets the default locale of the bot.
         /// </summary>
         /// <value>


### PR DESCRIPTION
This is regarding #2180 and a need for additional fields in the skill manifest
### Purpose
Adds version and privacy policy per Salem's design

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? 
No

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
These are changes to the manifest.

### Feature Plan
I have linked to an issue tracking this request.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
