### PR TITLE
[TypeScript][Skill Sample/Template] Update casing for name property

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.de.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.de.json
@@ -11,12 +11,12 @@
     "HaveNamePrompt": {
       "replies": [
         {
-          "text": "Hallo, {Name}!",
-          "speak": "Hallo, {Name}!"
+          "text": "Hallo, {name}!",
+          "speak": "Hallo, {name}!"
         },
         {
-          "text": "Schön, dich zu treffen, {Name}!",
-          "speak": "Schön, dich zu treffen, {Name}!"
+          "text": "Schön, dich zu treffen, {name}!",
+          "speak": "Schön, dich zu treffen, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.es.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.es.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "¡Hola, {Name}!",
-          "speak": "¡Hola, {Name}!"
+          "text": "¡Hola, {name}!",
+          "speak": "¡Hola, {name}!"
         },
         {
-          "text": "Encantado de conocerte, {Name}!",
-          "speak": "Encantado de conocerte, {Name}!"
+          "text": "Encantado de conocerte, {name}!",
+          "speak": "Encantado de conocerte, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.fr.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.fr.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "Bonjour, {Name}!",
-          "speak": "Bonjour, {Name}!"
+          "text": "Bonjour, {name}!",
+          "speak": "Bonjour, {name}!"
         },
         {
-          "text": "Enchanté, {Name}!",
-          "speak": "Enchanté, {Name}!"
+          "text": "Enchanté, {name}!",
+          "speak": "Enchanté, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.it.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.it.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "Ciao, {Name}!",
-          "speak": "Ciao, {Name}!"
+          "text": "Ciao, {name}!",
+          "speak": "Ciao, {name}!"
         },
         {
-          "text": "Piacere di conoscerti, {Name}!",
-          "speak": "Piacere di conoscerti, {Name}!"
+          "text": "Piacere di conoscerti, {name}!",
+          "speak": "Piacere di conoscerti, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.zh.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/responses/sample/resources/SampleResponses.zh.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "嗨, {Name}!",
-          "speak": "嗨, {Name}!"
+          "text": "嗨, {name}!",
+          "speak": "嗨, {name}!"
         },
         {
-          "text": "很高兴见到你, {Name}!",
-          "speak": "很高兴见到你, {Name}!"
+          "text": "很高兴见到你, {name}!",
+          "speak": "很高兴见到你, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.de.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.de.json
@@ -11,12 +11,12 @@
     "HaveNamePrompt": {
       "replies": [
         {
-          "text": "Hallo, {Name}!",
-          "speak": "Hallo, {Name}!"
+          "text": "Hallo, {name}!",
+          "speak": "Hallo, {name}!"
         },
         {
-          "text": "Schön, dich zu treffen, {Name}!",
-          "speak": "Schön, dich zu treffen, {Name}!"
+          "text": "Schön, dich zu treffen, {name}!",
+          "speak": "Schön, dich zu treffen, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.es.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.es.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "¡Hola, {Name}!",
-          "speak": "¡Hola, {Name}!"
+          "text": "¡Hola, {name}!",
+          "speak": "¡Hola, {name}!"
         },
         {
-          "text": "Encantado de conocerte, {Name}!",
-          "speak": "Encantado de conocerte, {Name}!"
+          "text": "Encantado de conocerte, {name}!",
+          "speak": "Encantado de conocerte, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.fr.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.fr.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "Bonjour, {Name}!",
-          "speak": "Bonjour, {Name}!"
+          "text": "Bonjour, {name}!",
+          "speak": "Bonjour, {name}!"
         },
         {
-          "text": "Enchanté, {Name}!",
-          "speak": "Enchanté, {Name}!"
+          "text": "Enchanté, {name}!",
+          "speak": "Enchanté, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.it.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.it.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "Ciao, {Name}!",
-          "speak": "Ciao, {Name}!"
+          "text": "Ciao, {name}!",
+          "speak": "Ciao, {name}!"
         },
         {
-          "text": "Piacere di conoscerti, {Name}!",
-          "speak": "Piacere di conoscerti, {Name}!"
+          "text": "Piacere di conoscerti, {name}!",
+          "speak": "Piacere di conoscerti, {name}!"
         }
       ],
       "inputHint": "acceptingInput"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.zh.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/responses/sample/resources/SampleResponses.zh.json
@@ -11,12 +11,12 @@
     "HaveNameMessage": {
       "replies": [
         {
-          "text": "嗨, {Name}!",
-          "speak": "嗨, {Name}!"
+          "text": "嗨, {name}!",
+          "speak": "嗨, {name}!"
         },
         {
-          "text": "很高兴见到你, {Name}!",
-          "speak": "很高兴见到你, {Name}!"
+          "text": "很高兴见到你, {name}!",
+          "speak": "很高兴见到你, {name}!"
         }
       ],
       "inputHint": "acceptingInput"


### PR DESCRIPTION
## Purpose
*What is the context of this pull request? Why is it being done?*
Running a skill with a different culture to `en`, the skill doesn't replace the placeholder of `{name}` **due to TypeScript is case sensitive**.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
For the `SampleResponses` we updated the casing for the name property:
- `{Name}` -> `{name}`

![image](https://user-images.githubusercontent.com/11904023/64187076-545e2780-ce46-11e9-865c-2d4fee4f9cc7.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\- 

### Testing Steps
1. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-skill`
1. Execute `npm install`
1. Deploy a Skill in `es` culture
1. Execute `npm run start`
1. Run the **Sample dialog** sending a `Test` message
1. Send your name once the Skill has answered with `¿Cómo te llamas?`
1. Check that the Skill is answering `Hola <PLACEHOLDER_REPLACED>` replacing the placeholder with the correct one

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
