### PR TITLE
Fix null reference exception in ScheduledTask.AddScheduledTask

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/TaskExtensions/ScheduledProcessor.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/TaskExtensions/ScheduledProcessor.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Builder.Solutions.TaskExtensions
         public ScheduledProcessor(IBackgroundTaskQueue backgroundTaskQueue)
         {
             _backgroundTaskQueue = backgroundTaskQueue;
+            Schedules = new List<ScheduledTaskModel>();
         }
 
         protected List<ScheduledTaskModel> Schedules { get; }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
This PR fixes a null reference exception when attempting to add a task to the ScheduledProcessor's Schedules field via ScheduledTask.AddScheduledTask

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? No

### Tests
No, none of the TaskExtensions have any testing around them at present.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
No

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [x] I have updated related documentation

