### PR TITLE
[VA] Added "repeat last message" logic

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/InterruptionTests.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/InterruptionTests.cs
@@ -66,5 +66,22 @@ namespace VirtualAssistantSample.Tests
                .AssertReply(TemplateEngine.EvaluateTemplate("cancelledMessage"))
                .StartTestAsync();
         }
+
+        [TestMethod]
+        public async Task Test_Repeat_Interruption()
+        {
+            await GetTestFlow()
+                .Send(new Activity()
+                {
+                    Type = ActivityTypes.ConversationUpdate,
+                    MembersAdded = new List<ChannelAccount>() { new ChannelAccount("user") }
+                })
+               .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
+               .AssertReply(TemplateEngine.EvaluateTemplate("namePrompt"))
+               .Send(GeneralUtterances.Repeat)
+               .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
+               .AssertReply(TemplateEngine.EvaluateTemplate("namePrompt"))
+               .StartTestAsync();
+        }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
close #2152 

### Purpose
*What is the context of this pull request? Why is it being done?*
This change enables the VA to handle the "repeat" intent to show/speak all the messages since the user last responded. This allows users in speech scenarios to have an activity read out again as needed.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Updated MainDialog with an onSendActivities handler that logs the last messages

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Added new repeat test to VA

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation