### PR TITLE
use handoff to signal completion of skill dialog

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillCallingRequestHandler.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillCallingRequestHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Bot.Builder.Skills
                                             throw new ArgumentNullException("FallbackRequestHandler", "Skill is asking for fallback but there is no handler on the calling side!");
                                         }
                                     }
-                                    else if (activity.Type == ActivityTypes.EndOfConversation)
+                                    else if (activity.Type == ActivityTypes.Handoff)
                                     {
                                         var result = await _turnContext.SendActivityAsync(activity).ConfigureAwait(false);
                                         if (_handoffActivityHandler != null)

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillDialog.cs
@@ -318,12 +318,12 @@ namespace Microsoft.Bot.Builder.Skills
         {
             try
             {
-                var endOfConversationActivity = await _skillTransport.ForwardToSkillAsync(_skillManifest, _serviceClientCredentials, innerDc.Context, activity, GetTokenRequestCallback(innerDc), GetFallbackCallback(innerDc));
+                var handoffActivity = await _skillTransport.ForwardToSkillAsync(_skillManifest, _serviceClientCredentials, innerDc.Context, activity, GetTokenRequestCallback(innerDc), GetFallbackCallback(innerDc));
 
-                if (endOfConversationActivity != null)
+                if (handoffActivity != null)
                 {
                     await innerDc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"<--Ending the skill conversation with the {_skillManifest.Name} Skill and handing off to Parent Bot."));
-                    return await innerDc.EndDialogAsync(endOfConversationActivity.SemanticAction?.Entities);
+                    return await innerDc.EndDialogAsync(handoffActivity.SemanticAction?.Entities);
                 }
                 else if (_authDialogCancelled)
                 {

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder.Skills
                     activity.SemanticAction = turnContext.Activity.SemanticAction;
                 }
 
-                if (activity.Type == ActivityTypes.EndOfConversation)
+                if (activity.Type == ActivityTypes.Handoff)
                 {
                     activity.SemanticAction.State = SkillConstants.SkillDone;
                 }

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Skills
     {
         private IStreamingTransportClient _streamingTransportClient;
         private readonly IBotTelemetryClient _botTelemetryClient;
-        private Activity endOfConversationActivity;
+        private Activity _handoffActivity;
 
         public SkillWebSocketTransport(
             IBotTelemetryClient botTelemetryClient,
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Skills
                     { "Latency", stopWatch.ElapsedMilliseconds },
                 });
 
-            return endOfConversationActivity;
+            return _handoffActivity;
         }
 
         public async Task CancelRemoteDialogsAsync(SkillManifest skillManifest, IServiceClientCredentials appCredentials, ITurnContext turnContext)
@@ -126,7 +126,7 @@ namespace Microsoft.Bot.Builder.Skills
         {
             return (activity) =>
             {
-                endOfConversationActivity = activity;
+                _handoffActivity = activity;
             };
         }
 

--- a/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Dialogs/MainDialog.cs
@@ -121,7 +121,7 @@ namespace AutomotiveSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }

--- a/skills/src/csharp/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
+++ b/skills/src/csharp/automotiveskill/automotiveskilltest/Flow/VehicleSettingsTests.cs
@@ -104,7 +104,7 @@ namespace AutomotiveSkillTest.Flow
                     IsConfirmed = true,
                 }))
                 .AssertReply(this.CheckReply("Setting Lane Change Detection to Off."))
-                .AssertReply(this.CheckForEndOfConversation())
+                .AssertReply(this.CheckForHandoff())
                 .StartTestAsync();
         }
 
@@ -116,7 +116,7 @@ namespace AutomotiveSkillTest.Flow
                 .AssertReply(this.CheckReply("So, you want to change Lane Change Detection to Off. Is that correct? (1) Yes or (2) No"))
                 .Send("no")
                 .AssertReply(this.CheckReply("Ok, not making any changes."))
-                .AssertReply(this.CheckForEndOfConversation())
+                .AssertReply(this.CheckForHandoff())
                 .StartTestAsync();
         }
 
@@ -332,12 +332,11 @@ namespace AutomotiveSkillTest.Flow
             };
         }
 
-        private Action<IActivity> CheckForEndOfConversation()
+        private Action<IActivity> CheckForHandoff()
         {
             return activity =>
             {
-                var eventReceived = activity.AsEndOfConversationActivity();
-                Assert.IsNotNull(eventReceived, "End of Conversation Activity not received.");
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff, "End of Conversation Activity not received.");
             };
         }
 

--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/MainDialog.cs
@@ -221,7 +221,7 @@ namespace CalendarSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -244,7 +244,7 @@ namespace CalendarSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/ConnectToMeetingFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/ConnectToMeetingFlowTests.cs
@@ -60,7 +60,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
     }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/CreateCalendarFlowTests.cs
@@ -758,7 +758,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/DeleteCalendarFlowTests.cs
@@ -151,7 +151,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
     }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/NextCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/NextCalendarFlowTests.cs
