### PR TITLE
[Sdk] restore ManifestTemplateFilename

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillController.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/SkillController.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
         // There are protected to enable unit tests to mock.
         protected HttpClient HttpClient { get; set; } = new HttpClient();
 
-        protected string ManifestTemplateFilename { get; set; } = @".\Skills\manifestTemplate.json";
+        protected string ManifestTemplateFilename { get; set; } = "manifestTemplate.json";
 
         /// <summary>
         /// This API is the endpoint for when a bot receives a message from a channel or a parent bot.

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/ManifestTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/ManifestTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests.Skills
             _mockHttp.When("https://westus.api.cognitive.microsoft.com*")
                     .Respond("application/json", luisResponse);
 
-            var controller = CreateMockSkillController();
+            var controller = CreateMockSkillController(@".\Skills\manifestTemplate.json");
 
             // Replace the NullStream with a MemoryStream
             var ms = new MemoryStream();

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/ManifestTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/ManifestTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Solutions.Tests.Skills
         [TestMethod]
         public async Task SkillControllerManifestRequest()
         {
-            var controller = CreateMockSkillController();
+            var controller = CreateMockSkillController(@".\Skills\manifestTemplate.json");
 
             // Replace the NullStream with a MemoryStream
             var ms = new MemoryStream();


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Fix a change from moving files.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
