### PR TITLE
Set app registration homepage to skill url as part of deploy.

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -77,27 +77,43 @@ if (-not $luisAuthoringKey) {
 	}
 }
 
+$app = $null
+
 if (-not $appId) {
 	# Create app registration
-	$app = (az ad app create `
+	$appJson = (az ad app create `
 		--display-name $name `
 		--password `"$($appPassword)`" `
 		--available-to-other-tenants `
 		--reply-urls 'https://token.botframework.com/.auth/web/redirect' `
         --output json)
 
-	# Retrieve AppId
-	if ($app) {
-		$appId = ($app | ConvertFrom-Json) | Select-Object -ExpandProperty appId
-	}
-
-	if(-not $appId) {
+	if(-not $appJson) {
 		Write-Host "! Could not provision Microsoft App Registration automatically. Review the log for more information." -ForegroundColor DarkRed
 		Write-Host "! Log: $($logFile)" -ForegroundColor DarkRed
 		Write-Host "+ Provision an app manually in the Azure Portal, then try again providing the -appId and -appPassword arguments. See https://aka.ms/vamanualappcreation for more information." -ForegroundColor Magenta
 		Break
 	}
+
+	$app = ($appJson | ConvertFrom-Json)
+} else {
+	# Get the app registration
+	$appsJson = (az ad app list `
+		--app-id $appId `
+		--output json)
+
+	$apps = ($appsJson | ConvertFrom-Json)
+
+	if($apps.Length -eq 0) {
+		Write-Host "! Could not find appId $($appId). Review the log for more information." -ForegroundColor DarkRed
+		Write-Host "! Log: $($logFile)" -ForegroundColor DarkRed
+		Break
+	}
+
+	$app = $apps[0];
 }
+
+$appId = $app.appId
 
 # Get timestamp
 $timestamp = Get-Date -f MMddyyyyHHmmss
@@ -207,6 +223,9 @@ if ($outputs)
 	# Deploy cognitive models
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 	
+	# Update app registration homepage to point to skill
+	az ad app update --id $app.objectId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+
 	# Summary 
 	Write-Host "Summary of the deployed resources:" -ForegroundColor Yellow
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -77,27 +77,43 @@ if (-not $luisAuthoringKey) {
 	}
 }
 
+$app = $null
+
 if (-not $appId) {
 	# Create app registration
-	$app = (az ad app create `
+	$appJson = (az ad app create `
 		--display-name $name `
 		--password `"$($appPassword)`" `
 		--available-to-other-tenants `
 		--reply-urls 'https://token.botframework.com/.auth/web/redirect' `
         --output json)
 
-	# Retrieve AppId
-	if ($app) {
-		$appId = ($app | ConvertFrom-Json) | Select-Object -ExpandProperty appId
-	}
-
-	if(-not $appId) {
+	if(-not $appJson) {
 		Write-Host "! Could not provision Microsoft App Registration automatically. Review the log for more information." -ForegroundColor DarkRed
 		Write-Host "! Log: $($logFile)" -ForegroundColor DarkRed
 		Write-Host "+ Provision an app manually in the Azure Portal, then try again providing the -appId and -appPassword arguments. See https://aka.ms/vamanualappcreation for more information." -ForegroundColor Magenta
 		Break
 	}
+
+	$app = ($appJson | ConvertFrom-Json)
+} else {
+	# Get the app registration
+	$appsJson = (az ad app list `
+		--app-id $appId `
+		--output json)
+
+	$apps = ($appsJson | ConvertFrom-Json)
+
+	if($apps.Length -eq 0) {
+		Write-Host "! Could not find appId $($appId). Review the log for more information." -ForegroundColor DarkRed
+		Write-Host "! Log: $($logFile)" -ForegroundColor DarkRed
+		Break
+	}
+
+	$app = $apps[0];
 }
+
+$appId = $app.appId
 
 # Get timestamp
 $timestamp = Get-Date -f MMddyyyyHHmmss
@@ -207,6 +223,9 @@ if ($outputs)
 	# Deploy cognitive models
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -luisAuthoringRegion $($luisAuthoringRegion) -luisAuthoringKey $($luisAuthoringKey) -luisAccountName $($outputs.luis.value.accountName) -luisAccountRegion $($outputs.luis.value.region) -luisSubscriptionKey $($outputs.luis.value.key) -resourceGroup $($resourceGroup) -qnaSubscriptionKey '$($qnaSubscriptionKey)' -outFolder '$($srcDir)' -languages '$($languages)'"
 	
+	# Update app registration homepage to point to skill
+	az ad app update --id $app.objectId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+
 	# Summary 
 	Write-Host "Summary of the deployed resources:" -ForegroundColor Yellow
 


### PR DESCRIPTION
Close #2586: Set homepage in AAD app registration for skill.
### Purpose
This allows an AAD admin (or tooling) to establish a relationship between the skill and AAD app registration, because they reference each other - the former via the manifest, and the latter via the AAD homepage property.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
N/A

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
N/A

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
N/A

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation

#### Bots
- [x] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [x] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
