### PR TITLE
[Skill Sample/Template] Update useDispatch parameter

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -9,7 +9,7 @@ Param(
 	[string] $luisSubscriptionKey,
     [string] $qnaSubscriptionKey,
 	[string] $resourceGroup,
-	[switch] $useDispatch = $true,
+	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
     [string] $outFolder = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -9,7 +9,7 @@ Param(
 	[string] $luisSubscriptionKey,
     [string] $qnaSubscriptionKey,
 	[string] $resourceGroup,
-	[switch] $useDispatch,
+	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
     [string] $outFolder = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -9,7 +9,7 @@ Param(
 	[string] $luisSubscriptionKey,
     [string] $qnaSubscriptionKey,
 	[string] $resourceGroup,
-	[switch] $useDispatch = $true,
+	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
     [string] $outFolder = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -9,7 +9,7 @@ Param(
 	[string] $luisSubscriptionKey,
     [string] $qnaSubscriptionKey,
 	[string] $resourceGroup,
-	[switch] $useDispatch = $true,
+	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
     [string] $outFolder = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")


### PR DESCRIPTION
Fix #2240

## Purpose
_What is the context of this pull request? Why is it being done?_

We updated the `deploy_cognitive_models.ps1` script in order to omit the deployment of the `dispatch` resource in the Skill by default.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp?_ (Include illustrative screenshots for context if applicable.)

The parameter `useDispatch` of `deploy_cognitive_models.ps1` was updated from `true` to `false`.

![image](https://user-images.githubusercontent.com/11904023/63953764-57c56d80-ca58-11e9-8972-a2afa89fadcf.png)

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
\-

## Testing Steps
1. Open a terminal in `.\templates\Skill-Template\csharp\Sample\SkillSample`
1. Execute `pwsh.exe -File deployment\scripts\deploy.ps1`
1. Once the deployment has finished, go to [LUIS portal](http://luis.ai).
1. Verify that a `Dispatch` is not deployed

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects