### PR TITLE
[Calendar] Fix digest time entity logic

### DIFF
--- a/skills/src/csharp/calendarskill/calendarskill/CalendarSkill.csproj
+++ b/skills/src/csharp/calendarskill/calendarskill/CalendarSkill.csproj
@@ -114,8 +114,8 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.5.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.6.1" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -858,7 +858,7 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToDate != null)
+                            if (entity.ToDate != null && !state.MeetingInfor.EndDate.Any())
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
@@ -887,7 +887,7 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToTime != null)
+                            if (entity.ToTime != null && !state.MeetingInfor.EndTime.Any())
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
@@ -923,9 +923,16 @@ namespace CalendarSkill.Dialogs
                             break;
                         }
 
+                    case CalendarLuis.Intent.ConnectToMeeting:
+                    case CalendarLuis.Intent.TimeRemaining:
                     case CalendarLuis.Intent.AcceptEventEntry:
                     case CalendarLuis.Intent.DeleteCalendarEntry:
                         {
+                            if (entity.OrderReference != null)
+                            {
+                                state.MeetingInfor.OrderReference = GetOrderReferenceFromEntity(entity);
+                            }
+
                             if (entity.Subject != null)
                             {
                                 state.MeetingInfor.Title = GetSubjectFromEntity(entity);
@@ -1084,7 +1091,7 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToDate != null)
+                            if (entity.ToDate != null && !state.MeetingInfor.EndDate.Any())
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
@@ -1110,7 +1117,7 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToTime != null)
+                            if (entity.ToTime != null && !state.MeetingInfor.EndTime.Any())
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
@@ -1121,68 +1128,6 @@ namespace CalendarSkill.Dialogs
                             }
 
                             state.ShowMeetingInfor.AskParameterContent = luisResult.Text;
-
-                            break;
-                        }
-
-                    case CalendarLuis.Intent.ConnectToMeeting:
-                    case CalendarLuis.Intent.TimeRemaining:
-                        {
-                            if (entity.FromDate != null)
-                            {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
-                                if (date != null)
-                                {
-                                    state.MeetingInfor.StartDate = date;
-                                }
-                            }
-
-                            if (entity.ToDate != null)
-                            {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
-                                if (date != null)
-                                {
-                                    state.MeetingInfor.EndDate = date;
-                                }
-                            }
-
-                            if (entity.FromTime != null)
-                            {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
-                                if (time != null)
-                                {
-                                    state.MeetingInfor.StartTime = time;
-                                }
-
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
-                                if (time != null)
-                                {
-                                    state.MeetingInfor.EndTime = time;
-                                }
-                            }
-
-                            if (entity.ToTime != null)
-                            {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
-                                if (time != null)
-                                {
-                                    state.MeetingInfor.EndTime = time;
-                                }
-                            }
-
-                            if (entity.OrderReference != null)
-                            {
-                                state.MeetingInfor.OrderReference = GetOrderReferenceFromEntity(entity);
-                            }
-
-                            if (entity.Subject != null)
-                            {
-                                state.MeetingInfor.Title = entity._instance.Subject[0].Text;
-                            }
 
                             break;
                         }
@@ -1675,6 +1620,7 @@ namespace CalendarSkill.Dialogs
 
         private List<DateTime> GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart = true)
         {
+            // if isStart is false, will only get the end time of a timerange
             var culture = local ?? English;
             var results = RecognizeDateTime(time, culture, false);
             var dateTimeResults = new List<DateTime>();

--- a/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/src/csharp/calendarskill/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -843,14 +843,15 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
                                     state.MeetingInfor.StartDate = date;
                                 }
 
-                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                // get end date from time range
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
@@ -858,10 +859,10 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToDate != null && !state.MeetingInfor.EndDate.Any())
+                            if (entity.ToDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
@@ -872,14 +873,14 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
                                     state.MeetingInfor.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
@@ -887,10 +888,10 @@ namespace CalendarSkill.Dialogs
                                 }
                             }
 
-                            if (entity.ToTime != null && !state.MeetingInfor.EndTime.Any())
+                            if (entity.ToTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.CreateHasDetail = true;
@@ -941,13 +942,13 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.StartDate = date;
                                 }
 
-                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.EndDate = date;
@@ -957,13 +958,13 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.EndTime = time;
@@ -983,13 +984,13 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.StartDate = date;
                                 }
 
