### PR TITLE
Remove callerId in Auth flow as callerId shouldn't be transferred over the wire

### DIFF
--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -126,6 +126,10 @@ namespace Microsoft.Bot.Builder.Skills
                 {
                     var requestPath = $"/activities/{activity.Id}";
                     var request = StreamingRequest.CreatePost(requestPath);
+
+                    // set callerId to empty so it's not sending over the wire
+                    activity.CallerId = null;
+
                     request.SetBody(activity);
 
                     _botTelemetryClient.TrackTrace($"Sending activity. ReplyToId: {activity.ReplyToId}", Severity.Information, null);
@@ -173,6 +177,10 @@ namespace Microsoft.Bot.Builder.Skills
         {
             var requestPath = $"/activities/{activity.Id}";
             var request = StreamingRequest.CreatePut(requestPath);
+
+            // set callerId to empty so it's not sending over the wire
+            activity.CallerId = null;
+
             request.SetBody(activity);
 
             var response = default(ResourceResponse);

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketBotAdapter.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Builder.Skills
                     var requestPath = $"/activities/{activity.Id}";
                     var request = StreamingRequest.CreatePost(requestPath);
 
-                    // set callerId to empty so it's not sending over the wire
+                    // set callerId to empty so it's not sent over the wire
                     activity.CallerId = null;
 
                     request.SetBody(activity);
@@ -178,7 +178,7 @@ namespace Microsoft.Bot.Builder.Skills
             var requestPath = $"/activities/{activity.Id}";
             var request = StreamingRequest.CreatePut(requestPath);
 
-            // set callerId to empty so it's not sending over the wire
+            // set callerId to empty so it's not sent over the wire
             activity.CallerId = null;
 
             request.SetBody(activity);

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketRequestHandler.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketRequestHandler.cs
@@ -78,13 +78,8 @@ namespace Microsoft.Bot.Builder.Skills
 
             var appIdClaimName = AuthHelpers.GetAppIdClaimName(_claimsIdentity);
 
-            // verify if caller id is the same as the appid in the claims
-            var appIdClaim = _claimsIdentity.Claims.FirstOrDefault(c => c.Type == appIdClaimName)?.Value;
-            if (!activity.CallerId.Equals(appIdClaim))
-            {
-                response.StatusCode = (int)HttpStatusCode.Forbidden;
-                return response;
-            }
+            // retrieve the appid and use it to populate callerId on the activity
+            activity.CallerId = _claimsIdentity.Claims.FirstOrDefault(c => c.Type == appIdClaimName)?.Value;
 
             try
             {

--- a/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
+++ b/lib/csharp/microsoft.bot.builder.skills/Microsoft.Bot.Builder.Skills/SkillWebSocketTransport.cs
@@ -54,9 +54,6 @@ namespace Microsoft.Bot.Builder.Skills
 
             await _streamingTransportClient.ConnectAsync(headers);
 
-            // populate call id for auth purpose
-            activity.CallerId = serviceClientCredentials.MicrosoftAppId;
-
             // set recipient to the skill
             var recipientId = activity.Recipient.Id;
             activity.Recipient.Id = skillManifest.MSAappId;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

We shouldn't pass callerId over the wire so removing the callerId in Auth flow
set callerId on the Adapter side so SDK can use it to set state storage key using it

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
