### PR TITLE
[TypeScript][Samples/Templates] Fix publish instructions after deployment

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -10,10 +10,12 @@ Param(
 	[string] $luisAuthoringRegion,
     [string] $parametersFile,
 	[string] $languages = "en-us",
-	[string] $projDir = $(Join-Path $(Get-Location) "src"),
+	[string] $projDir = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot ".." "deploy_log.txt")
 )
 
+# Src folder path
+$srcDir = $(Join-Path $projDir "src")
 # Reset log file
 if (Test-Path $logFile) {
 	Clear-Content $logFile -Force | Out-Null
@@ -21,7 +23,7 @@ if (Test-Path $logFile) {
 else {
 	New-Item -Path $logFile | Out-Null
 }
-if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
+if (-not (Test-Path (Join-Path $srcDir 'appsettings.json')))
 {
 	Write-Host "! Could not find an 'appsettings.json' file in the current directory." -ForegroundColor DarkRed
 	Write-Host "+ Please re-run this script from your project directory." -ForegroundColor Magenta
@@ -183,8 +185,8 @@ if ($outputs)
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
-	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
+	if (Test-Path $(Join-Path $srcDir appsettings.json)) {
+		$settings = Get-Content $(Join-Path $srcDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -194,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
 
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $srcDir appsettings.json)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 
@@ -202,7 +204,7 @@ if ($outputs)
 	Start-Sleep -s 30
 
 	# Deploy cognitive models
-	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
+	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 
 	# Publish bot
 	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"-ForegroundColor Magenta

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/templates/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -10,8 +10,8 @@ Param(
 	[string] $qnaSubscriptionKey,
 	[string] $resourceGroup,
 	[switch] $useDispatch = $true,
-    [string] $languages = "en-us",
-    [string] $outFolder = $(Get-Location),
+	[string] $languages = "en-us",
+	[string] $outFolder = $(Join-Path $(Get-Location) "src"),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")
 )
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -10,10 +10,12 @@ Param(
 	[string] $luisAuthoringRegion,
     [string] $parametersFile,
 	[string] $languages = "en-us",
-	[string] $projDir = $(Join-Path $(Get-Location) "src"),
+	[string] $projDir = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot ".." "deploy_log.txt")
 )
 
+# Src folder path
+$srcDir = $(Join-Path $projDir "src")
 # Reset log file
 if (Test-Path $logFile) {
 	Clear-Content $logFile -Force | Out-Null
@@ -22,7 +24,7 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
-if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
+if (-not (Test-Path (Join-Path $srcDir 'appsettings.json')))
 {
 	Write-Host "! Could not find an 'appsettings.json' file in the current directory." -ForegroundColor DarkRed
 	Write-Host "+ Please re-run this script from your project directory." -ForegroundColor Magenta
@@ -186,8 +188,8 @@ if ($outputs)
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
-	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
+	if (Test-Path $(Join-Path $srcDir appsettings.json)) {
+		$settings = Get-Content $(Join-Path $srcDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,14 +198,14 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $srcDir appsettings.json)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
 	# Deploy cognitive models
-	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
+	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 	
 	# Publish bot
 	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'" -ForegroundColor Magenta

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -11,7 +11,7 @@ Param(
 	[string] $resourceGroup,
 	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
-    [string] $outFolder = $(Get-Location),
+    [string] $outFolder = $(Join-Path $(Get-Location) "src"),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")
 )
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -10,10 +10,12 @@ Param(
 	[string] $luisAuthoringRegion,
     [string] $parametersFile,
 	[string] $languages = "en-us",
-	[string] $projDir = $(Join-Path $(Get-Location) "src"),
+	[string] $projDir = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot ".." "deploy_log.txt")
 )
 
+# Src folder path
+$srcDir = $(Join-Path $projDir "src")
 # Reset log file
 if (Test-Path $logFile) {
 	Clear-Content $logFile -Force | Out-Null
@@ -21,7 +23,7 @@ if (Test-Path $logFile) {
 else {
 	New-Item -Path $logFile | Out-Null
 }
-if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
+if (-not (Test-Path (Join-Path $srcDir 'appsettings.json')))
 {
 	Write-Host "! Could not find an 'appsettings.json' file in the current directory." -ForegroundColor DarkRed
 	Write-Host "+ Please re-run this script from your project directory." -ForegroundColor Magenta
@@ -183,8 +185,8 @@ if ($outputs)
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
-	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
+	if (Test-Path $(Join-Path $srcDir appsettings.json)) {
+		$settings = Get-Content $(Join-Path $srcDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -194,7 +196,7 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
 
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $srcDir appsettings.json)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 
@@ -202,7 +204,7 @@ if ($outputs)
 	Start-Sleep -s 30
 
 	# Deploy cognitive models
-	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
+	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 
 	# Publish bot
 	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"-ForegroundColor Magenta

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/deployment/scripts/deploy_cognitive_models.ps1
@@ -11,7 +11,7 @@ Param(
 	[string] $resourceGroup,
 	[switch] $useDispatch = $true,
     [string] $languages = "en-us",
-    [string] $outFolder = $(Get-Location),
+    [string] $outFolder = $(Join-Path $(Get-Location) "src"),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")
 )
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -10,10 +10,12 @@ Param(
 	[string] $luisAuthoringRegion,
     [string] $parametersFile,
 	[string] $languages = "en-us",
-	[string] $projDir = $(Join-Path $(Get-Location) "src"),
+	[string] $projDir = $(Get-Location),
 	[string] $logFile = $(Join-Path $PSScriptRoot ".." "deploy_log.txt")
 )
 
+# Src folder path
+$srcDir = $(Join-Path $projDir "src")
 # Reset log file
 if (Test-Path $logFile) {
 	Clear-Content $logFile -Force | Out-Null
@@ -22,7 +24,7 @@ else {
 	New-Item -Path $logFile | Out-Null
 }
 
-if (-not (Test-Path (Join-Path $projDir 'appsettings.json')))
+if (-not (Test-Path (Join-Path $srcDir 'appsettings.json')))
 {
 	Write-Host "! Could not find an 'appsettings.json' file in the current directory." -ForegroundColor DarkRed
 	Write-Host "+ Please re-run this script from your project directory." -ForegroundColor Magenta
@@ -186,8 +188,8 @@ if ($outputs)
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..."
-	if (Test-Path $(Join-Path $projDir appsettings.json)) {
-		$settings = Get-Content $(Join-Path $projDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
+	if (Test-Path $(Join-Path $srcDir appsettings.json)) {
+		$settings = Get-Content $(Join-Path $srcDir appsettings.json) -Encoding utf8 | ConvertFrom-Json
 	}
 	else {
 		$settings = New-Object PSObject
@@ -196,14 +198,14 @@ if ($outputs)
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppId' -Value $appId
 	$settings | Add-Member -Type NoteProperty -Force -Name 'microsoftAppPassword' -Value $appPassword
 	foreach ($key in $outputMap.Keys) { $settings | Add-Member -Type NoteProperty -Force -Name $key -Value $outputMap[$key].value }
-	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $projDir appsettings.json)
+	$settings | ConvertTo-Json -depth 100 | Out-File $(Join-Path $srcDir appsettings.json)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
 	# Deploy cognitive models
-	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($projDir)' -languages '$($languages)'"
+	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 	
 	# Publish bot
 	Write-Host "+ To publish your bot, run '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'" -ForegroundColor Magenta

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy_cognitive_models.ps1
@@ -11,7 +11,7 @@ Param(
 	[string] $resourceGroup,
 	[switch] $useDispatch = $false,
     [string] $languages = "en-us",
-    [string] $outFolder = $(Get-Location),
+    [string] $outFolder = $(Join-Path $(Get-Location) "src"),
 	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")
 )
 


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
There is a path error when running the script `deploy.ps1`, print the command to run the script `publish.ps1`, in the path to the `src` folder.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_
Change the path from `publish.ps1` to the bot root folder outside the `src` folder.
The scripts that we updated in the Templates and Samples, are the following:
 * deploy.ps1
 * deploy_cognitive_models.ps1

![image](https://user-images.githubusercontent.com/40918752/65338717-2e07ee00-dba1-11e9-8512-11a2bd0b6045.png)

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
\-
### Testing Steps
1. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant`.
2. Open a terminal in that location and execute `pwsh.exe -File deployment\scripts\deploy.ps1`.
3. Check that the image matches.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
