### PR TITLE
[POI] add ShouldInterrupt for SelectPointOfInterestPrompt, SelectActionPrompt

### DIFF
--- a/skills/csharp/pointofinterestskill/Content/PointOfInterestOverview.1.0.json
+++ b/skills/csharp/pointofinterestskill/Content/PointOfInterestOverview.1.0.json
@@ -61,7 +61,12 @@
       ],
       "selectAction": {
         "type": "Action.Submit",
-        "data": "{SubmitText}"
+        "data": {
+          "msteams": {
+            "type": "imBack",
+            "value": "{SubmitText}"
+          }
+        }
       }
     }
   ],

--- a/skills/csharp/pointofinterestskill/Models/PointOfInterestSkillState.cs
+++ b/skills/csharp/pointofinterestskill/Models/PointOfInterestSkillState.cs
@@ -25,6 +25,8 @@ namespace PointOfInterestSkill.Models
 
         public List<RouteDirections.Summary> FoundRoutes { get; set; }
 
+        public bool ShouldInterrupt { get; set; }
+
         public string Keyword { get; set; }
 
         public string Address { get; set; }

--- a/skills/csharp/tests/pointofinterestskill.tests/Flow/PointOfInterestDialogTests.cs
+++ b/skills/csharp/tests/pointofinterestskill.tests/Flow/PointOfInterestDialogTests.cs
@@ -120,6 +120,31 @@ namespace PointOfInterestSkill.Tests.Flow
         }
 
         /// <summary>
+        /// Find points of interest nearby with interruptions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [TestMethod]
+        public async Task RouteToPointOfInterestAndInterruptTest()
+        {
+            await GetTestFlow()
+                .Send(BaseTestUtterances.LocationEvent)
+                .Send(FindPointOfInterestUtterances.WhatsNearby)
+                .AssertReply(AssertContains(POISharedResponses.MultipleLocationsFound, new string[] { CardStrings.Overview }))
+                .Send(FindPointOfInterestUtterances.WhatsNearby)
+                .AssertReply(AssertContains(POISharedResponses.MultipleLocationsFound, new string[] { CardStrings.Overview }))
+                .Send(BaseTestUtterances.OptionOne)
+                .AssertReply(AssertContains(null, new string[] { CardStrings.DetailsNoCall }))
+                .Send(FindPointOfInterestUtterances.WhatsNearby)
+                .AssertReply(AssertContains(POISharedResponses.MultipleLocationsFound, new string[] { CardStrings.Overview }))
+                .Send(BaseTestUtterances.OptionOne)
+                .AssertReply(AssertContains(null, new string[] { CardStrings.DetailsNoCall }))
+                .Send(BaseTestUtterances.StartNavigation)
+                .AssertReply(CheckForEvent())
+                .AssertReply(CompleteDialog())
+                .StartTestAsync();
+        }
+
+        /// <summary>
         /// Find points of interest nearby with multiple routes.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2212 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* Set ShouldInterrupt when it is not recognized by prompt and recognized by PointOfInterestLuis in InterruptablePromptValidator for SelectPointOfInterestPrompt and SelectActionPrompt
  - If run luis first, some option would be treated as valid intent
  - Although it depends on skill state, it is always cleared when begin, so I think it is fine
* In ContinueDialogAsync, return DialogTurnStatus.Empty when ShouldInterrupt since RouterDialog will call RouteAsync when receives it
  - It depends on logic of RouterDialog
* Fix selectAction

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

* Add test RouteToPointOfInterestAndInterruptTest

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

After #2266 for better utterances

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
