### PR TITLE
[ITSM] cache user sys id

### DIFF
--- a/skills/csharp/experimental/itsmskill/Dialogs/CloseTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/CloseTicketDialog.cs
@@ -64,7 +64,7 @@ namespace ITSMSkill.Dialogs
         protected async Task<DialogTurnResult> CloseTicket(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = await StateAccessor.GetAsync(sc.Context, () => new SkillState());
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
             var result = await management.CloseTicket(id: state.Id, reason: state.CloseReason);
 
             if (!result.Success)

--- a/skills/csharp/experimental/itsmskill/Dialogs/CreateTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/CreateTicketDialog.cs
@@ -91,7 +91,7 @@ namespace ITSMSkill.Dialogs
         protected async Task<DialogTurnResult> CreateTicket(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = await StateAccessor.GetAsync(sc.Context, () => new SkillState());
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
             var result = await management.CreateTicket(state.TicketTitle, state.TicketDescription, state.UrgencyLevel);
 
             if (!result.Success)

--- a/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
@@ -181,7 +181,7 @@ namespace ITSMSkill.Dialogs
                 state.PageIndex = 0;
             }
 
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
 
             var urgencies = new List<UrgencyLevel>();
             if (state.UrgencyLevel != UrgencyLevel.None)

--- a/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
@@ -609,7 +609,7 @@ namespace ITSMSkill.Dialogs
         protected async Task<DialogTurnResult> SetIdFromNumber(WaterfallStepContext sc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = await StateAccessor.GetAsync(sc.Context, () => new SkillState());
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
             var result = await management.SearchTicket(0, number: state.TicketNumber);
 
             if (!result.Success)
@@ -800,7 +800,7 @@ namespace ITSMSkill.Dialogs
                 state.PageIndex = 0;
             }
 
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
 
             var countResult = await management.CountKnowledge(state.TicketTitle);
 

--- a/skills/csharp/experimental/itsmskill/Dialogs/UpdateTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/UpdateTicketDialog.cs
@@ -127,7 +127,7 @@ namespace ITSMSkill.Dialogs
                 return await sc.NextAsync();
             }
 
-            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse);
+            var management = ServiceManager.CreateManagement(Settings, sc.Result as TokenResponse, state.ServiceCache);
             var result = await management.UpdateTicket(state.Id, state.TicketTitle, state.TicketDescription, state.UrgencyLevel);
 
             if (!result.Success)

--- a/skills/csharp/experimental/itsmskill/Models/ServiceCache.cs
+++ b/skills/csharp/experimental/itsmskill/Models/ServiceCache.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace ITSMSkill.Models
+{
+    public class ServiceCache
+    {
+        public object Cache { get; set; }
+    }
+}

--- a/skills/csharp/experimental/itsmskill/Models/ServiceNow/Cache.cs
+++ b/skills/csharp/experimental/itsmskill/Models/ServiceNow/Cache.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ITSMSkill.Models.ServiceNow
+{
+    public class Cache
+    {
+        public string UserSysId { get; set; }
+
+        public string TokenHash { get; set; }
+    }
+}

--- a/skills/csharp/experimental/itsmskill/Models/SkillState.cs
+++ b/skills/csharp/experimental/itsmskill/Models/SkillState.cs
@@ -12,8 +12,12 @@ namespace ITSMSkill.Models
     {
         public SkillState()
         {
+            ServiceCache = new ServiceCache();
             ClearLuisResult();
         }
+
+        // used by Service to cache internal states
+        public ServiceCache ServiceCache { get; set; }
 
         // handle manually
         public int PageIndex { get; set; }

--- a/skills/csharp/experimental/itsmskill/Services/IServiceManager.cs
+++ b/skills/csharp/experimental/itsmskill/Services/IServiceManager.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using ITSMSkill.Models;
 using Microsoft.Bot.Schema;
 
 namespace ITSMSkill.Services
 {
     public interface IServiceManager
     {
-        IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse);
+        IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse, ServiceCache serviceCache = null);
     }
 }

