### PR TITLE
[Hospitality] LateCheckOut uses time

### DIFF
--- a/skills/csharp/experimental/hospitalityskill/Dialogs/HospitalityDialogBase.cs
+++ b/skills/csharp/experimental/hospitalityskill/Dialogs/HospitalityDialogBase.cs
@@ -101,11 +101,12 @@ namespace HospitalitySkill.Dialogs
                 // When the token is cached we get a TokenResponse object.
                 if (sc.Result is ProviderTokenResponse providerTokenResponse)
                 {
-                    var state = await StateAccessor.GetAsync(sc.Context);
-                    state.Token = providerTokenResponse.TokenResponse.Token;
+                    return await sc.NextAsync(providerTokenResponse);
                 }
-
-                return await sc.NextAsync();
+                else
+                {
+                    return await sc.NextAsync();
+                }
             }
             catch (SkillException ex)
             {
@@ -152,15 +153,7 @@ namespace HospitalitySkill.Dialogs
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
                 var state = await StateAccessor.GetAsync(dc.Context, () => new HospitalitySkillState());
-
-                // Get luis service for current locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
-                var luisService = localeConfig.LuisServices["Hospitality"];
-
-                // Get intent and entities for activity
-                var result = await luisService.RecognizeAsync<HospitalityLuis>(dc.Context, CancellationToken.None);
-                state.LuisResult = result;
+                state.LuisResult = dc.Context.TurnState.Get<HospitalityLuis>(StateProperties.SkillLuisResult);
             }
         }
 

--- a/skills/csharp/experimental/hospitalityskill/Models/HospitalitySkillState.cs
+++ b/skills/csharp/experimental/hospitalityskill/Models/HospitalitySkillState.cs
@@ -9,8 +9,6 @@ namespace HospitalitySkill.Models
 {
     public class HospitalitySkillState
     {
-        public string Token { get; set; }
-
         public HospitalityLuis LuisResult { get; set; }
 
         public ReservationData UpdatedReservation { get; set; }

--- a/skills/csharp/experimental/hospitalityskill/Models/HospitalityUserSkillState.cs
+++ b/skills/csharp/experimental/hospitalityskill/Models/HospitalityUserSkillState.cs
@@ -15,7 +15,7 @@ namespace HospitalitySkill.Models
             {
                 CheckInDate = DateTime.Now.ToString("MMMM d, yyyy"),
                 CheckOutDate = DateTime.Now.AddDays(4).ToString("MMMM d, yyyy"),
-                CheckOutTime = "12:00 pm"
+                CheckOutTimeData = new TimeSpan(12, 0, 0)
             };
         }
 

--- a/skills/csharp/experimental/hospitalityskill/Models/ReservationData.cs
+++ b/skills/csharp/experimental/hospitalityskill/Models/ReservationData.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Builder.Solutions.Responses;
 
 namespace HospitalitySkill.Models
@@ -13,7 +14,9 @@ namespace HospitalitySkill.Models
 
         public string CheckOutDate { get; set; }
 
-        public string CheckOutTime { get; set; }
+        public string CheckOutTime { get { return CheckOutTimeData.ToString(@"hh\:mm"); } }
+
+        public TimeSpan CheckOutTimeData { get; set; }
 
         public ReservationData Copy()
         {

--- a/skills/csharp/experimental/hospitalityskill/Models/StateProperties.cs
+++ b/skills/csharp/experimental/hospitalityskill/Models/StateProperties.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HospitalitySkill.Models
+{
+    public class StateProperties
+    {
+        public const string GeneralLuisResult = "generalLuisResult";
+        public const string SkillLuisResult = "skillLuisResult";
+    }
+}

--- a/skills/csharp/experimental/hospitalityskill/Services/HotelService.cs
+++ b/skills/csharp/experimental/hospitalityskill/Services/HotelService.cs
@@ -35,10 +35,10 @@ namespace HospitalitySkill.Services
                 .First();
         }
 
-        public async Task<string> GetLateCheckOutAsync()
+        public async Task<TimeSpan> GetLateCheckOutAsync()
         {
             // make request for the late check out time
-            var lateTime = "4:00 pm";
+            var lateTime = new TimeSpan(16, 0, 0);
 
             return await Task.FromResult(lateTime);
         }

--- a/skills/csharp/experimental/hospitalityskill/Services/IHotelService.cs
+++ b/skills/csharp/experimental/hospitalityskill/Services/IHotelService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using HospitalitySkill.Models;
@@ -18,7 +19,7 @@ namespace HospitalitySkill.Services
         void UpdateReservationDetails(ReservationData reservation);
 
         // check late check out availability
-        Task<string> GetLateCheckOutAsync();
+        Task<TimeSpan> GetLateCheckOutAsync();
 
         // request items to be brought
         Task<bool> RequestItems(List<ItemRequestClass> items);


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2314

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* Use TimeSpan CheckOutTimeData 
* Use TimexParsing.ParseString (however it has bugs)
* Remove redundant luis calls

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

After https://github.com/microsoft/botframework-solutions/pull/2647

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
