### PR TITLE
[TypeScript][Samples/Templates] Execute the installation and compilation during the publish

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
@@ -23,6 +23,13 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for existing deployment files
+if (-not (Test-Path (Join-Path $projFolder '.web.config'))) {
+
+	# Add needed deployment files for az
+	az bot prepare-deploy --code-dir $projFolder --lang Typescript --output json | Out-Null
+}
+
 # Check for existing deployment configuration
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
@@ -35,8 +42,13 @@ $zipPath = $(Join-Path $projFolder 'code.zip')
 if (Test-Path $zipPath) {
 	Remove-Item $zipPath -Force | Out-Null
 }
-if($?) 
-{  
+if($?)
+{
+	# Install dependencies locally
+	Invoke-Expression "npm install"
+
+	# Build the project
+	Invoke-Expression "npm run build"
 	# Compress source code
 	Get-ChildItem -Path "$($projFolder)" -Exclude @("node_modules", "test", "deployment") | Compress-Archive -DestinationPath "$($zipPath)" -Force | Out-Null
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
@@ -23,6 +23,13 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for existing deployment files
+if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
+
+	# Add needed deployment files for az
+	az bot prepare-deploy --code-dir $projFolder --lang Typescript --output json | Out-Null
+}
+
 # Check for existing deployment configuration
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 
@@ -36,7 +43,13 @@ if (Test-Path $zipPath) {
 	Remove-Item $zipPath -Force | Out-Null
 }
 if($?) 
-{  
+{
+	# Install dependencies locally
+	Invoke-Expression "npm install"
+
+	# Build the project
+	Invoke-Expression "npm run build"
+
 	# Compress source code
 	Get-ChildItem -Path "$($projFolder)" -Exclude @("node_modules", "test", "deployment") | Compress-Archive -DestinationPath "$($zipPath)" -Force | Out-Null
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/publish.ps1
@@ -26,10 +26,17 @@ else {
 }
 
 # Check for existing deployment files
-if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
+if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 
 	# Add needed deployment files for az
 	az bot prepare-deploy --code-dir $projFolder --lang Typescript --output json | Out-Null
+}
+
+# Check for existing deployment configuration
+if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
+
+	# Add needed deployment configuration
+	Add-Content -Path $(Join-Path $projFolder ".deployment") -Value @("[config]", "SCM_DO_BUILD_DURING_DEPLOYMENT=true") -Encoding utf8
 }
 
 # Delete src zip, if it exists
@@ -39,7 +46,13 @@ if (Test-Path $zipPath) {
 }
 
 if($?) 
-{     
+{
+	# Install dependencies locally
+	Invoke-Expression "npm install"
+
+	# Build the project
+	Invoke-Expression "npm run build"
+	
 	# Compress source code
 	Get-ChildItem -Path "$($projFolder)" -Exclude @("node_modules", "test", "deployment") | Compress-Archive -DestinationPath "$($zipPath)" -Force | Out-Null
 


### PR DESCRIPTION
Fix #2151 

## Purpose
_What is the context of this pull request? Why is it being done?_

The publish script (`publish.ps1`) doesn't include the installation of the dependencies and the compilation of the solution.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp?_ (Include illustrative screenshots for context if applicable.)

The installation and the compilation of the solution were added and executed during the publish of the bot.

We updated the following files in `Virtual Assistant/Skill Templates` & `Virtual Assistant/Skill Samples`:
- `publish.ps1`

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
\-

## Testing Steps
1. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant` open a terminal and execute `pwsh.exe -File deployment\scripts\publish.ps1`.
1. Verify that the folder `node_modules` and `lib` are created in `sample-assistant`.
1. Open the emulator to connect the Assistant with the production's endpoint.
1. Send a "Hi" to the bot.
1. Verify that the bot responds correctly.


## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
