### PR TITLE
[botskills] update split and err

### DIFF
--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -116,7 +116,7 @@ export class AuthenticationUtils {
                     logger.message('Configuring Azure AD connection ...');
 
                     let connectionName: string = aadConfig.id;
-                    const newScopes: string[] = aadConfig.scopes.split(', ');
+                    const newScopes: string[] = aadConfig.scopes.split(',');
                     let scopes: string[] = newScopes.slice(0);
 
                     // check for existing aad connection
@@ -257,18 +257,18 @@ export class AuthenticationUtils {
         } catch (err) {
             logger.warning(`Could not configure authentication connection automatically.`);
             if (currentCommand.length > 0) {
-                logger.warning(`There was an error while executing the following command:\n\t${currentCommand.join(' ')}\n${err.message}`);
+                logger.warning(`There was an error while executing the following command:\n\t${currentCommand.join(' ')}\n${err.message || err}`);
                 logger.warning(`You must configure one of the following connection types MANUALLY in the Azure Portal:
         ${manifest.authenticationConnections.map((authConn: IAuthenticationConnection) => authConn.serviceProviderId)
                     .join(', ')}`);
                 logger.warning(`For more information on setting up the authentication configuration manually go to:\n${this.docLink}`);
             } else if (manifest.authenticationConnections && manifest.authenticationConnections.length > 0) {
-                logger.warning(`${err.message} You must configure one of the following connection types MANUALLY in the Azure Portal:
+                logger.warning(`${err.message || err} You must configure one of the following connection types MANUALLY in the Azure Portal:
         ${manifest.authenticationConnections.map((authConn: IAuthenticationConnection) => authConn.serviceProviderId)
                     .join(', ')}`);
                 logger.warning(`For more information on setting up the authentication configuration manually go to:\n${this.docLink}`);
             } else {
-                logger.warning(err.message);
+                logger.warning(err.message || err);
             }
 
             return false;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

* Split scopes by ',' instead of ', ' (note the space behind)
* When err is string, use it instead of err.message (which is undefined)
    - string is thrown in ```pReject(stderr);``` inside ```await this.childProcessUtils.tryExecute```

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
