### PR TITLE
[Skills] use more GetCognitiveModels

### DIFF
--- a/skills/csharp/experimental/automotiveskill/Dialogs/VehicleSettingsDialog.cs
+++ b/skills/csharp/experimental/automotiveskill/Dialogs/VehicleSettingsDialog.cs
@@ -62,12 +62,12 @@ namespace AutomotiveSkill.Dialogs
             TelemetryClient = telemetryClient;
 
             // Initialise supporting LUIS models for followup questions
-            vehicleSettingNameSelectionLuisRecognizer = services.CognitiveModelSets["en"].LuisServices["SettingsName"];
-            vehicleSettingValueSelectionLuisRecognizer = services.CognitiveModelSets["en"].LuisServices["SettingsValue"];
+            vehicleSettingNameSelectionLuisRecognizer = services.GetCognitiveModels().LuisServices["SettingsName"];
+            vehicleSettingValueSelectionLuisRecognizer = services.GetCognitiveModels().LuisServices["SettingsValue"];
 
             // Initialise supporting LUIS models for followup questions
-            vehicleSettingNameSelectionLuisRecognizer = services.CognitiveModelSets["en"].LuisServices["SettingsName"];
-            vehicleSettingValueSelectionLuisRecognizer = services.CognitiveModelSets["en"].LuisServices["SettingsValue"];
+            vehicleSettingNameSelectionLuisRecognizer = services.GetCognitiveModels().LuisServices["SettingsName"];
+            vehicleSettingValueSelectionLuisRecognizer = services.GetCognitiveModels().LuisServices["SettingsValue"];
 
             // Supporting setting files are stored as embedded resources
             var resourceAssembly = typeof(VehicleSettingsDialog).Assembly;

--- a/skills/csharp/experimental/bingsearchskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/bingsearchskill/Dialogs/SkillDialogBase.cs
@@ -148,8 +148,7 @@ namespace BingSearchSkill.Dialogs
                 var state = await StateAccessor.GetAsync(dc.Context, () => new SkillState());
 
                 // Get luis service for current locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 var luisService = localeConfig.LuisServices["BingSearchSkill"];
 
                 // Get intent and entities for activity

--- a/skills/csharp/experimental/eventskill/Dialogs/EventDialogBase.cs
+++ b/skills/csharp/experimental/eventskill/Dialogs/EventDialogBase.cs
@@ -150,8 +150,7 @@ namespace EventSkill.Dialogs
                 var state = await StateAccessor.GetAsync(dc.Context, () => new EventSkillState());
 
                 // Get luis service for current locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 var luisService = localeConfig.LuisServices["Event"];
 
                 // Get intent and entities for activity

--- a/skills/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
@@ -91,8 +91,7 @@ namespace HospitalitySkill.Dialogs
             var state = await _stateAccessor.GetAsync(dc.Context, () => new HospitalitySkillState());
 
             // get current activity locale
-            var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            var localeConfig = _services.CognitiveModelSets[locale];
+            var localeConfig = _services.GetCognitiveModels();
 
             // Populate state from SemanticAction as required
             await PopulateStateFromSemanticAction(dc.Context);

--- a/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
@@ -310,8 +310,7 @@ namespace ITSMSkill.Dialogs
             }
             else
             {
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 localeConfig.LuisServices.TryGetValue("ITSM", out var service);
                 var result = await service.RecognizeAsync<ITSMLuis>(promptContext.Context, CancellationToken.None);
                 var topIntent = result.TopIntent();

--- a/skills/csharp/experimental/musicskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/musicskill/Dialogs/SkillDialogBase.cs
@@ -145,8 +145,7 @@ namespace MusicSkill.Dialogs
                 var state = await StateAccessor.GetAsync(dc.Context, () => new SkillState());
 
                 // Get luis service for current locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 var luisService = localeConfig.LuisServices["MusicSkill"];
 
                 // Get intent and entities for activity

--- a/skills/csharp/experimental/newsskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/MainDialog.cs
@@ -142,7 +142,7 @@ namespace NewsSkill.Dialogs
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
                 // check luis intent
-                _services.CognitiveModelSets["en"].LuisServices.TryGetValue("General", out var luisService);
+                _services.GetCognitiveModels().LuisServices.TryGetValue("General", out var luisService);
 
                 if (luisService == null)
                 {

--- a/skills/csharp/experimental/phoneskill/Dialogs/PhoneSkillDialogBase.cs
+++ b/skills/csharp/experimental/phoneskill/Dialogs/PhoneSkillDialogBase.cs
@@ -163,8 +163,7 @@ namespace PhoneSkill.Dialogs
             where T : IRecognizerConvert, new()
         {
             // Get luis service for current locale
-            var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            var localeConfig = Services.CognitiveModelSets[locale];
+            var localeConfig = Services.GetCognitiveModels();
             var luisService = localeConfig.LuisServices[luisServiceName];
 
             // Get intent and entities for activity

--- a/skills/csharp/experimental/restaurantbookingskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Dialogs/SkillDialogBase.cs
@@ -76,8 +76,7 @@ namespace RestaurantBookingSkill.Dialogs
                     var state = await ConversationStateAccessor.GetAsync(dc.Context);
 
                     // Get luis service for current locale
-                    var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                    var localeConfig = Services.CognitiveModelSets[locale];
+                    var localeConfig = Services.GetCognitiveModels();
                     var luisService = localeConfig.LuisServices["Restaurant"];
 
                     // Get intent and entities for activity

--- a/skills/csharp/experimental/weatherskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/weatherskill/Dialogs/SkillDialogBase.cs
@@ -148,8 +148,7 @@ namespace WeatherSkill.Dialogs
                 var state = await StateAccessor.GetAsync(dc.Context, () => new SkillState());
 
                 // Get luis service for current locale
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 var luisService = localeConfig.LuisServices["WeatherSkill"];
 
                 // Get intent and entities for activity

--- a/skills/csharp/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/pointofinterestskill/Dialogs/MainDialog.cs
@@ -76,8 +76,7 @@ namespace PointOfInterestSkill.Dialogs
         protected override async Task OnMessageActivityAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             // get current activity locale
-            var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            var localeConfig = _services.CognitiveModelSets[locale];
+            var localeConfig = _services.GetCognitiveModels();
 
             await PopulateStateFromSemanticAction(dc.Context);
 

--- a/skills/csharp/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
+++ b/skills/csharp/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
@@ -928,8 +928,7 @@ namespace PointOfInterestSkill.Dialogs
             }
             else
             {
-                var locale = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-                var localeConfig = Services.CognitiveModelSets[locale];
+                var localeConfig = Services.GetCognitiveModels();
                 localeConfig.LuisServices.TryGetValue("PointOfInterest", out var poiService);
                 var poiResult = await poiService.RecognizeAsync<PointOfInterestLuis>(promptContext.Context, CancellationToken.None);
                 var topIntent = poiResult.TopIntent();


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Fix as cognitivemodels.json uses en-us instead of en now.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
