### PR TITLE
[Skills] use single comma for scopes

### DIFF
--- a/skills/csharp/calendarskill/Services/GoogleAPI/GoogleClient.cs
+++ b/skills/csharp/calendarskill/Services/GoogleAPI/GoogleClient.cs
@@ -33,7 +33,7 @@ namespace CalendarSkill.Services.GoogleAPI
                 ApplicationName = appName,
                 ClientId = clientId,
                 ClientSecret = clientSecret,
-                Scopes = scopes.Split(" "),
+                Scopes = scopes.Split(","),
             };
 
             return googleClient;

--- a/skills/csharp/calendarskill/appsettings.json
+++ b/skills/csharp/calendarskill/appsettings.json
@@ -28,7 +28,7 @@
   "googleAppName": "",
   "googleClientId": "",
   "googleClientSecret": "",
-  "googleScopes": "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts",
+  "googleScopes": "https://www.googleapis.com/auth/calendar, https://www.googleapis.com/auth/contacts",
   "DisplaySize": 3,
   "defaultValue": {
     "createMeeting": [

--- a/skills/csharp/calendarskill/manifestTemplate.json
+++ b/skills/csharp/calendarskill/manifestTemplate.json
@@ -12,7 +12,7 @@
     {
       "id": "Google",
       "serviceProviderId": "Google",
-      "scopes": "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts"
+      "scopes": "https://www.googleapis.com/auth/calendar, https://www.googleapis.com/auth/contacts"
     }
   ],
   "actions": [

--- a/skills/csharp/emailskill/Services/GoogleAPI/GoogleClient.cs
+++ b/skills/csharp/emailskill/Services/GoogleAPI/GoogleClient.cs
@@ -34,7 +34,7 @@ namespace EmailSkill.Services.GoogleAPI
                 ApplicationName = appName,
                 ClientId = clientId,
                 ClientSecret = clientSecret,
-                Scopes = scopes.Split(" "),
+                Scopes = scopes.Split(","),
             };
 
             return googleClient;

--- a/skills/csharp/emailskill/appsettings.json
+++ b/skills/csharp/emailskill/appsettings.json
@@ -35,7 +35,7 @@
   "googleAppName": "",
   "googleClientId": "",
   "googleClientSecret": "",
-  "googleScopes": "https://mail.google.com/ https://www.googleapis.com/auth/contacts",
+  "googleScopes": "https://mail.google.com/, https://www.googleapis.com/auth/contacts",
   "displaySize": 3,
   "azureMapsKey": ""
 }

--- a/skills/csharp/emailskill/manifestTemplate.json
+++ b/skills/csharp/emailskill/manifestTemplate.json
@@ -12,7 +12,7 @@
     {
       "id": "Google",
       "serviceProviderId": "Google",
-      "scopes": "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/contacts"
+      "scopes": "https://www.googleapis.com/auth/calendar, https://www.googleapis.com/auth/contacts"
     }
   ],
   "actions": [

--- a/skills/csharp/experimental/phoneskill/Services/GoogleAPI/GoogleClient.cs
+++ b/skills/csharp/experimental/phoneskill/Services/GoogleAPI/GoogleClient.cs
@@ -32,7 +32,7 @@ namespace PhoneSkill.Services.GoogleAPI
             ApplicationName = appName as string;
             ClientId = clientId as string;
             ClientSecret = clientSecret as string;
-            Scopes = (scopes as string).Split(" ");
+            Scopes = (scopes as string).Split(",");
         }
 
         public string Token { get; set; }

--- a/skills/csharp/todoskill/manifestTemplate.json
+++ b/skills/csharp/todoskill/manifestTemplate.json
@@ -7,7 +7,7 @@
     {
       "id": "Outlook",
       "serviceProviderId": "Azure Active Directory v2",
-      "scopes": "Tasks.ReadWrite Notes.ReadWrite User.Read User.ReadBasic.All Mail.Send"
+      "scopes": "Tasks.ReadWrite, Notes.ReadWrite, User.Read, User.ReadBasic.All, Mail.Send"
     }
   ],
   "actions": [


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close https://github.com/microsoft/botframework-solutions/issues/2281

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Use single comma for scopes. 

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
