### PR TITLE
[Botskills] Add msaAppId property to skillManifest model

### DIFF
--- a/tools/botskills/src/models/skillManifest.ts
+++ b/tools/botskills/src/models/skillManifest.ts
@@ -6,6 +6,7 @@
 export interface ISkillManifest {
     id: string;
     name: string;
+    msaAppId: string;
     endpoint: string;
     description: string;
     suggestedAction: string;

--- a/tools/botskills/test/authentication.test.js
+++ b/tools/botskills/test/authentication.test.js
@@ -137,7 +137,7 @@ describe("The authentication util", function() {
 
             const warningList = configuration.logger.getWarning();
             strictEqual(warningList[warningList.length - 1], `For more information on setting up the authentication configuration manually go to:
-https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assistant/linkedaccounts.md#authentication-configuration`);
+https://aka.ms/vamanualauthsteps`);
             strictEqual(warningList[warningList.length - 2], `There's no Azure Active Directory v2 authentication connection in your Skills manifest. You must configure one of the following connection types MANUALLY in the Azure Portal:
         Google`);
         });
@@ -171,7 +171,7 @@ https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assis
             
             const warningList = configuration.logger.getWarning();
             strictEqual(warningList[warningList.length - 1], `For more information on setting up the authentication configuration manually go to:
-https://github.com/microsoft/botframework-solutions/blob/master/docs/howto/assistant/linkedaccounts.md#authentication-configuration`);
+https://aka.ms/vamanualauthsteps`);
             strictEqual(warningList[warningList.length - 2], `You must configure one of the following connection types MANUALLY in the Azure Portal:
         Azure Active Directory v2`);
             strictEqual(warningList[warningList.length - 3], `There was an error while executing the following command:\n\taz ad app show --id \nMocked function throws an Error`)


### PR DESCRIPTION
Cherry pick of #1983 to master

## Purpose
_What is the context of this pull request? Why is it being done?_

When making the connection between the `VA` and the `Skill`, we realized that a property from the manifest was missing.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_

- Add the `msaAppId` property to `Botskills CLI` `skillManifest` model
- Fix broken tests

## Testing Steps
1. Go to `.\tools\botskills`.
1. Open a terminal in that location.
1. Execute `npm link` to install the library locally.
1. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant\` and  `.\templates\Virtual-Assistant-Template\typescript\samples\sample-skill\`.
1. Open a terminal in both location.
1. Connect the `sample-assistant` with the `sample-skill`.
1. Execute `npm install` to install dependencies.
1. Execute `npm run build` to build the project.
1. Execute `npm run start` to start the bots.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._

This property is the one that was added to `botskills` in the `SkillManifest` so that you can make the connection between the `Skill` and the `Virtual Assistant`.