-                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.EndDate = date;
@@ -999,23 +1000,29 @@ namespace CalendarSkill.Dialogs
                             if (entity.ToDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
                                     state.UpdateMeetingInfor.NewStartDate = date;
+                                }
+
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
+                                if (date != null)
+                                {
+                                    state.UpdateMeetingInfor.NewEndDate = date;
                                 }
                             }
 
                             if (entity.FromTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.EndTime = time;
@@ -1025,13 +1032,13 @@ namespace CalendarSkill.Dialogs
                             if (entity.ToTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
                                     state.UpdateMeetingInfor.NewStartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (time != null)
                                 {
                                     state.UpdateMeetingInfor.NewEndTime = time;
@@ -1077,24 +1084,24 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.StartDate = date;
                                     state.MeetingInfor.StartDateString = dateString;
                                 }
 
-                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.EndDate = date;
                                 }
                             }
 
-                            if (entity.ToDate != null && !state.MeetingInfor.EndDate.Any())
+                            if (entity.ToDate != null)
                             {
                                 var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
-                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (date != null)
                                 {
                                     state.MeetingInfor.EndDate = date;
@@ -1104,23 +1111,23 @@ namespace CalendarSkill.Dialogs
                             if (entity.FromTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true);
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.StartTime = time;
                                 }
 
-                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false);
+                                time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, true);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.EndTime = time;
                                 }
                             }
 
-                            if (entity.ToTime != null && !state.MeetingInfor.EndTime.Any())
+                            if (entity.ToTime != null)
                             {
                                 var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
-                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone());
+                                var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (time != null)
                                 {
                                     state.MeetingInfor.EndTime = time;
@@ -1574,8 +1581,9 @@ namespace CalendarSkill.Dialogs
             return inputString.Substring(data.StartIndex, data.EndIndex - data.StartIndex);
         }
 
