### PR TITLE
[Samples/Templates] Add resourceGroupName attribute in the appsettings after deployment

### DIFF
--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Resources/template.json
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Resources/template.json
@@ -207,6 +207,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Resources/template.json
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Resources/template.json
@@ -207,6 +207,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/template.json
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/template.json
@@ -344,6 +344,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/template.json
@@ -344,6 +344,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/resources/template.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/resources/template.json
@@ -355,6 +355,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -205,7 +205,7 @@ if ($outputs)
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
 
 	# Publish bot
-	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"-ForegroundColor Magenta
+	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($outputs.resourceGroupName.value) -projFolder '$($projDir)'"-ForegroundColor Magenta
 	Write-Host "> Done."
 }
 else

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/resources/template.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/resources/template.json
@@ -235,6 +235,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -206,7 +206,7 @@ if ($outputs)
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
 	
 	# Publish bot
-	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'" -ForegroundColor Magenta
+	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($outputs.resourceGroupName.value) -projFolder '$($projDir)'" -ForegroundColor Magenta
 	Write-Host "> Done."
 }
 else

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/resources/template.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/resources/template.json
@@ -355,6 +355,10 @@
     }
   ],
   "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[parameters('name')]"
+    },
     "botWebAppName": {
       "type": "string",
       "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -205,7 +205,7 @@ if ($outputs)
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
 
 	# Publish bot
-	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"-ForegroundColor Magenta
+	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($outputs.resourceGroupName.value) -projFolder '$($projDir)'"-ForegroundColor Magenta
 	Write-Host "> Done."
 }
 else

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/resources/template.json
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/resources/template.json
@@ -218,6 +218,10 @@
       }
     ],
     "outputs": {
+      "resourceGroupName": {
+        "type": "string",
+        "value": "[parameters('name')]"
+      },
       "botWebAppName": {
         "type": "string",
         "value": "[variables('botWebAppName')]"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -212,17 +212,10 @@ if ($outputs)
 	Start-Sleep -s 30
 
 	# Deploy cognitive models
-<<<<<<< HEAD
-	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
-	
-	# Publish bot
-	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1') -name $($name) -resourceGroup $($resourceGroup) -projFolder `"$($projDir)` '" -ForegroundColor Magenta
-=======
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
 	
 	# Publish bot
-	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'" -ForegroundColor Magenta
->>>>>>> c1ac5dac... Update Sample Skill
+	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($outputs.resourceGroupName.value) -projFolder '$($projDir)'" -ForegroundColor Magenta
 	Write-Host "> Done."
 }
 else


### PR DESCRIPTION
**This Pull Request will be present in the next release.**

Related to #2217 

### Purpose
*What is the context of this pull request? Why is it being done?*
As the `botWebAppName` is added in the `appsettings.json` file after the deployment, we added the `resourceGroupName` attribute too. Now, `Botskills CLI Tool` will be able to use them internally.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update `template.json` to add the `resourceGroupName` attribute in the `appsettings.json` file during the deployment
- Update the publish message for the `deploy.ps1` in TypeScript

![image](https://user-images.githubusercontent.com/11904023/64374857-0c343600-cffb-11e9-9f37-afc684f5384b.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Testing Steps
1. Deploy a `Virtual Assistant` or a `Skill` using `deploy.ps1` script
1. Check the `appsettings.json` that is including a `resourceGroupName` attribute with the name provided in the deployment

![image](https://user-images.githubusercontent.com/11904023/64376242-31767380-cffe-11e9-8ee5-17509e9a5717.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
Update `Botskills CLI Tool` to use those attributes internally.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [X] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [X] I have replicated my changes in the **Skill Template** and **Sample** projects
