### PR TITLE
[ITSM] replace enum prompt

### DIFF
--- a/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
@@ -159,7 +159,8 @@ namespace ITSMSkill.Dialogs
             }
 
             var state = await StateAccessor.GetAsync(sc.Context, () => new SkillState());
-            state.AttributeType = (AttributeType)sc.Result;
+            Enum.TryParse((string)sc.Result, out AttributeType attributeType);
+            state.AttributeType = attributeType;
             return await sc.NextAsync();
         }
 
@@ -275,7 +276,7 @@ namespace ITSMSkill.Dialogs
                 throw new Exception($"Invalid InterruptedIntent {state.InterruptedIntent}");
             }
 
-            var intent = (GeneralLuis.Intent)sc.Result;
+            Enum.TryParse((string)sc.Result, out GeneralLuis.Intent intent);
             if (intent == GeneralLuis.Intent.Reject)
             {
                 await sc.Context.SendActivityAsync(ResponseManager.GetResponse(SharedResponses.ActionEnded));
@@ -301,7 +302,7 @@ namespace ITSMSkill.Dialogs
             }
         }
 
-        protected async Task<bool> ShowNavigateValidator(PromptValidatorContext<GeneralLuis.Intent> promptContext, CancellationToken cancellationToken)
+        protected async Task<bool> ShowNavigateValidator(PromptValidatorContext<string> promptContext, CancellationToken cancellationToken)
         {
             if (promptContext.Recognized.Succeeded)
             {

--- a/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
@@ -345,7 +345,8 @@ namespace ITSMSkill.Dialogs
             }
 
             var state = await StateAccessor.GetAsync(sc.Context, () => new SkillState());
-            state.AttributeType = (AttributeType)sc.Result;
+            Enum.TryParse((string)sc.Result, out AttributeType attributeType);
+            state.AttributeType = attributeType;
             return await sc.NextAsync();
         }
 
@@ -881,7 +882,7 @@ namespace ITSMSkill.Dialogs
 
         protected async Task<DialogTurnResult> IfKnowledgeHelp(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var intent = (GeneralLuis.Intent)sc.Result;
+            Enum.TryParse((string)sc.Result, out GeneralLuis.Intent intent);
             if (intent == GeneralLuis.Intent.Confirm)
             {
                 await sc.Context.SendActivityAsync(ResponseManager.GetResponse(SharedResponses.ActionEnded));

--- a/skills/csharp/experimental/itsmskill/Prompts/AttributeWithNoPrompt.cs
+++ b/skills/csharp/experimental/itsmskill/Prompts/AttributeWithNoPrompt.cs
@@ -15,11 +15,11 @@ using Microsoft.Bot.Schema;
 
 namespace ITSMSkill.Prompts
 {
-    public class AttributeWithNoPrompt : Prompt<AttributeType?>
+    public class AttributeWithNoPrompt : Prompt<string>
     {
         private readonly AttributeType[] attributes;
 
-        public AttributeWithNoPrompt(string dialogId, AttributeType[] attributes, PromptValidator<AttributeType?> validator = null, string defaultLocale = null)
+        public AttributeWithNoPrompt(string dialogId, AttributeType[] attributes, PromptValidator<string> validator = null, string defaultLocale = null)
        : base(dialogId, validator)
         {
             this.attributes = attributes;
@@ -50,14 +50,14 @@ namespace ITSMSkill.Prompts
             }
         }
 
-        protected override async Task<PromptRecognizerResult<AttributeType?>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<PromptRecognizerResult<string>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (turnContext == null)
             {
                 throw new ArgumentNullException(nameof(turnContext));
             }
 
-            var result = new PromptRecognizerResult<AttributeType?>();
+            var result = new PromptRecognizerResult<string>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
                 var message = turnContext.Activity.AsMessageActivity();
@@ -77,7 +77,7 @@ namespace ITSMSkill.Prompts
                         if (IsMessageAttributeMatch(text, attribute))
                         {
                             result.Succeeded = true;
-                            result.Value = attribute;
+                            result.Value = attribute.ToString();
                             break;
                         }
                     }

--- a/skills/csharp/experimental/itsmskill/Prompts/GeneralPrompt.cs
+++ b/skills/csharp/experimental/itsmskill/Prompts/GeneralPrompt.cs
@@ -12,12 +12,12 @@ using Microsoft.Bot.Builder.Dialogs;
 
 namespace ITSMSkill.Prompts
 {
-    public class GeneralPrompt : Prompt<GeneralLuis.Intent>
+    public class GeneralPrompt : Prompt<string>
     {
         private readonly ISet<GeneralLuis.Intent> intents;
         private readonly IStatePropertyAccessor<SkillState> stateAccessor;
 
-        public GeneralPrompt(string dialogId, ISet<GeneralLuis.Intent> intents, IStatePropertyAccessor<SkillState> stateAccessor, PromptValidator<GeneralLuis.Intent> validator = null, string defaultLocale = null)
+        public GeneralPrompt(string dialogId, ISet<GeneralLuis.Intent> intents, IStatePropertyAccessor<SkillState> stateAccessor, PromptValidator<string> validator = null, string defaultLocale = null)
 : base(dialogId, validator)
         {
             this.intents = intents;
@@ -49,21 +49,21 @@ namespace ITSMSkill.Prompts
             }
         }
 
-        protected override async Task<PromptRecognizerResult<GeneralLuis.Intent>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<PromptRecognizerResult<string>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (turnContext == null)
             {
                 throw new ArgumentNullException(nameof(turnContext));
             }
 
-            var result = new PromptRecognizerResult<GeneralLuis.Intent>();
+            var result = new PromptRecognizerResult<string>();
 
             var skillState = await stateAccessor.GetAsync(turnContext);
 
             if (intents.Contains(skillState.GeneralIntent))
             {
                 result.Succeeded = true;
-                result.Value = skillState.GeneralIntent;
+                result.Value = skillState.GeneralIntent.ToString();
             }
 
             return await Task.FromResult(result);


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Work around for https://github.com/microsoft/botbuilder-dotnet/issues/2891

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Use string prompt instead of enum prompt.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

Fix tests of Calendar skill.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