--- a/skills/csharp/experimental/itsmskill/Services/ServiceManager.cs
+++ b/skills/csharp/experimental/itsmskill/Services/ServiceManager.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using ITSMSkill.Models;
 using Microsoft.Bot.Schema;
 
 namespace ITSMSkill.Services
 {
     public class ServiceManager : IServiceManager
     {
-        public IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse)
+        public IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse, ServiceCache serviceCache)
         {
             if (tokenResponse.ConnectionName == "ServiceNow" && !string.IsNullOrEmpty(botSettings.ServiceNowUrl) && !string.IsNullOrEmpty(botSettings.ServiceNowGetUserId))
             {
-                return new ServiceNow.Management(botSettings.ServiceNowUrl, tokenResponse.Token, botSettings.LimitSize, botSettings.ServiceNowGetUserId);
+                return new ServiceNow.Management(botSettings.ServiceNowUrl, tokenResponse.Token, botSettings.LimitSize, botSettings.ServiceNowGetUserId, serviceCache);
             }
             else
             {

--- a/skills/csharp/experimental/itsmskill/Services/ServiceNow/Management.cs
+++ b/skills/csharp/experimental/itsmskill/Services/ServiceNow/Management.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using ITSMSkill.Models;
 using ITSMSkill.Models.ServiceNow;
 using ITSMSkill.Responses.Shared;
+using Microsoft.AspNetCore.Identity;
 using Newtonsoft.Json;
 using RestSharp;
 using RestSharp.Serializers;
@@ -32,6 +33,7 @@ namespace ITSMSkill.Services.ServiceNow
         private readonly string token;
         private readonly int limitSize;
         private readonly string knowledgeUrl;
+        private readonly string userId;
 
         static Management()
         {
@@ -56,13 +58,47 @@ namespace ITSMSkill.Services.ServiceNow
             StringToTicketState = new Dictionary<string, TicketState>(TicketStateToString.Select(pair => KeyValuePair.Create(pair.Value, pair.Key)));
         }
 
-        public Management(string url, string token, int limitSize, string getUserIdResource, IRestClient restClient = null)
+        public Management(string url, string token, int limitSize, string getUserIdResource, ServiceCache serviceCache = null, IRestClient restClient = null)
         {
             this.client = restClient ?? new RestClient($"{url}/api/");
             this.getUserIdResource = getUserIdResource;
             this.token = token;
             this.limitSize = limitSize;
             this.knowledgeUrl = $"{url}/kb_view.do?sysparm_article={{0}}";
+
+            bool validUserId = false;
+
+            var hasher = new PasswordHasher<Management>();
+            if (serviceCache != null && serviceCache.Cache is Cache cache && !string.IsNullOrEmpty(cache.UserSysId) && !string.IsNullOrEmpty(cache.TokenHash))
+            {
+                var result = hasher.VerifyHashedPassword(null, cache.TokenHash, token);
+                if (result == PasswordVerificationResult.Success)
+                {
+                    validUserId = true;
+                }
+                else if (result == PasswordVerificationResult.SuccessRehashNeeded)
+                {
+                    validUserId = true;
+                    cache.TokenHash = hasher.HashPassword(null, token);
+                }
+            }
+
+            if (validUserId)
+            {
+                userId = (serviceCache.Cache as Cache).UserSysId;
+            }
+            else
+            {
+                userId = GetUserId().Result;
+                if (serviceCache != null)
+                {
+                    serviceCache.Cache = new Cache
+                    {
+                        UserSysId = userId,
+                        TokenHash = hasher.HashPassword(null, token)
+                    };
+                }
+            }
         }
 
         public async Task<TicketsResult> CreateTicket(string title, string description, UrgencyLevel urgency)
@@ -72,7 +108,7 @@ namespace ITSMSkill.Services.ServiceNow
                 var request = CreateRequest(TicketResource);
                 var body = new CreateTicketRequest()
                 {
-                    caller_id = await GetUserId(),
+                    caller_id = userId,
                     short_description = title,
                     description = description,
                     urgency = UrgencyToString[urgency]
@@ -197,7 +233,7 @@ namespace ITSMSkill.Services.ServiceNow
                 {
                     close_code = "Closed/Resolved by Caller",
                     state = "7",
-                    caller_id = await GetUserId(),
+                    caller_id = userId,
                     close_notes = reason
                 };
                 request.JsonSerializer = new JsonNoNull();
@@ -285,7 +321,7 @@ namespace ITSMSkill.Services.ServiceNow
         {
             var sysparmQuery = new List<string>
             {
-                $"caller_id={await GetUserId()}"
+                $"caller_id={userId}"
             };
 
             if (!string.IsNullOrEmpty(query))

--- a/skills/csharp/tests/itsmskill.tests/API/Fakes/MockServiceNowRestClient.cs
+++ b/skills/csharp/tests/itsmskill.tests/API/Fakes/MockServiceNowRestClient.cs
@@ -128,7 +128,7 @@ namespace ITSMSkill.Tests.API.Fakes
             // TODO use Execute*TaskAsync instead of extension methods
             mockClient
                .Setup(c => c.ExecuteGetTaskAsync<GetUserIdResponse>(It.IsAny<IRestRequest>()))
-               .ReturnsAsync(CreateIRestResponse(GetUserIdResponse));
+               .ReturnsAsync(CreateGetUserIdResponseAndCount());
 
             mockClient
                .Setup(c => c.ExecuteGetTaskAsync<SingleAggregateResponse>(It.Is<IRestRequest>(r => r.Resource.StartsWith("now/v1/stats/incident") && r.Parameters.Any(p => p.Name == "sysparm_count" && p.Value is bool && (bool)p.Value))))
@@ -168,6 +168,14 @@ namespace ITSMSkill.Tests.API.Fakes
         }
 
         public IRestClient MockRestClient { get; }
+
+        public int GetUserIdResponseCount { get; set; } = 0;
+
+        private IRestResponse<GetUserIdResponse> CreateGetUserIdResponseAndCount()
+        {
+            GetUserIdResponseCount += 1;
+            return CreateIRestResponse(GetUserIdResponse);
+        }
 
         private IRestResponse<T> CreateIRestResponse<T>(T data)
         {

--- a/skills/csharp/tests/itsmskill.tests/API/ServiceNowServiceTests.cs
+++ b/skills/csharp/tests/itsmskill.tests/API/ServiceNowServiceTests.cs
@@ -15,18 +15,20 @@ namespace ITSMSkill.Tests.API
     [TestClass]
     public class ServiceNowServiceTests
     {
+        private MockServiceNowRestClient mockServiceNowRestClient;
         private IRestClient mockClient;
 
         [TestInitialize]
         public void Initialize()
         {
-            mockClient = new MockServiceNowRestClient().MockRestClient;
+            mockServiceNowRestClient = new MockServiceNowRestClient();
+            mockClient = mockServiceNowRestClient.MockRestClient;
         }
 
         [TestMethod]
         public async Task CreateTicketTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.CreateTicket(MockData.CreateTicketTitle, MockData.CreateTicketDescription, MockData.CreateTicketUrgencyLevel);
 
@@ -44,7 +46,7 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task SearchTicketTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.SearchTicket(0);
 
@@ -62,7 +64,7 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task CountTicketTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.CountTicket();
 
@@ -73,7 +75,7 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task UpdateTicketTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.UpdateTicket(MockData.CreateTicketId);
 
@@ -91,7 +93,7 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task CloseTicketTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.CloseTicket(MockData.CloseTicketId, MockData.CloseTicketReason);
 
@@ -110,7 +112,7 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task SearchKnowledgeTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.SearchKnowledge(MockData.KnowledgeTitle, 0);
 
@@ -127,12 +129,32 @@ namespace ITSMSkill.Tests.API
         [TestMethod]
         public async Task CountKnowledgeTest()
         {
-            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, mockClient);
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, null, mockClient);
 
             var result = await service.CountKnowledge(MockData.KnowledgeTitle);
 
             Assert.AreEqual(result.Success, true);
             Assert.AreEqual(result.Knowledges.Length, MockData.KnowledgeCount);
+        }
+
+        [TestMethod]
+        public async Task ServiceHasCacheTest()
+        {
+            var cache = new ServiceCache();
+
+            var service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, cache, mockClient);
+            var result = await service.CountKnowledge(MockData.KnowledgeTitle);
+            Assert.AreEqual(result.Success, true);
+            Assert.AreEqual(result.Knowledges.Length, MockData.KnowledgeCount);
+
+            Assert.AreEqual(mockServiceNowRestClient.GetUserIdResponseCount, 1);
+
+            service = new Management(MockData.ServiceNowUrl, MockData.Token, MockData.LimitSize, MockData.ServiceNowGetUserId, cache, mockClient);
+            result = await service.CountKnowledge(MockData.KnowledgeTitle);
+            Assert.AreEqual(result.Success, true);
+            Assert.AreEqual(result.Knowledges.Length, MockData.KnowledgeCount);
+
+            Assert.AreEqual(mockServiceNowRestClient.GetUserIdResponseCount, 1);
         }
     }
 }

