### PR TITLE
[TypeScript][Skill Sample/Template] Add missing properties for the manifestTemplate

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/_manifestTemplate.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/_manifestTemplate.json
@@ -2,6 +2,8 @@
   "id": "<%= skillNameCamelCase %>",
   "name": "<%= skillNameCamelCase %>",
   "description": "This is the description of the <%= skillNameCamelCase %>",
+  "endpoint": "",
+  "msaAppId": "",
   "iconUrl": "",
   "authenticationConnections": [],
   "actions": [

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/manifestTemplate.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/manifestTemplate.json
@@ -2,6 +2,8 @@
   "id": "sampleSkill",
   "name": "sampleSkill",
   "description": "This is the description of the sampleSkill",
+  "endpoint": "",
+  "msaAppId": "",
   "iconUrl": "",
   "authenticationConnections": [],
   "actions": [


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
There were some missing properties in the `manifestTemplate.json` of the `Skill Sample/Template` which were necessary for the connection between the **Virtual Assistant** and the **Skill**.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We introduced the following changes in the `manifestTemplate.json` file:
- Add `endpoint` property
- Add `msaAppId` property

![image](https://user-images.githubusercontent.com/11904023/64206424-b59af080-ce70-11e9-899b-e2cb3c1d5bd8.png)


### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Testing Steps
**Using the `generator-botbuilder-assistant` and `Botskills CLI Tool`:**

1. Create a Virtual Assistant and a Skill
1. Deploy each of them using `deploy.ps1` script
1. Add the `endpoint` and `msaAppId` values in the `manifestTemplate.json` of the Skill
1. Execute the connection of the Virtual Assistant and the Skill with the `botskills connect` command
1. Execute `npm run start` in the Virtual Assistant
1. Validate that the initialization of the Virtual Assistant finished correctly
1. Verify that the communication between the Virtual Assistant and the Skill is correct sending a `run sample dialog` message

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will update the `manifestGenerator` adding those properties,

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
