### PR TITLE
[Lib] Refactored routerDialog

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/CognitiveModelSet.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/CognitiveModelSet.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Bot.Builder.Solutions
     {
         public IRecognizer DispatchService { get; set; }
 
-        public Dictionary<string, ITelemetryRecognizer> LuisServices { get; set; } = new Dictionary<string, ITelemetryRecognizer>();
+        public Dictionary<string, LuisRecognizer> LuisServices { get; set; } = new Dictionary<string, LuisRecognizer>();
 
-        public Dictionary<string, ITelemetryQnAMaker> QnAServices { get; set; } = new Dictionary<string, ITelemetryQnAMaker>();
+        public Dictionary<string, QnAMaker> QnAServices { get; set; } = new Dictionary<string, QnAMaker>();
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/InterruptableDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/InterruptableDialog.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
         {
             var status = await OnInterruptDialogAsync(dc, cancellationToken).ConfigureAwait(false);
 
-            if (status == InterruptionAction.MessageSentToUser)
+            if (status == InterruptionAction.Resume)
             {
                 // Resume the waiting dialog after interruption
                 await dc.RepromptDialogAsync().ConfigureAwait(false);
                 return EndOfTurn;
             }
-            else if (status == InterruptionAction.StartedDialog)
+            else if (status == InterruptionAction.Waiting)
             {
                 // Stack is already waiting for a response, shelve inner stack
                 return EndOfTurn;

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/InterruptionAction.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/InterruptionAction.cs
@@ -3,17 +3,25 @@
 
 namespace Microsoft.Bot.Builder.Solutions.Dialogs
 {
+    /// <summary>
+    /// Indicates the current status of a dialog interruption.
+    /// </summary>
     public enum InterruptionAction
     {
         /// <summary>
+        /// Indicates that the active dialog was interrupted and should end.
+        /// </summary>
+        End,
+
+        /// <summary>
         /// Indicates that the active dialog was interrupted and needs to resume.
         /// </summary>
-        MessageSentToUser,
+        Resume,
 
         /// <summary>
         /// Indicates that there is a new dialog waiting and the active dialog needs to be shelved.
         /// </summary>
-        StartedDialog,
+        Waiting,
 
         /// <summary>
         /// Indicates that no interruption action is required.

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Solutions.Extensions;
@@ -14,80 +15,48 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
             TelemetryClient = telemetryClient;
         }
 
-        protected override Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        protected override Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default)
         {
             return OnContinueDialogAsync(innerDc, cancellationToken);
         }
 
-        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default)
         {
+            // Check for any interruptions.
             var status = await OnInterruptDialogAsync(innerDc, cancellationToken).ConfigureAwait(false);
 
-            if (status == InterruptionAction.MessageSentToUser)
+            if (status == InterruptionAction.Resume)
             {
-                // Resume the waiting dialog after interruption
+                // Interruption message was sent, and the waiting dialog should resume/reprompt.
                 await innerDc.RepromptDialogAsync().ConfigureAwait(false);
+            }
+            else if (status == InterruptionAction.Waiting)
+            {
+                // Interruption intercepted conversation and is waiting for user to respond.
                 return EndOfTurn;
             }
-            else if (status == InterruptionAction.StartedDialog)
+            else if (status == InterruptionAction.End)
             {
-                // Stack is already waiting for a response, shelve inner stack
-                return EndOfTurn;
+                // Interruption ended conversation, and current dialog should end.
+                return await innerDc.EndDialogAsync().ConfigureAwait(false);
             }
-            else
+            else if (status == InterruptionAction.NoAction)
             {
+                // No interruption was detected. Process activity normally.
                 var activity = innerDc.Context.Activity;
-
-                if (activity.IsStartActivity())
-                {
-                    await OnStartAsync(innerDc).ConfigureAwait(false);
-                }
 
                 switch (activity.Type)
                 {
                     case ActivityTypes.Message:
                         {
-                            // Note: This check is a workaround for adaptive card buttons that should map to an event (i.e. startOnboarding button in intro card)
-                            if (activity.Value != null)
+                            // Pass message to waiting child dialog.
+                            var result = await innerDc.ContinueDialogAsync().ConfigureAwait(false);
+
+                            if (result.Status == DialogTurnStatus.Empty
+                                || (result.Result is RouterDialogTurnResult routerDialogTurnResult && routerDialogTurnResult.Status == RouterDialogTurnStatus.Restart))
                             {
-                                await OnEventAsync(innerDc).ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                var result = await innerDc.ContinueDialogAsync().ConfigureAwait(false);
-
-                                switch (result.Status)
-                                {
-                                    case DialogTurnStatus.Empty:
-                                        {
-                                            await RouteAsync(innerDc).ConfigureAwait(false);
-                                            break;
-                                        }
-
-                                    case DialogTurnStatus.Complete:
-                                        {
-                                            if (result.Result is RouterDialogTurnResult routerDialogTurnResult && routerDialogTurnResult.Status == RouterDialogTurnStatus.Restart)
-                                            {
-                                                await RouteAsync(innerDc).ConfigureAwait(false);
-                                                break;
-                                            }
-
-                                            // End active dialog
-                                            await innerDc.EndDialogAsync().ConfigureAwait(false);
-                                            break;
-                                        }
-
-                                    default:
-                                        {
-                                            break;
-                                        }
-                                }
-                            }
-
-                            // If the active dialog was ended on this turn (either on single-turn dialog, or on continueDialogAsync) run CompleteAsync method.
-                            if (innerDc.ActiveDialog == null)
-                            {
-                                await CompleteAsync(innerDc).ConfigureAwait(false);
+                                // There was no waiting dialog on the stack, process message normally.
+                                await OnMessageActivityAsync(innerDc).ConfigureAwait(false);
                             }
 
                             break;
@@ -95,56 +64,61 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
 
                     case ActivityTypes.Event:
                         {
-                            await OnEventAsync(innerDc).ConfigureAwait(false);
+                            await OnEventActivityAsync(innerDc).ConfigureAwait(false);
                             break;
                         }
 
-                    case ActivityTypes.Invoke:
+                    case ActivityTypes.ConversationUpdate:
                         {
-                            // Used by Teams for Authentication scenarios.
-                            await innerDc.ContinueDialogAsync().ConfigureAwait(false);
+                            await OnMembersAddedAsync(innerDc).ConfigureAwait(false);
                             break;
                         }
 
                     default:
                         {
-                            await OnSystemMessageAsync(innerDc).ConfigureAwait(false);
+                            // All other activity types will be routed here. Custom handling should be added in implementation.
+                            await OnUnhandledActivityTypeAsync(innerDc).ConfigureAwait(false);
                             break;
                         }
                 }
-
-                return EndOfTurn;
             }
+
+            if (innerDc.ActiveDialog == null)
+            {
+                // If the inner dialog stack completed during this turn, this component should be ended.
+                return await innerDc.EndDialogAsync().ConfigureAwait(false);
+            }
+
+            return EndOfTurn;
         }
 
-        protected override Task OnEndDialogAsync(ITurnContext context, DialogInstance instance, DialogReason reason, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
         {
-            return base.OnEndDialogAsync(context, instance, reason, cancellationToken);
-        }
-
-        protected override Task OnRepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return base.OnRepromptDialogAsync(turnContext, instance, cancellationToken);
+            // This happens when an inner dialog ends. Could call complete here
+            await OnDialogCompleteAsync(outerDc, result, cancellationToken).ConfigureAwait(false);
+            return await base.EndComponentAsync(outerDc, result, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Called when the inner dialog stack is empty.
+        /// Called on every turn, enabling interruption scenarios.
+        /// </summary>
+        /// <param name="innerDc">The dialog context for the component.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> returning an <see cref="InterruptionAction">
+        /// which indicates what action should be taken after interruption.</returns>.
+        protected override Task<InterruptionAction> OnInterruptDialogAsync(DialogContext innerDc, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(InterruptionAction.NoAction);
+        }
+
+        /// <summary>
+        /// Called when an event activity is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected abstract Task RouteAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Called when the inner dialog stack is complete.
-        /// </summary>
-        /// <param name="innerDc">The dialog context for the component.</param>
-        /// <param name="result">The dialog result when inner dialog completed.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual Task CompleteAsync(DialogContext innerDc, DialogTurnResult result = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual Task OnEventActivityAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
-            innerDc.EndDialogAsync(result).Wait(cancellationToken);
             return Task.CompletedTask;
         }
 
@@ -154,36 +128,43 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual Task OnEventAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual Task OnMessageActivityAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.CompletedTask;
         }
 
         /// <summary>
-        /// Called when a system activity is received.
+        /// Called when an event activity is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual Task OnSystemMessageAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual Task OnMembersAddedAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.CompletedTask;
         }
 
         /// <summary>
-        /// Called when a conversation update activity is received.
+        /// Called when an event activity is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual Task OnStartAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual Task OnUnhandledActivityTypeAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.CompletedTask;
         }
 
-        protected override Task<InterruptionAction> OnInterruptDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Called when the inner dialog stack completes.
+        /// </summary>
+        /// <param name="outerDc">The dialog context for the component.</param>
+        /// <param name="result">The dialog turn result for the component.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected virtual Task OnDialogCompleteAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
         {
-            return Task.FromResult(InterruptionAction.NoAction);
+            return Task.CompletedTask;
         }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
         }
 
         /// <summary>
-        /// Called when an event activity is received.
+        /// Called when a message activity is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -134,7 +134,7 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
         }
 
         /// <summary>
-        /// Called when an event activity is received.
+        /// Called when a conversationUpdate activity is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -145,7 +145,7 @@ namespace Microsoft.Bot.Builder.Solutions.Dialogs
         }
 
         /// <summary>
-        /// Called when an event activity is received.
+        /// Called when an activity type other than event, message, or conversationUpdate is received.
         /// </summary>
         /// <param name="innerDc">The dialog context for the component.</param>
         /// <param name="cancellationToken">The cancellation token.</param>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
Closes #2263 
Closes #2110

### Purpose
*What is the context of this pull request? Why is it being done?*
- Refactors the router dialog code to be less restrictive and align with bot framework activity types
- Renames InteruptionActions to be more applicable across scenarios
- Updates CognitiveModelSet to use full implementation rather than telemetry interfaces (per SDK request)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
- Implementing router dialog changes in VA and Skill templates
- Implementing router dialog changes in Skill projects

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
