### PR TITLE
[Skills] Enable anonymous skill

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Auth/Authenticator.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Auth/Authenticator.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Solutions.Skills.Auth
                 return null;
             }
 
-            var claimsIdentity = _authenticationProvider.Authenticate(authorizationHeader);
+            var claimsIdentity = await _authenticationProvider.AuthenticateAsync(authorizationHeader).ConfigureAwait(false);
             if (claimsIdentity == null)
             {
                 httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Auth/IAuthenticationProvider.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Auth/IAuthenticationProvider.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Solutions.Skills.Auth
 {
     public interface IAuthenticationProvider
     {
-        ClaimsIdentity Authenticate(string authHeader);
+        Task<ClaimsIdentity> AuthenticateAsync(string authHeader);
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillController.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillController.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
             _whitelistAuthenticationProvider = whitelistAuthenticationProvider ?? throw new ArgumentNullException(nameof(whitelistAuthenticationProvider));
             _skillWebSocketAdapter = skillWebSocketAdapter;
 
-            if (credentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false).GetAwaiter().GetResult())
+            if (credentialProvider == null ||
+                !credentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false).GetAwaiter().GetResult())
             {
                 _authenticationProvider = new MsJWTAuthenticationProvider(_botSettings.MicrosoftAppId);
                 _authenticator = new Authenticator(_authenticationProvider, _whitelistAuthenticationProvider);
@@ -142,6 +143,10 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
             if (_authenticator != null)
             {
                 await _authenticator.AuthenticateAsync(Request, Response).ConfigureAwait(false);
+            }
+            else
+            {
+                Response.StatusCode = (int)HttpStatusCode.OK;
             }
         }
     }

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketAdapter.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketAdapter.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Solutions;
 using Microsoft.Bot.Builder.Solutions.Skills.Auth;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Streaming.Transport;
@@ -33,7 +32,6 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
         private readonly IAuthenticationProvider _authenticationProvider;
         private readonly IWhitelistAuthenticationProvider _whitelistAuthenticationProvider;
         private readonly IAuthenticator _authenticator;
-        private readonly ICredentialProvider _credentialProvider;
         private readonly Stopwatch _stopWatch;
 
         public SkillWebSocketAdapter(
@@ -46,10 +44,10 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
             _skillWebSocketBotAdapter = skillWebSocketBotAdapter ?? throw new ArgumentNullException(nameof(skillWebSocketBotAdapter));
             _botSettingsBase = botSettingsBase ?? throw new ArgumentNullException(nameof(botSettingsBase));
             _whitelistAuthenticationProvider = whitelistAuthenticationProvider ?? throw new ArgumentNullException(nameof(whitelistAuthenticationProvider));
-            _credentialProvider = credentialProvider;
 
             // only initialize auth components when auth is enabled
-            if (!_credentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false).GetAwaiter().GetResult())
+            if (credentialProvider == null ||
+                !credentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false).GetAwaiter().GetResult())
             {
                 _authenticationProvider = new MsJWTAuthenticationProvider(_botSettingsBase.MicrosoftAppId);
                 _authenticator = new Authenticator(_authenticationProvider, _whitelistAuthenticationProvider);

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketRequestHandler.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketRequestHandler.cs
@@ -79,10 +79,13 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
                 return response;
             }
 
-            var appIdClaimName = AuthHelpers.GetAppIdClaimName(_claimsIdentity);
+            if (_claimsIdentity.AuthenticationType != "anonymous")
+            {
+                var appIdClaimName = AuthHelpers.GetAppIdClaimName(_claimsIdentity);
 
-            // retrieve the appid and use it to populate callerId on the activity
-            activity.CallerId = _claimsIdentity.Claims.FirstOrDefault(c => c.Type == appIdClaimName)?.Value;
+                // retrieve the appid and use it to populate callerId on the activity
+                activity.CallerId = _claimsIdentity.Claims.FirstOrDefault(c => c.Type == appIdClaimName)?.Value;
+            }
 
             try
             {

--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketRequestHandler.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillWebSocketRequestHandler.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Solutions;
 using Microsoft.Bot.Builder.Solutions.Skills.Auth;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Streaming;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

This fixes #2639 

This change enables anonymous access to skill to enable local debugging. In your skill just make sure to pass in the additional parameter ICredentialProvider in your implementation of SkillWebSocketBotAdapter, as well as the SkillController. Since the app id is empty, then the IsAuthenticationDisabledAsync() function will return true which will skip auth on the skill side. This approach aligns with the SDK's pattern to allow anonymous access

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
