### PR TITLE
[Lib] Added support for custom text and title in multi provider auth card

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder.Solutions.Authentication
         private bool localAuthConfigured = false;
         private MicrosoftAppCredentials _appCredentials;
 
-        public MultiProviderAuthDialog(List<OAuthConnection> authenticationConnections, MicrosoftAppCredentials appCredentials = null)
+        public MultiProviderAuthDialog(List<OAuthConnection> authenticationConnections, MicrosoftAppCredentials appCredentials = null, OAuthPromptSettings promptSettings = null)
             : base(nameof(MultiProviderAuthDialog))
         {
             _authenticationConnections = authenticationConnections ?? throw new ArgumentNullException(nameof(authenticationConnections));
@@ -72,14 +72,16 @@ namespace Microsoft.Bot.Builder.Solutions.Authentication
                     // We ignore placeholder connections in config that don't have a Name
                     if (!string.IsNullOrEmpty(connection.Name))
                     {
+                        var settings = promptSettings ?? new OAuthPromptSettings
+                        {
+                            ConnectionName = connection.Name,
+                            Title = "Login",
+                            Text = string.Format("Login with {0}", connection.Name),
+                        };
+
                         AddDialog(new OAuthPrompt(
                             connection.Name,
-                            new OAuthPromptSettings
-                            {
-                                ConnectionName = connection.Name,
-                                Title = "Login",
-                                Text = string.Format("Login with {0}", connection.Name),
-                            },
+                            settings,
                             AuthPromptValidatorAsync));
 
                         authDialogAdded = true;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
close #1990 

### Purpose
*What is the context of this pull request? Why is it being done?*
Change allows user to provider their own OAuthPromptSettings when setting up the multi-provider auth dialog. 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
