### PR TITLE
[VA]remove personName for some languages and fix format

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/de-de/General.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/de-de/General.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- rufen Sie mich steve !
-- ich bin anna
-- ich bin john jackson.
-- ich bin Lily
-- es ist jackson .
-- es ist alice anderson!
-- mein Name ist bill jones
-- dies ist john w.smith .
-- ([Sie können]| [bitte]) Ruf mich an  {PersonName.Any} [.]
-- mein Name ist  {PersonName.Any} [.]
-- (i'm|i am)  {PersonName.Any} [.]
-- (es ist|es ist|dies ist)  {PersonName.Any} [.]
+- ([Sie können]|[bitte]) Ruf mich an {PersonName.Any} [.]
+- mein Name ist {PersonName.Any} [.]
+- (i'm|i am) {PersonName.Any} [.]
+- (es ist|es ist|dies ist) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -529,7 +521,6 @@ $PREBUILT:number
 
 $PREBUILT:ordinal
 
-$PREBUILT:personName
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/es-es/General.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/es-es/General.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- llámame steve !
-- Soy anna
-- Soy John Jackson.
-- Soy lirio
-- es Jackson .
-- es Alice Anderson!
-- mi nombre es Bill Jones
-- este es John w.smith .
-- ([se puede] [por favor]) Llámame  {PersonName.Any} [.]
-- Mi nombre es  {PersonName.Any} [.]
-- (Soy yo)  {PersonName.Any} [.]
-- (es esto)  {PersonName.Any} [.]
+- ([se puede]|[por favor]) Llámame {PersonName.Any} [.]
+- Mi nombre es {PersonName.Any} [.]
+- (Soy|yo) {PersonName.Any} [.]
+- (es|esto) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,9 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
-
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/fr-fr/General.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/fr-fr/General.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- appelez-moi steve !
-- je suis anna
-- Je suis John Jackson.
-- Je suis lys
-- c'est jackson .
-- c'est Alice anderson!
-- mon nom est bill jones
-- c'est john w.smith .
-- ([vous pouvez] [s'il vous plaît]) Appelle-moi  {PersonName.Any} [.]
-- mon nom est  {PersonName.Any} [.]
-- (je suis)  {PersonName.Any} [.]
-- (c'est c'est ça)  {PersonName.Any} [.]
+- ([vous pouvez]|[s'il vous plaît]) Appelle-moi {PersonName.Any} [.]
+- mon nom est {PersonName.Any} [.]
+- (je|suis) {PersonName.Any} [.]
+- (c'est|ça) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,8 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/it-it/General.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU/it-it/General.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- chiamami steve !
-- Io sono anna
-- Sono John Jackson.
-- Sono giglio
-- è jackson .
-- è Alice Anderson!
-- il mio nome è Bill Jones
-- questo è john w.smith .
-- ([si può] [per favore]) Chiamami  {PersonName.Any} [.]
-- mi chiamo  {PersonName.Any} [.]
-- (Io sono)  {PersonName.Any} [.]
-- (è, è, questo è)  {PersonName.Any} [.]
+- ([si può]|[per favore]) Chiamami {PersonName.Any} [.]
+- mi chiamo {PersonName.Any} [.]
+- (Io|sono) {PersonName.Any} [.]
+- (è|questo è) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,8 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/de-de/general.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/de-de/general.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- rufen Sie mich steve !
-- ich bin anna
-- ich bin john jackson.
-- ich bin Lily
-- es ist jackson .
-- es ist alice anderson!
-- mein Name ist bill jones
-- dies ist john w.smith .
-- ([Sie können]| [bitte]) Ruf mich an  {PersonName.Any} [.]
-- mein Name ist  {PersonName.Any} [.]
-- (i'm|i am)  {PersonName.Any} [.]
-- (es ist|es ist|dies ist)  {PersonName.Any} [.]
+- ([Sie können]|[bitte]) Ruf mich an {PersonName.Any} [.]
+- mein Name ist {PersonName.Any} [.]
+- (i'm|i am) {PersonName.Any} [.]
+- (es ist|es ist|dies ist) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -529,7 +521,6 @@ $PREBUILT:number
 
 $PREBUILT:ordinal
 
-$PREBUILT:personName
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/es-es/general.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/es-es/general.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- llámame steve !
-- Soy anna
-- Soy John Jackson.
-- Soy lirio
-- es Jackson .
-- es Alice Anderson!
-- mi nombre es Bill Jones
-- este es John w.smith .
-- ([se puede] [por favor]) Llámame  {PersonName.Any} [.]
-- Mi nombre es  {PersonName.Any} [.]
-- (Soy yo)  {PersonName.Any} [.]
-- (es esto)  {PersonName.Any} [.]
+- ([se puede]|[por favor]) Llámame {PersonName.Any} [.]
+- Mi nombre es {PersonName.Any} [.]
+- (Soy|yo) {PersonName.Any} [.]
+- (es|esto) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,9 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
-
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/fr-fr/general.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/fr-fr/general.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- appelez-moi steve !
-- je suis anna
-- Je suis John Jackson.
-- Je suis lys
-- c'est jackson .
-- c'est Alice anderson!
-- mon nom est bill jones
-- c'est john w.smith .
-- ([vous pouvez] [s'il vous plaît]) Appelle-moi  {PersonName.Any} [.]
-- mon nom est  {PersonName.Any} [.]
-- (je suis)  {PersonName.Any} [.]
-- (c'est c'est ça)  {PersonName.Any} [.]
+- ([vous pouvez]|[s'il vous plaît]) Appelle-moi {PersonName.Any} [.]
+- mon nom est {PersonName.Any} [.]
+- (je|suis) {PersonName.Any} [.]
+- (c'est|ça) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,8 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
 
 > # Phrase list definitions
 

--- a/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/it-it/general.lu
+++ b/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources/LU/it-it/general.lu
@@ -105,18 +105,10 @@
 
 
 ## ExtractName
-- chiamami steve !
-- Io sono anna
-- Sono John Jackson.
-- Sono giglio
-- è jackson .
-- è Alice Anderson!
-- il mio nome è Bill Jones
-- questo è john w.smith .
-- ([si può] [per favore]) Chiamami  {PersonName.Any} [.]
-- mi chiamo  {PersonName.Any} [.]
-- (Io sono)  {PersonName.Any} [.]
-- (è, è, questo è)  {PersonName.Any} [.]
+- ([si può]|[per favore]) Chiamami {PersonName.Any} [.]
+- mi chiamo {PersonName.Any} [.]
+- (Io|sono) {PersonName.Any} [.]
+- (è|questo è) {PersonName.Any} [.]
 
 
 ## FinishTask
@@ -528,8 +520,6 @@ $DirectionalReference:simple
 $PREBUILT:number
 
 $PREBUILT:ordinal
-
-$PREBUILT:personName
 
 > # Phrase list definitions
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
close #2796 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Remove prebuilt entity personName, and fix the pattern.any entity personName.Any to fix the deployment error of VA.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [x] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [x] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