-        private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone, bool isStart = true)
+        private List<DateTime> GetDateFromDateTimeString(string date, string local, TimeZoneInfo userTimeZone, bool isStart, bool isTargetTimeRange)
         {
+            // if isTargetTimeRange is true, will only parse the time range
             var culture = local ?? English;
             var results = RecognizeDateTime(date, culture, true);
             var dateTimeResults = new List<DateTime>();
@@ -1585,7 +1593,7 @@ namespace CalendarSkill.Dialogs
                 {
                     if (result.Value != null)
                     {
-                        if (!isStart)
+                        if (isTargetTimeRange)
                         {
                             break;
                         }
@@ -1618,9 +1626,9 @@ namespace CalendarSkill.Dialogs
             return dateTimeResults;
         }
 
-        private List<DateTime> GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart = true)
+        private List<DateTime> GetTimeFromDateTimeString(string time, string local, TimeZoneInfo userTimeZone, bool isStart, bool isTargetTimeRange)
         {
-            // if isStart is false, will only get the end time of a timerange
+            // if isTargetTimeRange is true, will only parse the time range
             var culture = local ?? English;
             var results = RecognizeDateTime(time, culture, false);
             var dateTimeResults = new List<DateTime>();
@@ -1630,7 +1638,7 @@ namespace CalendarSkill.Dialogs
                 {
                     if (result.Value != null)
                     {
-                        if (!isStart)
+                        if (isTargetTimeRange)
                         {
                             break;
                         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/Fakes/MockServiceManager.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/Fakes/MockServiceManager.cs
@@ -77,8 +77,32 @@ namespace CalendarSkillTest.Flow.Fakes
         public static IServiceManager SetMeetingsToSpecial(List<EventModel> eventList)
         {
             mockCalendarService.Setup(service => service.GetUpcomingEventsAsync(null)).Returns(Task.FromResult(eventList));
-            mockCalendarService.Setup(service => service.GetEventsByTimeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
-            mockCalendarService.Setup(service => service.GetEventsByStartTimeAsync(It.IsAny<DateTime>())).Returns(Task.FromResult(eventList));
+            mockCalendarService.Setup(service => service.GetEventsByTimeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns((DateTime startTime, DateTime endTime) =>
+            {
+                var result = new List<EventModel>();
+                foreach (var item in eventList)
+                {
+                    if (item.StartTime >= startTime && item.StartTime <= endTime)
+                    {
+                        result.Add(item);
+                    }
+                }
+
+                return Task.FromResult(result);
+            });
+            mockCalendarService.Setup(service => service.GetEventsByStartTimeAsync(It.IsAny<DateTime>())).Returns((DateTime startTime) =>
+            {
+                var result = new List<EventModel>();
+                foreach (var item in eventList)
+                {
+                    if (item.StartTime == startTime)
+                    {
+                        result.Add(item);
+                    }
+                }
+
+                return Task.FromResult(result);
+            });
             mockCalendarService.Setup(service => service.GetEventsByTitleAsync(It.IsAny<string>())).Returns(Task.FromResult(eventList));
             return mockServiceManager.Object;
         }

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/SummaryCalendarFlowTests.cs
@@ -174,6 +174,29 @@ namespace CalendarSkillTest.Flow
         }
 
         [TestMethod]
+        public async Task Test_CalendarSummaryByTimeframe()
+        {
+            DateTime now = DateTime.Now;
+            DateTime startTime = new DateTime(now.Year, now.Month, now.Day, 14, 0, 0);
+            startTime = TimeZoneInfo.ConvertTimeToUtc(startTime);
+            this.ServiceManager = MockServiceManager.SetMeetingsToSpecial(new List<EventModel>()
+            {
+                MockServiceManager.CreateEventModel(
+                    startDateTime: startTime,
+                    endDateTime: startTime.AddHours(1))
+            });
+
+            await this.GetTestFlow()
+                .Send(FindMeetingTestUtterances.FindMeetingByTimeframe)
+                .AssertReply(this.ShowAuth())
+                .Send(this.GetAuthResponse())
+                .AssertReplyOneOf(this.FoundOneEventPrompt(startTimeString: "at 2:00 PM"))
+                .Send(Strings.Strings.ConfirmNo)
+                .AssertReply(this.ActionEndMessage())
+                .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task Test_CalendarSummaryByStartTime()
         {
             await this.GetTestFlow()
@@ -233,15 +256,15 @@ namespace CalendarSkillTest.Flow
             return this.ParseReplies(SummaryResponses.AskForShowOverview, responseParams);
         }
 
-        private string[] FoundOneEventPrompt(string dateTime = "today")
+        private string[] FoundOneEventPrompt(string dateString = "today", string startTimeString = "at 6:00 PM")
         {
             var responseParams = new StringDictionary()
             {
                 { "Count", "1" },
                 { "EventName1", Strings.Strings.DefaultEventName },
                 { "EventDuration", "1 hour" },
-                { "DateTime", dateTime },
-                { "EventTime1", "at 6:00 PM" },
+                { "DateTime", dateString },
+                { "EventTime1", startTimeString },
                 { "Participants1", Strings.Strings.DefaultUserName }
             };
 

--- a/skills/src/csharp/calendarskill/calendarskilltest/Flow/Utterances/FindMeetingTestUtterances.cs
+++ b/skills/src/csharp/calendarskill/calendarskilltest/Flow/Utterances/FindMeetingTestUtterances.cs
@@ -13,6 +13,10 @@ namespace CalendarSkillTest.Flow.Utterances
             this.Add(FindMeetingByTimeRange, GetBaseFindMeetingIntent(
                 FindMeetingByTimeRange,
                 fromDate: new string[] { "next week" }));
+            this.Add(FindMeetingByTimeframe, GetBaseFindMeetingIntent(
+                FindMeetingByTimeframe,
+                fromTime: new string[] { "this afternoon" },
+                toTime: new string[] { "this afternoon" }));
             this.Add(FindMeetingByStartTime, GetBaseFindMeetingIntent(
                 FindMeetingByStartTime,
                 fromDate: new string[] { "tomorrow" },
@@ -32,6 +36,8 @@ namespace CalendarSkillTest.Flow.Utterances
         public static string BaseFindMeeting { get; } = "What should I do today";
 
         public static string FindMeetingByTimeRange { get; } = "What's on my schedule next week";
+
+        public static string FindMeetingByTimeframe { get; } = "What's on my schedule this afternoon";
 
         public static string FindMeetingByStartTime { get; } = "What are my meetings at tomorrow 6 pm";
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Close #2320 

### Changes
In this case "show me my schedule for this afternoon", "this afternoon" is labelled as "From Time" and "To Time". When parse it as "From Time" the end time is set as the correct time. When parse it as "To Time" the end time is covered by wrong result. To fix it, when parse "To Time" will get the end time of time range.

### Tests
Yes

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
