### PR TITLE
[TypeScript][Skill Sample/Template] Update populateStateFromSemanticAction method in Skill

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/dialogs/_mainDialog.ts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/dialogs/_mainDialog.ts
@@ -249,15 +249,16 @@ export class MainDialog extends RouterDialog {
     protected async populateStateFromSemanticAction(context: TurnContext): Promise<void> {
         // Example of populating local state with data passed through semanticAction out of Activity
         // const activity: Activity = context.activity;
-        // const semanticAction: SemanticAction | undefined  = activity.semanticAction;
+        // const semanticAction: SemanticAction | undefined = activity.semanticAction;
 
-        // if (semanticAction != null && semanticAction.Entities.ContainsKey("location"))
-        // {
-        //    var location = semanticAction.Entities["location"];
-        //    var locationObj = location.Properties["location"].ToString();
-        //    // Add to your local state
-        //    var state = await _stateAccessor.GetAsync(context, () => new SkillState());
-        //    state.CurrentCoordinates = locationObj;
+        // if (semanticAction !== undefined && Object.keys(semanticAction.entities)
+        //     .find((key: string) => key === "location")) {
+        //     // tslint:disable-next-line: no-explicit-any
+        //     const location: any = semanticAction.entities["location"];
+        //     const locationObj = location.properties["location"];
+        //     const state: SkillState = await this.stateAccessor.get(context, new SkillState());
+        //     state.location = locationObj !== undefined ? locationObj : location;
+        //     await this.stateAccessor.set(context, state);
         // }
     }
 }

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/dialogs/mainDialog.ts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/dialogs/mainDialog.ts
@@ -11,7 +11,7 @@ import {
     RecognizerResult,
     // SemanticAction,
     StatePropertyAccessor,
-    TurnContext} from 'botbuilder';
+    TurnContext } from 'botbuilder';
 import { LuisRecognizer, LuisRecognizerTelemetryClient } from 'botbuilder-ai';
 import {
     Dialog,
@@ -251,12 +251,14 @@ export class MainDialog extends RouterDialog {
         // const activity: Activity = context.activity;
         // const semanticAction: SemanticAction | undefined = activity.semanticAction;
 
-        // if (semanticAction != null && semanticAction.Entities.ContainsKey("location"))
-        // {
-        //    var location = semanticAction.Entities["location"];
-        //    var locationObj = location.Properties["location"].ToString();
-        //    var state = await _stateAccessor.GetAsync(context, () => new SkillState());
-        //    state.CurrentCoordinates = locationObj;
+        // if (semanticAction !== undefined && Object.keys(semanticAction.entities)
+        //     .find((key: string) => key === "location")) {
+        //     // tslint:disable-next-line: no-explicit-any
+        //     const location: any = semanticAction.entities["location"];
+        //     const locationObj = location.properties["location"];
+        //     const state: SkillState = await this.stateAccessor.get(context, new SkillState());
+        //     state.location = locationObj !== undefined ? locationObj : location;
+        //     await this.stateAccessor.set(context, state);
         // }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
After reviewing issue #2547, we realized the `populateStateFromSemanticAction` method in the Skill's `mainDialog` wasn't properly developed.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We updated the `populateStateFromSemanticAction` method in the Skill's `mainDialog` in order to have it ready out of the box to be used in any scenario where information is sent from the Virtual Assistant through the Activity's  `SemanticAction` property.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [x] I have replicated my changes in the **Skill Template** and **Sample** projects