@@ -190,7 +190,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
     }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
@@ -187,7 +187,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/TimeRemainingFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/TimeRemainingFlowTests.cs
@@ -67,7 +67,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
     }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/UpdateCalendarFlowTests.cs
@@ -159,7 +159,7 @@ namespace CalendarSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
     }

--- a/skills/src/csharp/emailskill/emailskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/emailskill/emailskill/Dialogs/MainDialog.cs
@@ -197,7 +197,7 @@ namespace EmailSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -220,7 +220,7 @@ namespace EmailSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/emailskill/emailskilltest/Flow/DeleteEmailFlowTests.cs
+++ b/skills/src/csharp/emailskill/emailskilltest/Flow/DeleteEmailFlowTests.cs
@@ -79,7 +79,7 @@ namespace EmailSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/emailskill/emailskilltest/Flow/ForwardEmailFlowTests.cs
+++ b/skills/src/csharp/emailskill/emailskilltest/Flow/ForwardEmailFlowTests.cs
@@ -154,7 +154,7 @@ namespace EmailSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/emailskill/emailskilltest/Flow/ReplyFlowTests.cs
+++ b/skills/src/csharp/emailskill/emailskilltest/Flow/ReplyFlowTests.cs
@@ -79,7 +79,7 @@ namespace EmailSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/emailskill/emailskilltest/Flow/SendEmailFlowTests.cs
+++ b/skills/src/csharp/emailskill/emailskilltest/Flow/SendEmailFlowTests.cs
@@ -366,7 +366,7 @@ namespace EmailSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/emailskill/emailskilltest/Flow/ShowEmailFlowTests.cs
+++ b/skills/src/csharp/emailskill/emailskilltest/Flow/ShowEmailFlowTests.cs
@@ -394,7 +394,7 @@ namespace EmailSkillTest.Flow
         {
             return activity =>
             {
-                Assert.AreEqual(activity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Dialogs/MainDialog.cs
@@ -114,7 +114,7 @@ namespace BingSearchSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -147,7 +147,7 @@ namespace BingSearchSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/experimental/eventskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/eventskill/Dialogs/MainDialog.cs
@@ -115,7 +115,7 @@ namespace EventSkill.Dialogs
         protected override async Task CompleteAsync(DialogContext dc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var response = dc.Context.Activity.CreateReply();
-            response.Type = ActivityTypes.EndOfConversation;
+            response.Type = ActivityTypes.Handoff;
             await dc.Context.SendActivityAsync(response);
             await dc.EndDialogAsync(result);
         }
@@ -133,7 +133,7 @@ namespace EventSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
@@ -162,7 +162,7 @@ namespace HospitalitySkill.Dialogs
         protected override async Task CompleteAsync(DialogContext dc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var response = dc.Context.Activity.CreateReply();
-            response.Type = ActivityTypes.EndOfConversation;
+            response.Type = ActivityTypes.Handoff;
             await dc.Context.SendActivityAsync(response);
             await dc.EndDialogAsync(result);
         }
@@ -180,7 +180,7 @@ namespace HospitalitySkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/experimental/musicskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/musicskill/Dialogs/MainDialog.cs
@@ -116,7 +116,7 @@ namespace MusicSkill.Dialogs
         protected override async Task CompleteAsync(DialogContext dc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var response = dc.Context.Activity.CreateReply();
-            response.Type = ActivityTypes.EndOfConversation;
+            response.Type = ActivityTypes.Handoff;
             await dc.Context.SendActivityAsync(response);
             await dc.EndDialogAsync(result);
         }
@@ -134,7 +134,7 @@ namespace MusicSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/experimental/newsskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/newsskill/Dialogs/MainDialog.cs
@@ -130,7 +130,7 @@ namespace NewsSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }

--- a/skills/src/csharp/experimental/restaurantbooking/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/restaurantbooking/Dialogs/MainDialog.cs
@@ -121,7 +121,7 @@ namespace RestaurantBooking.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -141,7 +141,7 @@ namespace RestaurantBooking.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/experimental/weatherskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/experimental/weatherskill/Dialogs/MainDialog.cs
@@ -123,7 +123,7 @@ namespace WeatherSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -156,7 +156,7 @@ namespace WeatherSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Dialogs/MainDialog.cs
@@ -152,7 +152,7 @@ namespace PointOfInterestSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/PointOfInterestDialogTests.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskilltests/Flow/PointOfInterestDialogTests.cs
@@ -2,10 +2,8 @@
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using Luis;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PointOfInterestSkill.Responses.CancelRoute;
 using PointOfInterestSkill.Responses.Route;
 using PointOfInterestSkill.Responses.Shared;
 using PointOfInterestSkillTests.Flow.Strings;
@@ -207,26 +205,6 @@ namespace PointOfInterestSkillTests.Flow
         }
 
         /// <summary>
-        /// Asserts bot response of PointOfInterestSelection.
-        /// </summary>
-        /// <returns>Returns an Action with IActivity object.</returns>
-        private Action<IActivity> PointOfInterestSelection()
-        {
-            return activity =>
-            {
-                var messageActivity = activity.AsMessageActivity();
-
-                int index = messageActivity.Text.IndexOf("\n");
-                if (index > 0)
-                {
-                    messageActivity.Text = messageActivity.Text.Substring(0, index);
-                }
-
-                CollectionAssert.Contains(ParseReplies(POISharedResponses.PointOfInterestSelection, new StringDictionary()), messageActivity.Text);
-            };
-        }
-
-        /// <summary>
         /// Asserts bot response of SingleLocationFound.
         /// </summary>
         /// <returns>Returns an Action with IActivity object.</returns>
@@ -275,34 +253,6 @@ namespace PointOfInterestSkillTests.Flow
         }
 
         /// <summary>