--- a/skills/csharp/tests/itsmskill.tests/Flow/Fakes/MockServiceManager.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/Fakes/MockServiceManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using ITSMSkill.Models;
 using ITSMSkill.Services;
 using ITSMSkill.Services.ServiceNow;
 using ITSMSkill.Tests.API.Fakes;
@@ -10,12 +11,12 @@ namespace ITSMSkill.Tests.Flow.Fakes
 {
     public class MockServiceManager : IServiceManager
     {
-        public IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse)
+        public IITServiceManagement CreateManagement(BotSettings botSettings, TokenResponse tokenResponse, ServiceCache serviceCache)
         {
             // TODO check tokenResponse.ConnectionName == "ServiceNow"
             if (!string.IsNullOrEmpty(botSettings.ServiceNowUrl) && !string.IsNullOrEmpty(botSettings.ServiceNowGetUserId))
             {
-                return new Management(botSettings.ServiceNowUrl, tokenResponse.Token, botSettings.LimitSize, botSettings.ServiceNowGetUserId, new MockServiceNowRestClient().MockRestClient);
+                return new Management(botSettings.ServiceNowUrl, tokenResponse.Token, botSettings.LimitSize, botSettings.ServiceNowGetUserId, serviceCache, new MockServiceNowRestClient().MockRestClient);
             }
             else
             {

--- a/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
+++ b/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Cache user sys id to speed up api calls.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Add TokenHash to verify if user id matches current token.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

After https://github.com/microsoft/botframework-solutions/pull/2621

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
