### PR TITLE
[ITSM] return error if could not get user id

### DIFF
--- a/skills/csharp/experimental/itsmskill/Responses/Shared/SharedStrings.Designer.cs
+++ b/skills/csharp/experimental/itsmskill/Responses/Shared/SharedStrings.Designer.cs
@@ -185,6 +185,16 @@ namespace ITSMSkill.Responses.Shared {
                 return ResourceManager.GetString("ID", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to GetUserId is invalid..
+        /// </summary>
+        public static string InvalidGetUserId {
+            get {
+                return ResourceManager.GetString("InvalidGetUserId", resourceCulture);
+
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to no.

--- a/skills/csharp/experimental/itsmskill/Responses/Shared/SharedStrings.resx
+++ b/skills/csharp/experimental/itsmskill/Responses/Shared/SharedStrings.resx
@@ -192,6 +192,9 @@
   <data name="GoPrevious" xml:space="preserve">
     <value>"Go previous" to navigate.</value>
   </data>
+  <data name="InvalidGetUserId" xml:space="preserve">
+    <value>GetUserId is invalid.</value>
+  </data>
   <data name="PoweredBy" xml:space="preserve">
     <value>Powered by **{0}**</value>
   </data>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Return error if could not get user id, 
![image](https://user-images.githubusercontent.com/2876650/66458692-f5737a00-eaa5-11e9-998b-9f4e386155bf.png)
so the following would not happen when creating ticket:
![1](https://user-images.githubusercontent.com/2876650/66458614-bf35fa80-eaa5-11e9-83fd-70bcbbf36c1a.png)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Add GetUserId().

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
