### PR TITLE
[C#][Samples/Templates] Add UTF8 default encoding for deployment scripts

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
@@ -187,7 +187,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $projDir appsettings.json)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -297,4 +297,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -24,7 +24,7 @@ else {
 
 Write-Host "> Getting config file ..."
 $languageMap = @{ }
-$config = Get-Content -Raw -Path $configFile | ConvertFrom-Json
+$config = Get-Content -Encoding utf8 -Raw -Path $configFile | ConvertFrom-Json
 $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.Name] = $_.Value }
 
 foreach ($langCode in $languageMap.Keys) {

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
@@ -187,7 +187,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $projDir appsettings.json)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -297,4 +297,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/update_cognitive_models.ps1
@@ -24,7 +24,7 @@ else {
 
 Write-Host "> Getting config file ..."
 $languageMap = @{ }
-$config = Get-Content -Raw -Path $configFile | ConvertFrom-Json
+$config = Get-Content -Encoding utf8 -Raw -Path $configFile | ConvertFrom-Json
 $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.Name] = $_.Value }
 
 foreach ($langCode in $languageMap.Keys) {

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -187,7 +187,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $projDir appsettings.json)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -297,4 +297,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -24,7 +24,7 @@ else {
 
 Write-Host "> Getting config file ..."
 $languageMap = @{ }
-$config = Get-Content -Raw -Path $configFile | ConvertFrom-Json
+$config = Get-Content -Encoding utf8 -Raw -Path $configFile | ConvertFrom-Json
 $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.Name] = $_.Value }
 
 foreach ($langCode in $languageMap.Keys) {

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
@@ -187,7 +187,7 @@ if ($outputs)
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
 	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
+		$settings = Get-Content -Encoding utf8 $(Join-Path $projDir appsettings.json) | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $projDir appsettings.json)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -297,4 +297,4 @@ foreach ($language in $languageArr)
 }
 
 # Write out config to file
-$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $outFolder "cognitivemodels.json" )
+$settings | ConvertTo-Json -depth 100 | Out-File -Encoding utf8 $(Join-Path $outFolder "cognitivemodels.json" )

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/update_cognitive_models.ps1
@@ -24,7 +24,7 @@ else {
 
 Write-Host "> Getting config file ..."
 $languageMap = @{ }
-$config = Get-Content -Raw -Path $configFile | ConvertFrom-Json
+$config = Get-Content -Encoding utf8 -Raw -Path $configFile | ConvertFrom-Json
 $config.cognitiveModels.PSObject.Properties | Foreach-Object { $languageMap[$_.Name] = $_.Value }
 
 foreach ($langCode in $languageMap.Keys) {


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
Due to the #2007, the #2130 was made fixing the issue in `TypeScript`, this PR is to replicate that fix in `C#`.

Related to #2130

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_
We added the argument `-Encoding utf8` for some cmdlets like `Out-File` and` Get-Content`.
The scripts that we updated in the Templates and Samples, are the following:

- `deploy.ps1`
- `deploy_cognitive_models.ps1`
- `update_cognitive_models.ps1`

![image](https://user-images.githubusercontent.com/40918752/64183890-f5e27a80-ce40-11e9-94a5-1e30e36a421c.png)

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
\-

## Testing Steps
1. Open a terminal in `.\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample`
2. Execute `pwsh.exe -File deployment\scripts\deploy.ps1`.
3. Verify that the `Encoding` in `appsettings.json` and `cognitivemodels.json` is `UTF8`.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects