### PR TITLE
[Generator] Update generator prompt for specific culture locales

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/README.md
@@ -19,7 +19,7 @@
     - `What will your assistant do? ()`
         > The description of your assistant.
     - `Which languages will your assistant use? (by default takes all the languages)`
-        - [x] Chinese (`zh-zh`)
+        - [x] Chinese (`zh-cn`)
         - [x] Deutsch (`de-de`)
         - [x] English (`en-us`)
         - [x] French (`fr-fr`)
@@ -38,7 +38,7 @@
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------|
 | -n, --assistantName [name]              | name of new assistant (by default takes `sample-assistant`)                                                          |
 | -d, --assistantDesc [description]       | description of the new assistant (by default takes ``) |
-| -l, --assistantLang [languages]| languages for the new assistant. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-zh` (by default takes all the languages)| 
+| -l, --assistantLang [languages]| languages for the new assistant. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-cn` (by default takes all the languages)| 
 | -p, --assistantGenerationPath [path]    | destination path for the new assistant (by default takes the path where you are runnning the generator)            |
 | --noPrompt                        | indicates to avoid the prompts                                                                               |
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/README.md
@@ -19,12 +19,12 @@
     - `What will your assistant do? ()`
         > The description of your assistant.
     - `Which languages will your assistant use? (by default takes all the languages)`
-        - [x] Chinese (`zh`)
-        - [x] Deutsch (`de`)
-        - [x] English (`en`)
-        - [x] French (`fr`)
-        - [x] Italian (`it`)
-        - [x] Spanish (`es`)
+        - [x] Chinese (`zh-zh`)
+        - [x] Deutsch (`de-de`)
+        - [x] English (`en-us`)
+        - [x] French (`fr-fr`)
+        - [x] Italian (`it-it`)
+        - [x] Spanish (`es-es`)
     - `Do you want to change the new assistant's location?`
         > A confirmation to change the destination for the generation.
         - `Where do you want to generate the assistant? (by default takes the path where you are running the generator)`
@@ -38,7 +38,7 @@
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------|
 | -n, --assistantName [name]              | name of new assistant (by default takes `sample-assistant`)                                                          |
 | -d, --assistantDesc [description]       | description of the new assistant (by default takes ``) |
-| -l, --assistantLang [languages]| languages for the new assistant. Possible values are `de`, `en`, `es`, `fr`, `it`, `zh` (by default takes all the languages)| 
+| -l, --assistantLang [languages]| languages for the new assistant. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-zh` (by default takes all the languages)| 
 | -p, --assistantGenerationPath [path]    | destination path for the new assistant (by default takes the path where you are runnning the generator)            |
 | --noPrompt                        | indicates to avoid the prompts                                                                               |
 
@@ -47,7 +47,7 @@
 #### Example
 
 ```bash
-> yo botbuilder-assistant -n "Virtual Assistant" -d "A description for my new assistant" -l "en,es" -p "\aPath" --noPrompt
+> yo botbuilder-assistant -n "Virtual Assistant" -d "A description for my new assistant" -l "en-us,es-es" -p "\aPath" --noPrompt
 ```
 
 After this, you can check the summary in your screen:

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
@@ -142,7 +142,7 @@ module.exports = class extends Generator {
       this.log.error(
         "ERROR: Language must be selected from the list:\n\t" +
           languages.map(l => `${l.value} -> ${l.name}`).join("\n\t") +
-          "\nDefault value: en"
+          "\nDefault value: en-us"
       );
       process.exit(1);
     }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/index.js
@@ -22,32 +22,32 @@ let finalAssistantName = "";
 
 const languagesChoice = [
   {
-    name: "Chinese",
+    name: "Chinese: zh-cn",
     value: "zh-cn",
     checked: true
   },
   {
-    name: "Deutsch",
+    name: "Deutsch: de-de",
     value: "de-de",
     checked: true
   },
   {
-    name: "English",
+    name: "English: en-us",
     value: "en-us",
     checked: true
   },
   {
-    name: "French",
+    name: "French: fr-fr",
     value: "fr-fr",
     checked: true
   },
   {
-    name: "Italian",
+    name: "Italian: it-it",
     value: "it-it",
     checked: true
   },
   {
-    name: "Spanish",
+    name: "Spanish: es-es",
     value: "es-es",
     checked: true
   }

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/README.md
@@ -19,7 +19,7 @@
     - `What will your skill do? ()`
         > The description of your skill.
     - `Which languages will your skill use? (by default takes all the languages)`
-        - [x] Chinese (`zh-zh`)
+        - [x] Chinese (`zh-cn`)
         - [x] Deutsch (`de-de`)
         - [x] English (`en-us`)
         - [x] French (`fr-fr`)
@@ -38,7 +38,7 @@
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------|
 | -n, --skillName [name]              | name of new skill (by default takes `sample-skill`)                                                          |
 | -d, --skillDesc [description]       | description of the new skill (by default takes ``) |
-| -l, --skillLang [languages]| languages for the new skill. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-zh` (by default takes all the languages)| 
+| -l, --skillLang [languages]| languages for the new skill. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-cn` (by default takes all the languages)| 
 | -p, --skillGenerationPath [path]    | destination path for the new skill (by default takes the path where you are runnning the generator)            |
 | --noPrompt                        | indicates to avoid the prompts                                                                               |
 

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/README.md
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/README.md
@@ -19,12 +19,12 @@
     - `What will your skill do? ()`
         > The description of your skill.
     - `Which languages will your skill use? (by default takes all the languages)`
-        - [x] Chinese (`zh`)
-        - [x] Deutsch (`de`)
-        - [x] English (`en`)
-        - [x] French (`fr`)
-        - [x] Italian (`it`)
-        - [x] Spanish (`es`)
+        - [x] Chinese (`zh-zh`)
+        - [x] Deutsch (`de-de`)
+        - [x] English (`en-us`)
+        - [x] French (`fr-fr`)
+        - [x] Italian (`it-it`)
+        - [x] Spanish (`es-es`)
     - `Do you want to change the new skill's location?`
         > A confirmation to change the destination for the generation.
         - `Where do you want to generate the skill? (by default takes the path where you are running the generator)`
@@ -38,7 +38,7 @@
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------|
 | -n, --skillName [name]              | name of new skill (by default takes `sample-skill`)                                                          |
 | -d, --skillDesc [description]       | description of the new skill (by default takes ``) |
-| -l, --skillLang [languages]| languages for the new skill. Possible values are `de`, `en`, `es`, `fr`, `it`, `zh` (by default takes all the languages)| 
+| -l, --skillLang [languages]| languages for the new skill. Possible values are `de-de`, `en-us`, `es-es`, `fr-fr`, `it-it`, `zh-zh` (by default takes all the languages)| 
 | -p, --skillGenerationPath [path]    | destination path for the new skill (by default takes the path where you are runnning the generator)            |
 | --noPrompt                        | indicates to avoid the prompts                                                                               |
 
@@ -47,7 +47,7 @@
 #### Example
 
 ```bash
-> yo botbuilder-skill -n "My Skill" -d "A description for my new skill" -l "en,es" -p "\aPath" --noPrompt
+> yo botbuilder-skill -n "My Skill" -d "A description for my new skill" -l "en-us,es-es" -p "\aPath" --noPrompt
 ```
 
 After this, you can check the summary in your screen:

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/index.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/index.js
@@ -21,32 +21,32 @@ let finalSkillName = "";
 
 const languagesChoice = [
   {
-    name: "Chinese",
+    name: "Chinese: zh-cn",
     value: "zh-cn",
     checked: true
   },
   {
-    name: "Deutsch",
+    name: "Deutsch: de-de",
     value: "de-de",
     checked: true
   },
   {
-    name: "English",
+    name: "English: en-us",
     value: "en-us",
     checked: true
   },
   {
-    name: "French",
+    name: "French: fr-fr",
     value: "fr-fr",
     checked: true
   },
   {
-    name: "Italian",
+    name: "Italian: it-it",
     value: "it-it",
     checked: true
   },
   {
-    name: "Spanish",
+    name: "Spanish: es-es",
     value: "es-es",
     checked: true
   }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The locale prompt and the documentation of the documentation were outdated.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update generator's documentation for specific cultures locales
- Update generator's locales prompts

![image](https://user-images.githubusercontent.com/11904023/70800353-cb328700-1d8a-11ea-9286-80c264eb40e8.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [X] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