-        /// Asserts bot response of PromptToStartRoute.
-        /// </summary>
-        /// <returns>Returns an Action with IActivity object.</returns>
-        private Action<IActivity> PromptToStartRoute()
-        {
-            return activity =>
-            {
-                var messageActivity = activity.AsMessageActivity();
-
-                CollectionAssert.Contains(ParseReplies(RouteResponses.PromptToStartRoute, new StringDictionary()), messageActivity.Speak);
-            };
-        }
-
-        /// <summary>
-        /// Asserts bot response of AskAboutRouteLater.
-        /// </summary>
-        /// <returns>Returns an Action with IActivity object.</returns>
-        private Action<IActivity> AskAboutRouteLater()
-        {
-            return activity =>
-            {
-                var messageActivity = activity.AsMessageActivity();
-
-                CollectionAssert.Contains(ParseReplies(RouteResponses.AskAboutRouteLater, new StringDictionary()), messageActivity.Speak);
-            };
-        }
-
-        /// <summary>
         /// Asserts bot response of SendingRouteDetails.
         /// </summary>
         /// <returns>Returns an Action with IActivity object.</returns>
@@ -317,34 +267,6 @@ namespace PointOfInterestSkillTests.Flow
         }
 
         /// <summary>
-        /// Asserts bot response of CannotCancelActiveRoute.
-        /// </summary>
-        /// <returns>Returns an Action with IActivity object.</returns>
-        private Action<IActivity> CannotCancelActiveRoute()
-        {
-            return activity =>
-            {
-                var messageActivity = activity.AsMessageActivity();
-
-                CollectionAssert.Contains(ParseReplies(CancelRouteResponses.CannotCancelActiveRoute, new StringDictionary()), messageActivity.Text);
-            };
-        }
-
-        /// <summary>
-        /// Asserts bot response of CancelActiveRoute.
-        /// </summary>
-        /// <returns>Returns an Action with IActivity object.</returns>
-        private Action<IActivity> CancelActiveRoute()
-        {
-            return activity =>
-            {
-                var messageActivity = activity.AsMessageActivity();
-
-                CollectionAssert.Contains(ParseReplies(CancelRouteResponses.CancelActiveRoute, new StringDictionary()), messageActivity.Text);
-            };
-        }
-
-        /// <summary>
         /// Asserts bot response of CompleteDialog.
         /// </summary>
         /// <returns>Returns an Action with IActivity object.</returns>
@@ -352,8 +274,7 @@ namespace PointOfInterestSkillTests.Flow
         {
             return activity =>
             {
-                var endOfConversationActivity = activity.AsEndOfConversationActivity();
-                Assert.AreEqual(endOfConversationActivity.Type, ActivityTypes.EndOfConversation);
+                Assert.AreEqual(activity.Type, ActivityTypes.Handoff);
             };
         }
 

--- a/skills/src/csharp/todoskill/todoskill/Dialogs/MainDialog.cs
+++ b/skills/src/csharp/todoskill/todoskill/Dialogs/MainDialog.cs
@@ -153,7 +153,7 @@ namespace ToDoSkill.Dialogs
             if (dc.Context.Adapter is IRemoteUserTokenProvider remoteInvocationAdapter || Channel.GetChannelId(dc.Context) != Channels.Msteams)
             {
                 var response = dc.Context.Activity.CreateReply();
-                response.Type = ActivityTypes.EndOfConversation;
+                response.Type = ActivityTypes.Handoff;
 
                 await dc.Context.SendActivityAsync(response);
             }
@@ -175,7 +175,7 @@ namespace ToDoSkill.Dialogs
                         if (result.Status != DialogTurnStatus.Waiting)
                         {
                             var response = dc.Context.Activity.CreateReply();
-                            response.Type = ActivityTypes.EndOfConversation;
+                            response.Type = ActivityTypes.Handoff;
 
                             await dc.Context.SendActivityAsync(response);
                         }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

To align better with activity schema, we should use Handoff activity instead of EndOfConversation activity to signal completion of skill dialog.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
