### PR TITLE
Update VA Sample to 4.7-rc0 lib

### DIFF
--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/BotTestBase.cs
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests/BotTestBase.cs
@@ -40,6 +40,7 @@ namespace VirtualAssistantSample.Tests
             Services.AddSingleton(new BotSettings());
             Services.AddSingleton(new BotServices()
             {
+                // Non US languages are empty as Dispatch/LUIS not required for localization tests.
                 CognitiveModelSets = new Dictionary<string, CognitiveModelSet>
                 {
                     {
@@ -51,6 +52,21 @@ namespace VirtualAssistantSample.Tests
                                 { "General", GeneralTestUtil.CreateRecognizer() }
                             },
                         }
+                    },
+                    {
+                        "zh-cn", new CognitiveModelSet { }
+                    },
+                    {
+                        "fr-fr", new CognitiveModelSet { }
+                    },
+                    {
+                        "es-es", new CognitiveModelSet { }
+                    },
+                    {
+                        "de-de", new CognitiveModelSet { }
+                    },
+                    {
+                        "it-it", new CognitiveModelSet { }
                     }
                 }
             });

--- a/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.7.0-rc1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.0-rc1" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.7.0-rc1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Solutions" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Solutions" Version="4.7.0-rc0" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.7.0-rc1" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.7.0-rc1" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.7.0-rc1" />


### PR DESCRIPTION
- Update VA Sample to 4.7-rc0 lib as a result of recently merged qnamaker changes
- Also addressing previously broken localization tests due to missing cognitivemodels