### PR TITLE
[VA] fix null UserState

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Startup.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Startup.cs
@@ -56,8 +56,6 @@ namespace VirtualAssistantSample
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
-            var provider = services.BuildServiceProvider();
-
             // Load settings
             var settings = new BotSettings();
             Configuration.Bind(settings);
@@ -97,10 +95,13 @@ namespace VirtualAssistantSample
 
             foreach (var skill in settings.Skills)
             {
-                var userState = provider.GetService<UserState>();
                 var authDialog = BuildAuthDialog(skill, settings, appCredentials);
                 var credentials = new MicrosoftAppCredentialsEx(settings.MicrosoftAppId, settings.MicrosoftAppPassword, skill.MSAappId);
-                services.AddTransient(sp => new SkillDialog(skill, credentials, telemetryClient, userState, authDialog));
+                services.AddTransient(sp =>
+                {
+                    var userState = sp.GetService<UserState>();
+                    return new SkillDialog(skill, credentials, telemetryClient, userState, authDialog);
+                });
             }
 
             // Configure adapters


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Fix null UserState for SkillDialog.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Use sp from AddTransient instead of BuildServiceProvider.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
