### PR TITLE
Added check for AZ CLI and a warning if older version

### DIFF
--- a/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/add_remote_skill.ps1
+++ b/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/add_remote_skill.ps1
@@ -26,6 +26,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Set defaults and validate file paths
 $langCode = ($language -split "-")[0]
 if (-not $luisFolder) {

--- a/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/deploy.ps1
+++ b/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/publish.ps1
+++ b/samples/EnterpriseNotification/VirtualAssistant/Deployment/Scripts/publish.ps1
@@ -15,6 +15,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/automotiveskill/automotiveskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/calendarskill/calendarskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/emailskill/emailskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/experimental/bingsearchskill/bingsearchskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/experimental/restaurantbooking/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/deploy.ps1
+++ b/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/publish.ps1
+++ b/skills/src/csharp/todoskill/todoskill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/publish.ps1
+++ b/templates/Skill-Template/csharp/Sample/SkillSample/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/publish.ps1
+++ b/templates/Skill-Template/csharp/Template/Skill/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts/publish.ps1
@@ -24,6 +24,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
@@ -25,6 +25,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -29,6 +29,32 @@ if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
 	Break
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Get mandatory parameters
 if (-not $name) {
     $name = Read-Host "? Bot Name (used as default name for resource group and deployed resources)"

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/publish.ps1
@@ -25,6 +25,32 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
+# Check for AZ CLI and confirm version
+if (Get-Command az -ErrorAction SilentlyContinue) {
+    $azcliversionoutput = az -v
+    [regex]$regex = '(\d{1,3}.\d{1,3}.\d{1,3})'
+    [version]$azcliversion = $regex.Match($azcliversionoutput[0]).value
+    [version]$minversion = '2.0.72'
+
+    if ($azcliversion -ge $minversion) {
+        $azclipassmessage = "AZ CLI passes minimum version. Current version is $azcliversion"
+        Write-Debug $azclipassmessage
+        $azclipassmessage | Out-File -Append -FilePath $logfile
+    }
+    else {
+        $azcliwarnmessage = "You are using an older version of the AZ CLI, `
+    please ensure you are using version $minversion or newer. `
+    The most recent version can be found here: http://aka.ms/installazurecliwindows"
+        Write-Warning $azcliwarnmessage
+        $azcliwarnmessage | Out-File -Append -FilePath $logfile
+    }
+}
+else {
+    $azclierrormessage = 'AZ CLI not found. Please install latest version.'
+    Write-Error $azclierrormessage
+    $azclierrormessage | Out-File -Append -FilePath $logfile
+}
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
To help minimize issues by running much older version of az cli.

### Changes
Changes were additive. Doesn't stop or hinder the PowerShell scripts. Only writes information to console or to log file.

### Tests
Just tested the added code. Again, just additive.

### Feature Plan
none

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
