### PR TITLE
[TypeScript][Templates] Fix '.web.config' in VA & Skill template

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
@@ -24,7 +24,7 @@ else {
 }
 
 # Check for existing deployment files
-if (-not (Test-Path (Join-Path $projFolder '.web.config'))) {
+if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 
 	# Add needed deployment files for az
 	az bot prepare-deploy --code-dir $projFolder --lang Typescript --output json | Out-Null

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
@@ -26,7 +26,7 @@ else {
 }
 
 # Check for existing deployment files
-if (-not (Test-Path (Join-Path $projFolder '.web.config'))) {
+if (-not (Test-Path (Join-Path $projFolder 'web.config'))) {
 
 	# Add needed deployment files for az
 	az bot prepare-deploy --code-dir $projFolder --lang Typescript --output json | Out-Null


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
There is a typographical error in 'publish.ps1', there is a condition that looks for a file '.web.config'.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_
- Change `.web.config` to `web.config` in the publish.ps1 of the templates

![image](https://user-images.githubusercontent.com/40918752/65259638-5f1deb00-dadb-11e9-80c7-8590188e9944.png)


## Tests
_Is this covered by existing tests or new ones? If no, why not?_
\-
### Testing Steps
1. Create a `Virtual Assistant/Skill` with the `Generator`.
2. In the generated `Virtual Assistant` or `Skill` folder, create an empty `web.config` file.
3. Open a terminal in that location and execute `pwsh.exe -File deployment\scripts\deploy.ps1`.
4. After deployment, execute `pwsh.exe -File deployment\scripts\publish.ps1`.
5. Verify that the `web.config` file is unchanged.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
