### PR TITLE
[Android] fix adaptive card of bing search skill can't be rendered in Android

### DIFF
--- a/samples/android/clients/VirtualAssistantClient/app/src/main/java/com/microsoft/bot/builder/solutions/virtualassistant/activities/main/chatlist/ChatAdapter.java
+++ b/samples/android/clients/VirtualAssistantClient/app/src/main/java/com/microsoft/bot/builder/solutions/virtualassistant/activities/main/chatlist/ChatAdapter.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -96,7 +97,7 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             View botCards = view.findViewById(R.id.bot_cards);
             botCards.setVisibility(View.VISIBLE); // bot cards is hidden by default, set to visible if cards exist
 
-            LinearLayout cardsContainer = view.findViewById(R.id.cards_container);
+            RelativeLayout cardsContainer = view.findViewById(R.id.cards_container);
 
             // generate horizontal or vertical carousel of cards
             for (int x = 0; x < botConnectorActivity.getAttachments().size(); x++) {
@@ -119,6 +120,9 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         renderedAdaptiveCardView.setFocusable(false);
                         renderedAdaptiveCardView.setFocusableInTouchMode(false);
                         renderedAdaptiveCardView.setBackgroundColor(colorBubbleBot);
+
+                        // workaround of adaptive card render issue
+                        renderedAdaptiveCardView.setLayoutParams(new LinearLayout.LayoutParams(parent.getWidth() * 3 / 4, LinearLayout.LayoutParams.WRAP_CONTENT));
 
                         // add the view to the existing card container
                         cardsContainer.addView(renderedAdaptiveCardView);

--- a/samples/android/clients/VirtualAssistantClient/app/src/main/res/layout/item_chat_bot.xml
+++ b/samples/android/clients/VirtualAssistantClient/app/src/main/res/layout/item_chat_bot.xml
@@ -41,7 +41,7 @@
         android:layout_alignParentStart="true"
         android:visibility="gone"
         android:paddingTop="8dp">
-        <LinearLayout
+        <RelativeLayout
             android:id="@+id/cards_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
+++ b/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
@@ -79,6 +79,8 @@
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/skills/csharp/experimental/bingsearchskill/Dialogs/SearchDialog.cs
+++ b/skills/csharp/experimental/bingsearchskill/Dialogs/SearchDialog.cs
@@ -110,6 +110,11 @@ namespace BingSearchSkill.Dialogs
                         Year = movieInfo.Year,
                     };
 
+                    if (Channel.GetChannelId(stepContext.Context) == Channels.DirectlineSpeech || Channel.GetChannelId(stepContext.Context) == Channels.Msteams)
+                    {
+                        movieData.Image = ImageToDataUri(movieInfo.Image);
+                    }
+
                     tokens.Add("Speak", movieInfo.Description);
 
                     prompt = ResponseManager.GetCardResponse(
@@ -128,9 +133,9 @@ namespace BingSearchSkill.Dialogs
                         EntityTypeDisplayHint = entitiesResult[0].EntityTypeDisplayHint
                     };
 
-                    if (Channel.GetChannelId(stepContext.Context) == Channels.Msteams && !string.IsNullOrEmpty(entitiesResult[0].ThumbnailUrl))
+                    if (Channel.GetChannelId(stepContext.Context) == Channels.DirectlineSpeech || Channel.GetChannelId(stepContext.Context) == Channels.Msteams)
                     {
-                        celebrityData.IconPath = entitiesResult[0].ThumbnailUrl;
+                        celebrityData.IconPath = ImageToDataUri(entitiesResult[0].ImageUrl);
                     }
 
                     tokens.Add("Speak", entitiesResult[0].Description);

--- a/skills/csharp/experimental/bingsearchskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/bingsearchskill/Dialogs/SkillDialogBase.cs
@@ -19,6 +19,12 @@ using Microsoft.Bot.Builder.Solutions.Skills;
 using Microsoft.Bot.Builder.Solutions.Util;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Net.Http;
+using System.IO;
+using System.Linq;
+using System.Drawing.Drawing2D;
 
 namespace BingSearchSkill.Dialogs
 {
@@ -186,6 +192,50 @@ namespace BingSearchSkill.Dialogs
             {
                 return card;
             }
+        }
+
+        protected string ImageToDataUri(string imageUrl)
+        {
+            var httpClient = new HttpClient();
+
+            long useDataUriJpegQuality = 75;
+
+            if (useDataUriJpegQuality > 0 && !string.IsNullOrEmpty(imageUrl))
+            {
+                using (var image = Image.FromStream(httpClient.GetStreamAsync(imageUrl).Result))
+                {
+                    MemoryStream ms = new MemoryStream();
+                    var encoder = ImageCodecInfo.GetImageDecoders().Where(x => x.FormatID == ImageFormat.Jpeg.Guid).FirstOrDefault();
+                    var encoderParameters = new EncoderParameters(1);
+                    encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, useDataUriJpegQuality);
+                    var maxWidth = 200;
+                    if (image.Width > maxWidth)
+                    {
+                        var newWidth = maxWidth;
+                        var newHeight = newWidth * image.Height / image.Width;
+                        var res = new Bitmap(newWidth, newHeight);
+
+                        using (var graphic = Graphics.FromImage(res))
+                        {
+                            graphic.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                            graphic.SmoothingMode = SmoothingMode.HighQuality;
+                            graphic.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                            graphic.CompositingQuality = CompositingQuality.HighQuality;
+                            graphic.DrawImage(image, 0, 0, newWidth, newHeight);
+                        }
+
+                        res.Save(ms, encoder, encoderParameters);
+                    }
+                    else
+                    {
+                        image.Save(ms, encoder, encoderParameters);
+                    }
+
+                    return $"data:image/jpeg;base64,{Convert.ToBase64String(ms.ToArray())}";
+                }
+            }
+
+            return string.Empty;
         }
 
         private class DialogIds


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
close: https://github.com/microsoft/botframework-solutions/issues/2425

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
1. the adaptive sdk in Android can't render external image link (tracked in here: https://github.com/MicrosoftDocs/AdaptiveCards/issues/238). So convert the image to base64 in bing search skill
2. the card width can't wrap by its content. as a workaroud, set the width to 3/4 of its parent view.
![image](https://user-images.githubusercontent.com/19773357/71170975-9eed9d80-2297-11ea-8f09-c549d1205aad.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
