### PR TITLE
[News] support location event

### DIFF
--- a/skills/csharp/experimental/newsskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/MainDialog.cs
@@ -167,6 +167,42 @@ namespace NewsSkill.Dialogs
             return result;
         }
 
+        protected override async Task OnEventActivityAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var ev = dc.Context.Activity.AsEventActivity();
+            var value = ev.Value?.ToString();
+
+            var state = await _stateAccessor.GetAsync(dc.Context, () => new NewsSkillState());
+
+            switch (ev.Name)
+            {
+                case Events.Location:
+                    {
+                        // Test trigger with
+                        // /event:{ "Name": "Location", "Value": "34.05222222222222,-118.2427777777777" }
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            var coords = value.Split(',');
+                            if (coords.Length == 2)
+                            {
+                                if (double.TryParse(coords[0], out var lat) && double.TryParse(coords[1], out var lng))
+                                {
+                                    state.CurrentCoordinates = value;
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+
+                default:
+                    {
+                        await dc.Context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Unknown Event '{ev.Name ?? "undefined"}' was received but not processed."));
+                        break;
+                    }
+            }
+        }
+
         private async Task<InterruptionAction> OnCancel(DialogContext dc)
         {
             await _responder.ReplyWith(dc.Context, MainResponses.Cancelled);
@@ -192,6 +228,11 @@ namespace NewsSkill.Dialogs
                 var state = await _stateAccessor.GetAsync(context, () => new NewsSkillState());
                 state.CurrentCoordinates = locationObj;
             }
+        }
+
+        public class Events
+        {
+            public const string Location = "Location";
         }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close https://github.com/microsoft/botframework-solutions/issues/2625

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
handle location event in news skill

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
