### PR TITLE
[Botskills] Update the output format for az commands

### DIFF
--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -123,6 +123,7 @@ export class AuthenticationUtils {
                     const listAuthSettingsCommand: string[] = ['az', 'bot', 'authsetting', 'list'];
                     listAuthSettingsCommand.push(...['-n', configuration.botName]);
                     listAuthSettingsCommand.push(...['-g', configuration.resourceGroup]);
+                    listAuthSettingsCommand.push(...['--output', 'json']);
 
                     logger.command('Checking for existing aad connections', listAuthSettingsCommand.join(' '));
                     currentCommand = listAuthSettingsCommand;
@@ -140,6 +141,7 @@ export class AuthenticationUtils {
                         showAuthSettingsCommand.push(...['-n', configuration.botName]);
                         showAuthSettingsCommand.push(...['-g', configuration.resourceGroup]);
                         showAuthSettingsCommand.push(...['-c', settingName]);
+                        showAuthSettingsCommand.push(...['--output', 'json']);
 
                         logger.command('Getting current aad auth settings', showAuthSettingsCommand.join(' '));
                         currentCommand = showAuthSettingsCommand;
@@ -155,6 +157,7 @@ export class AuthenticationUtils {
                         deleteAuthSettingCommand.push(...['-n', configuration.botName]);
                         deleteAuthSettingCommand.push(...['-g', configuration.resourceGroup]);
                         deleteAuthSettingCommand.push(...['-c', settingName]);
+                        deleteAuthSettingCommand.push(...['--output', 'json']);
 
                         logger.command('Deleting current bot authentication setting', deleteAuthSettingCommand.join(' '));
                         currentCommand = deleteAuthSettingCommand;
@@ -190,6 +193,7 @@ export class AuthenticationUtils {
                     // get the information of the app
                     const azureAppShowCommand: string[] = ['az', 'ad', 'app', 'show'];
                     azureAppShowCommand.push(...['--id', appSettings.microsoftAppId]);
+                    azureAppShowCommand.push(...['--output', 'json']);
 
                     logger.command('Getting the app information', azureAppShowCommand.join(' '));
                     currentCommand = azureAppShowCommand;
@@ -208,6 +212,7 @@ export class AuthenticationUtils {
                     const azureAppUpdateCommand: string[] = ['az', 'ad', 'app', 'update'];
                     azureAppUpdateCommand.push(...['--id', appSettings.microsoftAppId]);
                     azureAppUpdateCommand.push(...['--reply-urls', replyUrls.join(' ')]);
+                    azureAppUpdateCommand.push(...['--output', 'json']);
                     const scopeManifestText: string = JSON.stringify(scopeManifest)
                         .replace(/\"/g, '\'');
                     azureAppUpdateCommand.push(...['--required-resource-accesses', `"${scopeManifestText}"`]);
@@ -233,6 +238,7 @@ export class AuthenticationUtils {
                     authSettingCommand.push(...['--parameters', `clientId="${appSettings.microsoftAppId}"`]);
                     authSettingCommand.push(...[`clientSecret="${appSettings.microsoftAppPassword}"`, 'tenantId=common']);
                     authSettingCommand.push(...['--provider-scope-string', `"${scopes.join(' ')}"`]);
+                    authSettingCommand.push(...['--output', 'json']);
 
                     logger.command('Creating the updated bot authentication setting', authSettingCommand.join(' '));
                     currentCommand = authSettingCommand;

--- a/tools/botskills/test/authentication.test.js
+++ b/tools/botskills/test/authentication.test.js
@@ -137,7 +137,7 @@ describe("The authentication util", function() {
 
             const warningList = configuration.logger.getWarning();
             strictEqual(warningList[warningList.length - 1], `For more information on setting up the authentication configuration manually go to:
-https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assistant/linkedaccounts.md#authentication-configuration`);
+https://aka.ms/vamanualauthsteps`);
             strictEqual(warningList[warningList.length - 2], `There's no Azure Active Directory v2 authentication connection in your Skills manifest. You must configure one of the following connection types MANUALLY in the Azure Portal:
         Google`);
         });
@@ -171,10 +171,10 @@ https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assis
             
             const warningList = configuration.logger.getWarning();
             strictEqual(warningList[warningList.length - 1], `For more information on setting up the authentication configuration manually go to:
-https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assistant/linkedaccounts.md#authentication-configuration`);
+https://aka.ms/vamanualauthsteps`);
             strictEqual(warningList[warningList.length - 2], `You must configure one of the following connection types MANUALLY in the Azure Portal:
         Azure Active Directory v2`);
-            strictEqual(warningList[warningList.length - 3], `There was an error while executing the following command:\n\taz ad app show --id \nMocked function throws an Error`)
+            strictEqual(warningList[warningList.length - 3], `There was an error while executing the following command:\n\taz ad app show --id  --output json\nMocked function throws an Error`)
         });
 
         it("when the scopes are not configured automatically", async function() {


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
Solve the issue that the user had when the `az cli` default output is set to a different format to **json**, the connect command fails on the `az commands` during the authentication process.

Fix #2107

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp?_ (Include illustrative screenshots for context if applicable.)

Add the argument `--output json` for some commands like:
- `az bot authsetting list` 
- `az bot authsetting show`
- `az bot authsetting delete`
- `az bot authsetting create`
- `az ad app show`
- `az ad app update`

![image](https://user-images.githubusercontent.com/40918752/63467833-b0837d80-c43c-11e9-9c06-ab6c12c50f0f.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes, we updated `authentication` tests

### Testing Steps
1. Execute `az configure` to set the output to a different format to **json** following this [steps](https://microsoft.github.io/AzureTipsAndTricks/blog/tip8.html#configure-the-azure-cli-to-set-defaults-and-more).
1. Open a terminal in `.\tools\botskills`
1. Execute `npm install` to install the dependencies.
1. Execute `npm run build
1. Connect a `Virtual Assistant` and `Skill` with `authentication connections`
1. Verify that the authentication process finished successfully

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects