### PR TITLE
[Calendar] add bing spell check

### DIFF
--- a/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -886,12 +886,14 @@ namespace CalendarSkill.Dialogs
                     }
                 }
 
+                string luisResultText = string.IsNullOrEmpty(luisResult.AlteredText) ? luisResult.Text : luisResult.AlteredText;
+
                 if (!isBeginDialog)
                 {
                     if (entity.RelationshipName != null)
                     {
                         state.MeetingInfor.CreateHasDetail = true;
-                        state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResult.Text);
+                        state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResultText);
                         if (state.MeetingInfor.ContactInfor.ContactsNameList == null)
                         {
                             state.MeetingInfor.ContactInfor.ContactsNameList = new List<string>();
@@ -918,13 +920,13 @@ namespace CalendarSkill.Dialogs
                             if (entity.personName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResult.Text, state.MeetingInfor.ContactInfor.ContactsNameList);
+                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResultText, state.MeetingInfor.ContactInfor.ContactsNameList);
                             }
 
                             if (entity.RelationshipName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResult.Text);
+                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResultText);
                                 if (state.MeetingInfor.ContactInfor.ContactsNameList == null)
                                 {
                                     state.MeetingInfor.ContactInfor.ContactsNameList = new List<string>();
@@ -935,7 +937,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
@@ -954,7 +956,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (date != null)
                                 {
@@ -965,7 +967,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
@@ -983,7 +985,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (time != null)
                                 {
@@ -1030,7 +1032,7 @@ namespace CalendarSkill.Dialogs
                             if (entity.personName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResult.Text, state.MeetingInfor.ContactInfor.ContactsNameList);
+                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResultText, state.MeetingInfor.ContactInfor.ContactsNameList);
                             }
 
                             if (entity.Subject != null)
@@ -1040,7 +1042,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
@@ -1056,7 +1058,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
@@ -1073,7 +1075,7 @@ namespace CalendarSkill.Dialogs
                             if (entity.RelationshipName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResult.Text);
+                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResultText);
                                 if (state.MeetingInfor.ContactInfor.ContactsNameList == null)
                                 {
                                     state.MeetingInfor.ContactInfor.ContactsNameList = new List<string>();
@@ -1095,12 +1097,12 @@ namespace CalendarSkill.Dialogs
                             if (entity.personName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResult.Text, state.MeetingInfor.ContactInfor.ContactsNameList);
+                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResultText, state.MeetingInfor.ContactInfor.ContactsNameList);
                             }
 
                             if (entity.FromDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
@@ -1116,7 +1118,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
@@ -1132,7 +1134,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
@@ -1148,7 +1150,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
@@ -1186,7 +1188,7 @@ namespace CalendarSkill.Dialogs
                             if (entity.RelationshipName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResult.Text);
+                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResultText);
                                 if (state.MeetingInfor.ContactInfor.ContactsNameList == null)
                                 {
                                     state.MeetingInfor.ContactInfor.ContactsNameList = new List<string>();
@@ -1217,7 +1219,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.personName != null)
                             {
-                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResult.Text, state.MeetingInfor.ContactInfor.ContactsNameList);
+                                state.MeetingInfor.ContactInfor.ContactsNameList = GetAttendeesFromEntity(entity, luisResultText, state.MeetingInfor.ContactInfor.ContactsNameList);
                             }
 
                             if (entity.Location != null)
@@ -1227,7 +1229,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (date != null)
                                 {
@@ -1244,7 +1246,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToDate != null)
                             {
-                                var dateString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToDate[0]);
+                                var dateString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToDate[0]);
                                 var date = GetDateFromDateTimeString(dateString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (date != null)
                                 {
@@ -1254,7 +1256,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.FromTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.FromTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.FromTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), true, false);
                                 if (time != null)
                                 {
@@ -1270,7 +1272,7 @@ namespace CalendarSkill.Dialogs
 
                             if (entity.ToTime != null)
                             {
-                                var timeString = GetDateTimeStringFromInstanceData(luisResult.Text, entity._instance.ToTime[0]);
+                                var timeString = GetDateTimeStringFromInstanceData(luisResultText, entity._instance.ToTime[0]);
                                 var time = GetTimeFromDateTimeString(timeString, dc.Context.Activity.Locale, state.GetUserTimeZone(), false, false);
                                 if (time != null)
                                 {
@@ -1281,7 +1283,7 @@ namespace CalendarSkill.Dialogs
                             if (entity.RelationshipName != null)
                             {
                                 state.MeetingInfor.CreateHasDetail = true;
-                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResult.Text);
+                                state.MeetingInfor.ContactInfor.RelatedEntityInfoDict = GetRelatedEntityFromRelationship(entity, luisResultText);
                                 if (state.MeetingInfor.ContactInfor.ContactsNameList == null)
                                 {
                                     state.MeetingInfor.ContactInfor.ContactsNameList = new List<string>();
@@ -1290,7 +1292,7 @@ namespace CalendarSkill.Dialogs
                                 state.MeetingInfor.ContactInfor.ContactsNameList.AddRange(state.MeetingInfor.ContactInfor.RelatedEntityInfoDict.Keys);
                             }
 
-                            state.ShowMeetingInfor.AskParameterContent = luisResult.Text;
+                            state.ShowMeetingInfor.AskParameterContent = luisResultText;
 
                             break;
                         }

--- a/skills/csharp/calendarskill/Services/BotServices.cs
+++ b/skills/csharp/calendarskill/Services/BotServices.cs
@@ -28,6 +28,8 @@ namespace CalendarSkill.Services
                 {
                     TelemetryClient = telemetryClient,
                     LogPersonalInformation = true,
+                    SpellCheck = string.IsNullOrEmpty(settings.BingSpellCheckSubscriptionKey) ? false : true,
+                    BingSpellCheckSubscriptionKey = settings.BingSpellCheckSubscriptionKey
                 };
 
                 if (config.DispatchModel != null)

--- a/skills/csharp/calendarskill/Services/BotSettings.cs
+++ b/skills/csharp/calendarskill/Services/BotSettings.cs
@@ -35,5 +35,7 @@ namespace CalendarSkill.Services
         }
 
         public string AzureMapsKey { get; set; }
+
+        public string BingSpellCheckSubscriptionKey { get; set; }
     }
 }

--- a/skills/csharp/calendarskill/appsettings.json
+++ b/skills/csharp/calendarskill/appsettings.json
@@ -56,5 +56,6 @@
       }
     ]
   },
-  "azureMapsKey": ""
+  "azureMapsKey": "",
+  "bingSpellCheckSubscriptionKey": ""
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Related #2432 
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Add a bing spell check subscription key in the settings. 
If user enable the "BingSpellCheck" feature in the LUIS model, and give a BingSpellCheck subscription, bot can directly correct the spelling mistake.

**Without the spell check, if we input an utterance like "show metings tomorow", the result will be:**

![image](https://user-images.githubusercontent.com/44257569/68584232-f9862380-04b9-11ea-9ba6-51e8cc3aba52.png)

**With the spell check, the result will be:**

![image](https://user-images.githubusercontent.com/44257569/68583671-be372500-04b8-11ea-93df-c9ded2a23909.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

The LUIS CLI can not support opening the spell check feature directly, will update the script to automatically open the spell check feature when the CLI support.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
