### PR TITLE
Using country and region in code and comment

### DIFF
--- a/samples/clients/csharp/assistant-WebTest/Assistant-WebTest/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/samples/clients/csharp/assistant-WebTest/Assistant-WebTest/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -533,7 +533,7 @@ $.validator.addMethod( "giroaccountNL", function( value, element ) {
 
 /**
  * IBAN is the international bank account number.
- * It has a country - specific format, that is checked here too
+ * It has a country/Region - specific format, that is checked here too
  *
  * Validation is case-insensitive. Please make sure to normalize input yourself.
  */
@@ -562,7 +562,7 @@ $.validator.addMethod( "iban", function( value, element ) {
 		return false;
 	}
 
-	// Check the country code and find the country specific format
+	// Check the country code and find the country/region specific format
 	countrycode = iban.substring( 0, 2 );
 	bbancountrypatterns = {
 		"AL": "\\d{8}[\\dA-Z]{16}",
@@ -633,17 +633,17 @@ $.validator.addMethod( "iban", function( value, element ) {
 
 	bbanpattern = bbancountrypatterns[ countrycode ];
 
-	// As new countries will start using IBAN in the
+	// As new countries or regions will start using IBAN in the
 	// future, we only check if the countrycode is known.
 	// This prevents false negatives, while almost all
 	// false positives introduced by this, will be caught
 	// by the checksum validation below anyway.
 	// Strict checking should return FALSE for unknown
-	// countries.
+	// countries or regions.
 	if ( typeof bbanpattern !== "undefined" ) {
 		ibanregexp = new RegExp( "^[A-Z]{2}\\d{2}" + bbanpattern + "$", "" );
 		if ( !( ibanregexp.test( iban ) ) ) {
-			return false; // Invalid country specific format
+			return false; // Invalid country/region specific format
 		}
 	}
 

--- a/samples/utilities/linkedaccounts/linkedaccounts.web/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/samples/utilities/linkedaccounts/linkedaccounts.web/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -421,7 +421,7 @@ $.validator.addMethod("giroaccountNL", function(value, element) {
 
 /**
  * IBAN is the international bank account number.
- * It has a country - specific format, that is checked here too
+ * It has a country/Region - specific format, that is checked here too
  */
 $.validator.addMethod("iban", function(value, element) {
 	// some quick simple tests to prevent needless work
@@ -437,7 +437,7 @@ $.validator.addMethod("iban", function(value, element) {
 		cOperator = "",
 		countrycode, ibancheck, charAt, cChar, bbanpattern, bbancountrypatterns, ibanregexp, i, p;
 
-	// check the country code and find the country specific format
+	// check the country code and find the country/region specific format
 	countrycode = iban.substring(0, 2);
 	bbancountrypatterns = {
 		"AL": "\\d{8}[\\dA-Z]{16}",
@@ -507,17 +507,17 @@ $.validator.addMethod("iban", function(value, element) {
 	};
 
 	bbanpattern = bbancountrypatterns[countrycode];
-	// As new countries will start using IBAN in the
+	// As new countries or regions will start using IBAN in the
 	// future, we only check if the countrycode is known.
 	// This prevents false negatives, while almost all
 	// false positives introduced by this, will be caught
 	// by the checksum validation below anyway.
 	// Strict checking should return FALSE for unknown
-	// countries.
+	// countries or regions.
 	if (typeof bbanpattern !== "undefined") {
 		ibanregexp = new RegExp("^[A-Z]{2}\\d{2}" + bbanpattern + "$", "");
 		if (!(ibanregexp.test(iban))) {
-			return false; // invalid country specific format
+			return false; // invalid country/region specific format
 		}
 	}
 

--- a/skills/src/csharp/experimental/newsskill/Dialogs/NewsDialogBase.cs
+++ b/skills/src/csharp/experimental/newsskill/Dialogs/NewsDialogBase.cs
@@ -98,10 +98,10 @@ namespace NewsSkill.Dialogs
 
             if (string.IsNullOrWhiteSpace(userState.Market))
             {
-                string country = (string)sc.Result;
+                string countryregion = (string)sc.Result;
 
-                // use AzureMaps API to get country code from country input by user
-                userState.Market = await _mapsService.GetCountryCodeAsync(country);
+                // use AzureMaps API to get country code from country or region input by user
+                userState.Market = await _mapsService.GetCountryCodeAsync(countryregion);
             }
 
             return await sc.NextAsync();
@@ -109,11 +109,11 @@ namespace NewsSkill.Dialogs
 
         protected async Task<bool> MarketPromptValidatorAsync(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
         {
-            var country = promptContext.Recognized.Value;
+            var countryregion = promptContext.Recognized.Value;
 
             // check for valid country code
-            country = await _mapsService.GetCountryCodeAsync(country);
-            if (country != null)
+            var countryCode = await _mapsService.GetCountryCodeAsync(countryregion);
+            if (countryCode != null)
             {
                 return await Task.FromResult(true);
             }

--- a/skills/src/csharp/experimental/newsskill/Models/AzureMaps/SearchAddress.cs
+++ b/skills/src/csharp/experimental/newsskill/Models/AzureMaps/SearchAddress.cs
@@ -5,10 +5,10 @@ namespace NewsSkill.Models
     public class SearchAddress
     {
         /// <summary>
-        /// Gets or sets a string specifying the country of an address.
+        /// Gets or sets a string specifying the country or region name of an address.
         /// </summary>
         /// <value>
-        /// A string specifying the country of an address.
+        /// A string specifying the country or region name of an address.
         /// </value>
         [JsonProperty(PropertyName = "countryCode")]
         public string CountryCode { get; set; }

--- a/skills/src/csharp/experimental/newsskill/Responses/FindArticles/FindArticlesResponses.cs
+++ b/skills/src/csharp/experimental/newsskill/Responses/FindArticles/FindArticlesResponses.cs
@@ -18,7 +18,7 @@ namespace NewsSkill.Responses.FindArticles
             ["default"] = new TemplateIdMap
             {
                 { TopicPrompt, (context, data) => "What topic are you interested in?" },
-                { MarketPrompt, (context, data) => "What country do you want to search in?" },
+                { MarketPrompt, (context, data) => "What country or region do you want to search in?" },
                 { ShowArticles, (context, data) => ShowArticleCards(context, data) }
             },
             ["en"] = new TemplateIdMap { },

--- a/skills/src/csharp/experimental/newsskill/Responses/Main/MainResponses.cs
+++ b/skills/src/csharp/experimental/newsskill/Responses/Main/MainResponses.cs
@@ -30,8 +30,8 @@ namespace NewsSkill.Responses.Main
                 { Greeting, (context, data) => MainStrings.GREETING },
                 { Help, (context, data) => SendHelpCard(context, data) },
                 { Intro, (context, data) => SendIntroCard(context, data) },
-                { MarketPrompt, (context, data) => "What country do you want to search in?" },
-                { MarketRetryPrompt, (context, data) => "Couldn't find that country. What country do you want to search in?" }
+                { MarketPrompt, (context, data) => "What country or region do you want to search in?" },
+                { MarketRetryPrompt, (context, data) => "Couldn't find that country or region. What country or region do you want to search in?" }
             },
             ["en"] = new TemplateIdMap { },
             ["fr"] = new TemplateIdMap { },

--- a/skills/src/csharp/experimental/newsskill/Responses/TrendingArticles/TrendingArticlesResponses.cs
+++ b/skills/src/csharp/experimental/newsskill/Responses/TrendingArticles/TrendingArticlesResponses.cs
@@ -16,7 +16,7 @@ namespace NewsSkill.Responses.TrendingArticles
         {
             ["default"] = new TemplateIdMap
             {
-                { MarketPrompt, (context, data) => "What country are you in?" },
+                { MarketPrompt, (context, data) => "What country or region are you in?" },
                 { ShowArticles, (context, data) => ShowArticleCards(context, data) }
             },
             ["en"] = new TemplateIdMap { },

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/AzureMaps/Address.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/AzureMaps/Address.cs
@@ -65,11 +65,11 @@ namespace PointOfInterestSkill.Models
 
         /// <summary>
         /// Gets or sets a string specifying the populated place for the address.
-        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries.
+        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries or regions.
         /// </summary>
         /// <value>
         /// A string specifying the populated place for the address.
-        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries.
+        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries or regions.
         /// </value>
         [JsonProperty(PropertyName = "locality")]
         public string Locality { get; set; }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/AzureMaps/SearchAddress.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/AzureMaps/SearchAddress.cs
@@ -72,11 +72,11 @@ namespace PointOfInterestSkill.Models
 
         /// <summary>
         /// Gets or sets a string specifying the populated place for the address.
-        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries.
+        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries or regions.
         /// </summary>
         /// <value>
         /// A string specifying the populated place for the address.
-        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries.
+        /// This typically refers to a city, but may refer to a suburb or a neighborhood in certain countries or regions.
         /// </value>
         [JsonProperty(PropertyName = "municipalitySubdivision")]
         public string MunicipalitySubdivision { get; set; }

--- a/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/Foursquare/Location.cs
+++ b/skills/src/csharp/pointofinterestskill/pointofinterestskill/Models/Foursquare/Location.cs
@@ -34,7 +34,7 @@ namespace PointOfInterestSkill.Models.Foursquare
         public string State { get; set; }
 
         [JsonProperty(PropertyName = "country")]
-        public string Country { get; set; }
+        public string CountryRegion { get; set; }
 
         [JsonProperty(PropertyName = "formattedAddress")]
         public string[] FormattedAddress { get; set; }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
Close #2384 
### Purpose
*What is the context of this pull request? Why is it being done?*
Fixed country/region terms in code and comment

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
No.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
yes.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
