### PR TITLE
[TypeScript][BotBuilder-Solutions] Add a first element in createBaseElement method

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/src/middleware/setSpeakMiddleware.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/middleware/setSpeakMiddleware.ts
@@ -104,28 +104,22 @@ export class SetSpeakMiddleware implements Middleware {
 
     private createBaseElement(value: string): Element {
         // creating simple element
-        const result: Element = {
+        return {
             elements: [
                 {
                     type: 'element',
-                    name: 'speak'
+                    name: 'speak',
+                    elements: [
+                      {
+                          type: 'text',
+                          text: value
+                      }
+                    ],
+                    attributes: {
+                      xmlns: this.namespaceURI
+                    }
                 }
-            ]
-        };
-        // adding attributes
-        result.attributes = {
-            xmlns: this.namespaceURI
-        };
-
-        // adding sub-node
-        result.elements = [
-            {
-                type: 'text',
-                text: value
-            }
-        ];
-
-        return result;
+            ]};
     }
 
     private addAttributeIfMissing(element: Element, attName: string, attValue: string): void {


### PR DESCRIPTION
Close #2704

### Purpose
*What is the context of this pull request? Why is it being done?*
The `createBaseElement` was updating the first element of `result` array overwriting the `speak` element with the `text` element.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update the assignment of the **base element** for the `result` array adding a first element instead of overwriting in `setSpeakMiddleware`

![image](https://user-images.githubusercontent.com/11904023/69570602-e3d72a80-0f9e-11ea-994b-57f4a93f4746.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
