### PR TITLE
Update onboarding event check to fix null referemce exception

### DIFF
--- a/samples/assistants/EnterpriseNotification/VirtualAssistant/Dialogs/MainDialog.cs
+++ b/samples/assistants/EnterpriseNotification/VirtualAssistant/Dialogs/MainDialog.cs
@@ -227,10 +227,10 @@ namespace VirtualAssistant.Dialogs
             // Check if there was an action submitted from intro card
             var value = dc.Context.Activity.Value;
 
-            if (value.GetType() == typeof(JObject))
+            if (value != null && value.GetType() == typeof(JObject))
             {
                 var submit = JObject.Parse(value.ToString());
-                if (value != null && (string)submit["action"] == "startOnboarding")
+                if (submit.ContainsKey("action") && (string)submit["action"] == "startOnboarding")
                 {
                     await dc.BeginDialogAsync(nameof(OnboardingDialog));
                     return;

--- a/samples/assistants/HospitalitySample/Dialogs/MainDialog.cs
+++ b/samples/assistants/HospitalitySample/Dialogs/MainDialog.cs
@@ -211,10 +211,10 @@ namespace HospitalitySample.Dialogs
             // Check if there was an action submitted from intro card
             var value = dc.Context.Activity.Value;
 
-            if (value.GetType() == typeof(JObject))
+            if (value != null && value.GetType() == typeof(JObject))
             {
                 var submit = JObject.Parse(value.ToString());
-                if (value != null && (string)submit["action"] == "startOnboarding")
+                if (submit.ContainsKey("action") && (string)submit["action"] == "startOnboarding")
                 {
                     await dc.BeginDialogAsync(nameof(OnboardingDialog));
                     return;

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -189,10 +189,10 @@ namespace VirtualAssistantSample.Dialogs
             // Check if there was an action submitted from intro card
             var value = dc.Context.Activity.Value;
 
-            if (value.GetType() == typeof(JObject))
+            if (value != null && value.GetType() == typeof(JObject))
             {
                 var submit = JObject.Parse(value.ToString());
-                if (value != null && (string)submit["action"] == "startOnboarding")
+                if (submit.ContainsKey("action") && (string)submit["action"] == "startOnboarding")
                 {
                     await dc.BeginDialogAsync(nameof(OnboardingDialog));
                     return;

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Dialogs/MainDialog.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Dialogs/MainDialog.cs
@@ -189,10 +189,10 @@ namespace $safeprojectname$.Dialogs
             // Check if there was an action submitted from intro card
             var value = dc.Context.Activity.Value;
 
-            if (value.GetType() == typeof(JObject))
+            if (value != null && value.GetType() == typeof(JObject))
             {
                 var submit = JObject.Parse(value.ToString());
-                if (value != null && (string)submit["action"] == "startOnboarding")
+                if (submit.ContainsKey("action") && (string)submit["action"] == "startOnboarding")
                 {
                     await dc.BeginDialogAsync(nameof(OnboardingDialog));
                     return;


### PR DESCRIPTION
Found I was getting a null reference exception when using some of the new adapters, which was due to an event activity being sent but with a null value. 