### PR TITLE
Manifest generation locale testing update

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Manifest/SkillManifestGenerator.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Manifest/SkillManifestGenerator.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
                     foreach (var localeSet in cognitiveModels)
                     {
                         // Download/cache all the LUIS models configured for this locale (key is the locale name)
-                        await PreFetchLuisModelContentsAsync(localeLuisModels, localeSet.Key, localeSet.Value.LanguageModels).ConfigureAwait(false);
+                        await PreFetchLuisModelContentsAsync(localeLuisModels, localeSet.Value.LanguageModels).ConfigureAwait(false);
                     }
 
                     foreach (var action in skillManifest.Actions)
@@ -156,7 +156,7 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
         /// </summary>
         /// <param name="luisServices">List of LuisServices.</param>
         /// <returns>Collection of LUIS model definitions grouped by model name.</returns>
-        private async Task PreFetchLuisModelContentsAsync(Dictionary<string, dynamic> localeModelUtteranceCache, string locale, List<LuisService> luisServices)
+        private async Task PreFetchLuisModelContentsAsync(Dictionary<string, dynamic> localeModelUtteranceCache, List<LuisService> luisServices)
         {
             // For each luisSource we identify the Intent and match with available luisServices to identify the LuisAppId which we update
             foreach (LuisService luisService in luisServices)
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
                     string json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var luisApp = JsonConvert.DeserializeObject<dynamic>(json);
 
-                    localeModelUtteranceCache.Add($"{locale}_{luisService.Id}", luisApp);
+                    localeModelUtteranceCache.Add($"{luisApp.culture}_{luisService.Id}", luisApp);
                 }
             }
         }

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Microsoft.Bot.Builder.Solutions.Tests.csproj
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Microsoft.Bot.Builder.Solutions.Tests.csproj
@@ -10,6 +10,8 @@
     <None Remove="Responses\TestResponses.lg" />
     <None Remove="Skills\manifestTemplate.json" />
     <None Remove="Skills\TestData\luisCalendarModelResponse.json" />
+    <None Remove="Skills\TestData\luisCalendarModelResponse_de.json" />
+    <None Remove="Skills\TestData\luisCalendarModelResponse_fr.json" />
     <None Remove="Skills\TestData\malformedManifestTemplate.json" />
     <None Remove="Skills\TestData\manifestInvalidIntent.json" />
     <None Remove="Skills\TestData\manifestInvalidLUISModel.json" />
@@ -23,6 +25,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Skills\manifestTemplate.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Skills\TestData\luisCalendarModelResponse_de.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Skills\TestData\luisCalendarModelResponse_fr.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Skills\TestData\luisCalendarModelResponse.json">

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/luisCalendarModelResponse_de.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/luisCalendarModelResponse_de.json
@@ -1,0 +1,13545 @@
+{
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "test_Calendar",
+  "desc": "",
+  "culture": "de-de",
+  "tokenizerVersion": "1.0.0",
+  "intents": [
+    {
+      "name": "AcceptEventEntry"
+    },
+    {
+      "name": "ChangeCalendarEntry"
+    },
+    {
+      "name": "CheckAvailability"
+    },
+    {
+      "name": "ConnectToMeeting"
+    },
+    {
+      "name": "ContactMeetingAttendees"
+    },
+    {
+      "name": "CreateCalendarEntry"
+    },
+    {
+      "name": "DeleteCalendarEntry"
+    },
+    {
+      "name": "FindCalendarDetail"
+    },
+    {
+      "name": "FindCalendarEntry"
+    },
+    {
+      "name": "FindCalendarWhen"
+    },
+    {
+      "name": "FindCalendarWhere"
+    },
+    {
+      "name": "FindCalendarWho"
+    },
+    {
+      "name": "FindDuration"
+    },
+    {
+      "name": "FindMeetingRoom"
+    },
+    {
+      "name": "GoBack"
+    },
+    {
+      "name": "None"
+    },
+    {
+      "name": "ShowNextCalendar"
+    },
+    {
+      "name": "ShowPreviousCalendar"
+    },
+    {
+      "name": "TimeRemaining"
+    }
+  ],
+  "entities": [
+    {
+      "name": "DestinationCalendar",
+      "roles": []
+    },
+    {
+      "name": "Duration",
+      "roles": []
+    },
+    {
+      "name": "FromDate",
+      "roles": []
+    },
+    {
+      "name": "FromTime",
+      "roles": []
+    },
+    {
+      "name": "Location",
+      "roles": []
+    },
+    {
+      "name": "MeetingRoom",
+      "roles": []
+    },
+    {
+      "name": "Message",
+      "roles": []
+    },
+    {
+      "name": "MoveEarlierTimeSpan",
+      "roles": []
+    },
+    {
+      "name": "MoveLaterTimeSpan",
+      "roles": []
+    },
+    {
+      "name": "OrderReference",
+      "roles": []
+    },
+    {
+      "name": "PositionReference",
+      "roles": []
+    },
+    {
+      "name": "SlotAttribute",
+      "roles": []
+    },
+    {
+      "name": "Subject",
+      "roles": []
+    },
+    {
+      "name": "ToDate",
+      "roles": []
+    },
+    {
+      "name": "ToTime",
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [
+    {
+      "name": "RelationshipName",
+      "subLists": [
+        {
+          "canonicalForm": "aunt",
+          "list": []
+        },
+        {
+          "canonicalForm": "aunts",
+          "list": []
+        },
+        {
+          "canonicalForm": "boss",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "brothers",
+          "list": []
+        },
+        {
+          "canonicalForm": "child",
+          "list": []
+        },
+        {
+          "canonicalForm": "children",
+          "list": []
+        },
+        {
+          "canonicalForm": "colleague",
+          "list": []
+        },
+        {
+          "canonicalForm": "colleagues",
+          "list": []
+        },
+        {
+          "canonicalForm": "cousin",
+          "list": []
+        },
+        {
+          "canonicalForm": "cousins",
+          "list": []
+        },
+        {
+          "canonicalForm": "dad",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughters",
+          "list": []
+        },
+        {
+          "canonicalForm": "families",
+          "list": []
+        },
+        {
+          "canonicalForm": "family",
+          "list": []
+        },
+        {
+          "canonicalForm": "father",
+          "list": []
+        },
+        {
+          "canonicalForm": "father in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "father-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "friend",
+          "list": []
+        },
+        {
+          "canonicalForm": "friends",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandchild",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandchildren",
+          "list": []
+        },
+        {
+          "canonicalForm": "granddaughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandfather",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandma",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandmother",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandparent",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandparents",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandson",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandsons",
+          "list": []
+        },
+        {
+          "canonicalForm": "husband",
+          "list": []
+        },
+        {
+          "canonicalForm": "in-laws",
+          "list": []
+        },
+        {
+          "canonicalForm": "kids",
+          "list": []
+        },
+        {
+          "canonicalForm": "mom",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "neighbor",
+          "list": []
+        },
+        {
+          "canonicalForm": "neighbors",
+          "list": []
+        },
+        {
+          "canonicalForm": "nephew",
+          "list": []
+        },
+        {
+          "canonicalForm": "niece",
+          "list": []
+        },
+        {
+          "canonicalForm": "parent",
+          "list": []
+        },
+        {
+          "canonicalForm": "parents",
+          "list": []
+        },
+        {
+          "canonicalForm": "partner",
+          "list": []
+        },
+        {
+          "canonicalForm": "siblings",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "sisters",
+          "list": []
+        },
+        {
+          "canonicalForm": "son",
+          "list": []
+        },
+        {
+          "canonicalForm": "son in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "son-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "step daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "step-daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepfather",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepmother",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepsister",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepson",
+          "list": []
+        },
+        {
+          "canonicalForm": "students",
+          "list": []
+        },
+        {
+          "canonicalForm": "teachers",
+          "list": []
+        },
+        {
+          "canonicalForm": "uncle",
+          "list": []
+        },
+        {
+          "canonicalForm": "uncles",
+          "list": []
+        },
+        {
+          "canonicalForm": "wife",
+          "list": []
+        },
+        {
+          "canonicalForm": "manager",
+          "list": []
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "patternAnyEntities": [],
+  "regex_entities": [],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    },
+    {
+      "name": "number",
+      "roles": []
+    },
+    {
+      "name": "ordinal",
+      "roles": []
+    },
+    {
+      "name": "personName",
+      "roles": []
+    }
+  ],
+  "model_features": [],
+  "regex_features": [],
+  "patterns": [],
+  "utterances": [
+    {
+      "text": "2 hours meeting with ladawn padilla at 5 on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Duration",
+          "startPos": 0,
+          "endPos": 6
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 39
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 44,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "2 pm meeting tomorrow - who else is going",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 0,
+          "endPos": 3
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "2 pm meeting with who",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 0,
+          "endPos": 3
+        }
+      ]
+    },
+    {
+      "text": "a new meeting location find one",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "about how long will the meeting last",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "accept all meetings for christmas party next week.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "accept an appointment",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept dinner",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "accept my meeting at 7pm today",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "accept my meeting at tomorrow 10am",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment from 3pm to 5pm.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 30
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment on january 18th in palace meeting room.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 37
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 42,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment sent by lucas",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the event",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the event for tonight.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "accept the event on feb. 18 in beijing.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 26
+        },
+        {
+          "entity": "Location",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "accept the event sent by yolanda wong.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the meeting held on tomorrow at room 301",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 39,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "accept the meeting organized by jack lauren.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the meeting with mary and tom held on wednesday",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "accept the meeting with tom chen.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept this appointment with jane and mary on next tuesday.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "accept this event.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept this lunch meeting.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "accept today's event at 3pm.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "accept today's meeting",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "add a meeting with herman to my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "add an appointment on may 8th at shanghai",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 28
+        },
+        {
+          "entity": "Location",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add applied motion to my calendar 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add appt with mickey li for dinner on march 5th at 5 pm at dennys",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 54
+        },
+        {
+          "entity": "Location",
+          "startPos": 59,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "add balboa practice to my calendar at 3 30 today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 38,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "add ballet to my calendar wednesday at five thirty to six thirty pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 49
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 54,
+          "endPos": 66
+        }
+      ]
+    },
+    {
+      "text": "add baseball game on friday to calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "add chicago bulls versus washington wizards to my calendar tomorrow at seven pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 42
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 59,
+          "endPos": 66
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 71,
+          "endPos": 78
+        }
+      ]
+    },
+    {
+      "text": "add choir practice on saturday at 7 pm to my personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 45,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "add choreography to my family calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 23,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "add chorus concert to calendar for may 1st at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add church to personal calendar on sundays at 9",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 14,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "add coffee on august 12th at 2 pm with herman for one hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        },
+        {
+          "entity": "Duration",
+          "startPos": 50,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "add dance on tuesday at four o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 19
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add date night on the 5th at 7pm every month",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment on tuesday june at the 1st clinic",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        },
+        {
+          "entity": "Location",
+          "startPos": 47,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment to my calendar at 3:30 for the 8th of may",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 42,
+          "endPos": 45
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 55,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment to my calendar tomorrow from 3 to 4:30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 53,
+          "endPos": 53
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 58,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointments to my calendar at 3 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "add dinner to personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "add dinner with mom to personal",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "add doctors appointment on march 13 at 2 pm at the tricare virginia beach clinic",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "Location",
+          "startPos": 51,
+          "endPos": 79
+        }
+      ]
+    },
+    {
+      "text": "add go shopping with sam meng on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "add haircut to my google calendar tomorrow at 2 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 10
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 18,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add kane s dr appt to calendar for 3 friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add maple beach to my calendar at 10 on sunday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add me to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "add me to the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "add megan training to calendar on july 4th at 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "add office party on march 8th from 6 p to 9 p",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 37
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "add order cabinets to my calendar today at 2 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "add ow huth middle school meet and greet on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 4,
+          "endPos": 24
+        },
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "add pay credit card to calendar may twentieth",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "add pay pearl fees on my calendar tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "add picture day at school to my calendar for friday, november the 8th from 8 am to 9:30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "Location",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 68
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 75,
+          "endPos": 78
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 83,
+          "endPos": 86
+        }
+      ]
+    },
+    {
+      "text": "add solo gig at lincombe hall on the 7th of march at 8 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "Location",
+          "startPos": 16,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 48
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 53,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add team meeting to my calendar at 10pm with xiaoming wang",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "add ultimate frisbee on sunday at 2 pm for 2 hours",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "Duration",
+          "startPos": 43,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add vacation to my calendar from july 4th until july 29th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 48,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar at 3 pm on friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar friday from 8 for an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 33
+        },
+        {
+          "entity": "Duration",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar sunday 10 till 5",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar thursday 8 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add work to my calendar monday 6 am to 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "add work to my calendar today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "alert attendees meeting is at 8 30",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 16,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "alert attendees of dinner meeting that i will be late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 32
+        },
+        {
+          "entity": "Message",
+          "startPos": 39,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "alert quality control meeting participants that i am 15 minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 28
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "alert quality control meeting participants that the meeting will be 30 minutes later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 28
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 83
+        }
+      ]
+    },
+    {
+      "text": "am i available",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "am i available at 10 am on monday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "am i available on monday at 9 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i available tomorrow at 5 30 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "am i busy on the 6th of february",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i busy on this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "am i busy this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "am i free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "am i free at 5 pm today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "am i free at 7 p . m .",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "am i free for drinks monday at 5",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i free for drinks monday at 5 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "am i free for hiking on saturday at 8 am",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "am i free from 3 pm - 10 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 18
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "am i free on monday at 9 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "am i free on saturday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "am i free on the 12th of july",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "am i free to drive with kim on thurs at 3 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "am i free today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "am i free tomorrow 3 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "am i free tonight",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "am i free tuesday at 7 am",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "append dad's birthday every july 21st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "appending group meeting next monday at 11am for an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "Duration",
+          "startPos": 48,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "at 10 am do i have a 30 minutes meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 3,
+          "endPos": 7
+        },
+        {
+          "entity": "Duration",
+          "startPos": 21,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "attend the fy19 celebration party sent by daisy chan.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "attend the lunch meeting at 10:30 am.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "attend the meeting held at 3pm next tuesday at the conference center.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 42
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 51,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "attendees who will join the 5 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "back one step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "back the last step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "bing find me a conference room in the bravern this afternoon",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 38,
+          "endPos": 44
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "book a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "book a meeting",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "book blue meeting room",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "book the conference room for thursday at one i want to meet with benjamin",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "bring forward my 4 o'clock appointment 2 hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 25
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "call conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call genpact conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call harris conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call into conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call into marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "call into meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call the morning breifing conference number",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "call the weekly marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "can you cancel the 1st one",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 19,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "can you change it to 5 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "can you check my dad 's calendar for free time this week",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 47,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "can you go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "can you move this appointment to 5pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "can you reserve room 258 right away",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "can you show me the time remaining before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "can you tell me about master chief",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "can you tell me if my husband is free on sunday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "can you tell me something about shakespeare",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "cancel 1 pm staff meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 10
+        },
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "cancel all events",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel appointment today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "cancel appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel calendar entry",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel dinner",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "cancel doctor ' s appointment monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "cancel event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel event tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "cancel lunch next wednesday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "cancel meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel meeting with abigail 3 pm today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "cancel meeting with bob marlon 3pm today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "cancel my adventureworks trip to seattle",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "Location",
+          "startPos": 33,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "cancel my appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my appointment at 9 pm",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "cancel my appointment for october 4",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "cancel my driving lesson tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "cancel my event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my meeting at shanghai on monday at 10 am",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "cancel my next appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "cancel my singing appointment on monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "cancel my three o'clock appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "cancel that appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel that meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the group meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "cancel the meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the meeting with julie",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the pickup food from ted",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "cancel the untitled event on may twenty eighth",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "cancel this meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel today ' s appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "cancel tomorrow ' s plan",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change 10 am meeting to start 20 minutes later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 30,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "change 4pm lunch appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 9
+        },
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change 5pm appointment 1 hour earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 9
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 23,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "change an appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change big event to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 15
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change dentist appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change dentist appt to an hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 18
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 23,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "change developmental agenda for lunch tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change it to 5pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 13,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change location",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 7,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change lunch appt to 2",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 16
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 21,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "change lunch date from 11 - 12 to 12 - 1 30",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "change marathon training from 8:00am to 1:00pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 40,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change marketing meeting from every tuesday to every wednesdays",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 42
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 47,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "change meeting from 2-3pm to 4-5pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 24
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 29,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "change meeting from 2pm-3pm to 4pm-5pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 37
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my 11pm appointment's location to cal anderson park",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "SlotAttribute",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "Location",
+          "startPos": 41,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "change my 3pm event to 4pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 6pm event to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 7 30 pm appointment to 8 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "change my 7pm event to 6pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 8 till 9 appointment to 11 till 12",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 10
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 17
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my 9 30 till 10 30 appointment to 9 30 till 5",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 44
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 51,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "change my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change my dentist appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "change my dentist appointment from 3:30 to 4",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 43,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my meeting at night to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "change my next meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "change my schedule",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change my ten am appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change my vacation from ending on friday to monday",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 39
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 44,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "change recital to start half an hour earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 13
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "change shave tomorrow 8 30",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 13,
+          "endPos": 20
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change the appointment ending at 4 to end at 5 instead",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 33
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change the end date of my trip from the 3rd to the 4th",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 42
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 51,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "change the end time of my 3 o'clock meeting to 3 30 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "change the location of my singing appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "change the time",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change the time to eleven thirty am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 19,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "change the title of my 11am appointment to soccer practice",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 26
+        },
+        {
+          "entity": "Subject",
+          "startPos": 43,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "change the title of my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change this appointment's location",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "change thursday team meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change time",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 7,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "change today 's meeting from 6pm to tomorrow 9am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "change today 's meeting from 6pm to tomorrow 9pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "change tomorrow ' s appointment from 10am to wednesday at 9 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 37,
+          "endPos": 40
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 45,
+          "endPos": 53
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 58,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "check janice 's calendar for this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "check kronos calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check meeting room for tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "check my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check my family calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 9,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "check my mom's schedule",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check on the time to see when i go to school and pick up luca",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "clear all my appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear all of my appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear all of my appointments today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "clear all the appointments from my calendar for today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 48,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "clear my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear my calendar for january 29th",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "clear my schedule",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear my schedule for tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "clear my schedule today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "conference join",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to 10 00 conf call with bryan",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "connect me to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to conference call with debra",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "connect me to the budget meeting conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "connect me to the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to the marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "connect me with conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me with my 2 o clock meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "connect to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect to conference call now",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "connect to weekly marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "create a calendar appointment at 3:30 tomorrow for half an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        },
+        {
+          "entity": "Duration",
+          "startPos": 51,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "create a event with eden roth at 4pm today for 30 mins",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 41
+        },
+        {
+          "entity": "Duration",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "create a meeting at 7:00pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "create a meeting at 8am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "create a meeting for tomorrow 6pm with lucy chen",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "create a meeting with tom34@outlook.com",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "create appointment for 30 minutes",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Duration",
+          "startPos": 23,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "create appointment from tuesday to wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 30
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "create calendar : tomorrow morning from 9 to 11 at 1103 room for internal meeting",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 46
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 51,
+          "endPos": 59
+        },
+        {
+          "entity": "Subject",
+          "startPos": 65,
+          "endPos": 80
+        }
+      ]
+    },
+    {
+      "text": "decline my meeting on monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "delay the meeting event by 1 hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "delay the next meeting by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 26,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "delete an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete birthday calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "delete calendar event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete my schedule",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete my schedule for today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "delete that appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the 1st one from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "delete the appointment with jeffrey",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the appointment with mom",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the scheduled meeting with zachary",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete this appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "detail about tomorrow's meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "detailed information about the next meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "details about the meeting with grace",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "details about the meeting with karen and tom",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "dial into conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "dial marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "did hellen come to 3 pm's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "did mark sign up to the tomorrow's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "did martin come to today's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "discard the appointment with george",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "discard the meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "display olivia 's availability",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "do i have any appointments today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "do i have any free time this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "do i have any meetings today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "do i have any spare time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "do i have anything from 11 to 2",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 25
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "do i have anything on wednesday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "do i have anything today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "drop my appointment for monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "duration of machine learning talk",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "edit calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "extend meeting from 9 am to 12 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find a free meeting room for next tuesday",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "find a meeting about group meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "find a meeting about plan",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "find a meeting at 7pm from melissa",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from darren about status update",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from deborah about team session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 34,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from donna",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find a meeting subject daily meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with subject weekly report",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with title second lesson from amanda",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with title sharing from steven",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "find an available meeting room from 3 to 5 tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "find attendees who will attend 8 o ' clock meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "find me an empty conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "find me the meetings at 6",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "find me the meetings at 9 o'clock",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find the meeting around 5 to 8 pm",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find the meeting around 5 to 8pm",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "find the meeting with judith",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find the meeting with timothy",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find the meetings mary",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "find the next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "get me on the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "get to my next event",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "give me details of the next appointment",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 23,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back a step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back one step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back please",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "go back to the last step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "go back to the main menu",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back to the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "hello world",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "help me to book a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "help me to book a meeting room from 10 am to 3 pm",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "help me to book the room 102",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "help me to find a meeting room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "how long do i have for lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how long is going to last that meeting",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how long is it until the 14th of march",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how long is my 4 o'clock meeting",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how long is my dentist appointment",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "how long is my facial time",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how long is my lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how long is my meeting at 4",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "how long is the event",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how long is the movie jurassic world",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how long till disneyland paris",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "how long till my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "how long till the next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how long until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until the social",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "how long will i wait for the next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "how long will my dentist appointment last",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how many days is it until christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "how many days left until the opening ceremony",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many days till april",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how many days till christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how many days until june the fifteenth",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how many days until june the fifteenth 2019",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "how many days until march twenty six",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how many days until my doctor ' s appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many days until thanksgiving",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "how many days until the 10th of december",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "how many hours",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how many hours left till the closing ceremony",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many hours remaining till next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "how many hours until my doc appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how many minutes before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 27,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "how many minutes free do i have before next scheduled appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "how much longer do i have before pick up luca from school",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "how much longer do i have until pick up luca from school",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "how much longer until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much longer until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much time as of now is set for the bill payments",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 39,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "how much time as set for the bill payments",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "how much time before lunch",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how much time before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how much time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "how much time between schedule thursday meetings next week",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time do i have before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have before my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have for a lunch break today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 40
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have free until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 38,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have to take back the movie",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until i have to meet with michael",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 40,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until i start the meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until my doc appt",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until my meeting with larry",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time do i have until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "how much time do we have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "how much time does my meetings take up",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how much time for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much time is there before office meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "how much time is there for errands during my lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 33
+        },
+        {
+          "entity": "Subject",
+          "startPos": 45,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "how much time open today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time out on lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how much time remaining till next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "how much time to i have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how much time until my meeting with lori",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time until next scheduled appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time until noon",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time will i have to pick up groceries",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "how's the weather today",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "i need to check the previous appointment",
+      "intent": "ShowPreviousCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need to delete this appointment from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "i need to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i need to join conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "i need to join the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "i need to know about my date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need to know about my meeting",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "i need to know about my next appointment",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need you to find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "i need you to provide me the details of the meeting i have scheduled with my colleague amanda",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "i want to delete an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "i want to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i want to know the time left for my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "i want to meet with bruce lee so book the conference room for thursday at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 62,
+          "endPos": 69
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 74,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "i want to meet with donna please book for thursday the conference room at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 74,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "i want to take a look at the attendee list",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "i would like to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i would like to know if my mother is available today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 47,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "i'll attend the meeting at 2pm tomorrow in room 304",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "i'll attend the meeting this afternoon.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "i'll attend this upcoming event in redmond.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 35,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "i'm looking for a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "is bruce young attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "is carolyn available tuesday afternoon",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "is charles wong going to be at the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "is debra available on saturday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is gerald busy this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "is it going to last long",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "is joe going to be at the next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is madison busy",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "is my lunch long enough for errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "is nicholas available friday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "is raymond free on monday evening",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "is rebecca busy thursday at 4",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "is russell free on friday at 4pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "is saturday free",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 3,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "is theresa free october 9th",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "is this room busy at 5 pm",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "is this room busy tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "is victoria participating next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is virginia free on monday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "join budget conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "join conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join current budget conf call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "join current conference",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join current conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join lync meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join meeting now",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "join my meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join my next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join next link meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "join next meeting on link",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "join the budget meeting conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "join the conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join the meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join the next lync meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "let 5 pm meeting starting at 3",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 29,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "let me see who will attend party planning meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "let next meeting starting at 10am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "let's find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "link join my next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "link join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "list the attendees of the next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "list the participants for the 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "locate another meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "locate the next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "location of 11 am meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "location of the next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "look up my next appointment for me",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "lync join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "make appointment for 5 30 tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "make appointment for 7 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "make appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make appointment on monday.",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "make appointment on personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "make appointment to play squash on thursday at 7 20",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 30
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "make appointment to see doctor culver august the 22nd 2013 1 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 57
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 59,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "make appointment with tom roth.",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make appt for 3 pm on christmas",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "make me a calendar event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me a dentist appointment wednesday at two forty five",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me an appointment for next weekend",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment for ten forty next monday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment for the next week thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me an appointment tomorrow at 2 30 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "make next meeting to start 1 hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "make the appointment ending at 2 go until 4 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "make the meeting ending at 10 go until 11",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 28
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "make the meeting to start 1 hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 26,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "make the meeting to start 40 minutes earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 26,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "march 15 dinner at refectory at 6 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 0,
+          "endPos": 7
+        },
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "Location",
+          "startPos": 19,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "meet ming wang for lunch on tuesday at noon",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "meet with a.j. lee saturday at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "meet with carol lee at home on march 10th at 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 23,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "meeting at 3 pm today locations",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "meeting room changed to new location send to meeting attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "meeting will start soon remind everybody involved",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "meeting with ben randie tomorrow at noon",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "meeting with ellen fung on monday at 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 37,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "meeting with jia li monday 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "meeting with morrison sun at 2 pm saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "meeting with morrison yang at 4",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "message colleagues that meeting needs to be moved to 8 : 30 am",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 24,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "message everyone advising that i will be late to the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 31,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "message nancy and tell him to postpone the meeting because i ' m going to be 30 minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 30,
+          "endPos": 91
+        }
+      ]
+    },
+    {
+      "text": "minutes in lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "modify the meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "modify the second meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "move 3pm meeting to 4pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 7
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 20,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "move appt with rebecca to next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "move meeting from 9pm-10pm to 8pm-9pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 25
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 30,
+          "endPos": 32
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 36
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 38,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "move my 1 pm appointment up 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 28,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "move my 10 past 10 doctor ' s appointment to 10",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "move my 10pm meeting to 9pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 24,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "move my 12 pm meeting to 2",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my 4 pm to 5 pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 16,
+          "endPos": 19
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my 9 am doctor ' s appointment to 10 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "move my 9pm meeting to 8pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 10
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my meeting back by an hour",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 24,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "move my meeting to 6pm from 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 19,
+          "endPos": 21
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "move my meeting up by half an hour",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting out by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 28,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting out thirty minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 25,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting up by 10 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 27,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting up by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 27,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "move my text meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "move my twelve p . m . meeting forward two hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 21
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 39,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "move my twelve p. m. thirty minutes up",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 19
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 21,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "move shoe appointment to tuesday at one",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 20
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 25,
+          "endPos": 31
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "my 9 o ' clock meeting can ' t start until 9 15 can you let everyone know",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "my next meeting with emily is when",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 3,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "new appointment for tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "new appointment in calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new appointment in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new appointment next wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "new appointment today 6 pm see dead people",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 25
+        },
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "new appointment tomorrow at 3 pm at sunken",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "Location",
+          "startPos": 36,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "new calendar appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar entry",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar item",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new location for meeting this afternoon let others attendees know meeting is now in room 100",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 38
+        },
+        {
+          "entity": "Message",
+          "startPos": 66,
+          "endPos": 91
+        }
+      ]
+    },
+    {
+      "text": "next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 0,
+          "endPos": 3
+        }
+      ]
+    },
+    {
+      "text": "nokia conference room join",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 0,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "notify all attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "notify all attendees about the change",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "notify attendees of office meeting that i will be a little later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 40,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "notify diana that i ' ll be late to our meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 18,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "notify friday's 2 pm that we are cancelling the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 7,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "notify kimberly that i will be late for our 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 21,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "notify noah that our meeting is pushed back 30 minutes",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 17,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "notify others that i am going to be late to meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 19,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "notify people of meeting on tue that it will begin 15-30 min later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 28,
+          "endPos": 30
+        },
+        {
+          "entity": "Message",
+          "startPos": 37,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "obtain the appointment with frank",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "ok find out if that is possible by sending a meeting change notification to all attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "on saturday at 7 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 3,
+          "endPos": 10
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "over run of time in confer room - all attendees to be notified of meeting being moved to next room - will explain why later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 66,
+          "endPos": 97
+        }
+      ]
+    },
+    {
+      "text": "personal calendar 5/1/2013 meet mom for yard sale",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 0,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        },
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "place an appointment in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "please advise i am late for 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 14,
+          "endPos": 22
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "please alert 3 o ' clock meeting attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 13,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "please alert attendees meeting is at 8:30",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "please alert those attending the meeting that i am running a few minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 46,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "please go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "please inform colleagues running late and meeting half hour later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "please inform colleagues we will be meeting at 8 : 30 due to being late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "please inform joshua that i will be late for our meeting today",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 26,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "please inform meeting attendees that i am running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 37,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "please inform the thomas that i will be late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 30,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "please inform work contact group that i am running late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 38,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "please let all in work group know meeting to start at 9 15",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 34,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "please let them know i'm late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "please move this to 3 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "please notify everyone i ' m running late to the 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "please notify george that i will be late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 26,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "please open my date with stephanie and tell me about it",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "please remind the attendee that i am running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 32,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "please return back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "please show me how much time i have to run errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 39,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "please tell me how long i have for lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "postpone my 4 pm meeting today until 5 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 37,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "postpone my four p. m. meeting today until five p. m.",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 21
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 31,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 43,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "provide the time change for the meeting to all participants",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 8,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "push my trip july 16th out 5 days",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 21
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "put anniversary on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "put an appointment tomorrow morning",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put captains in my calendar for saturday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "put dance on my calendar for monday 7 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "put dance on my calendar from 6 to 7",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "put delainey on to doctor reddy on october 20th at 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 30
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "put dental appointment on my calendar saturday march 22nd at twelve pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 56
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 61,
+          "endPos": 69
+        }
+      ]
+    },
+    {
+      "text": "put dentist appointment in my calendar for tomorrow at one pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 50
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 55,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "put dentist appointment in my calendar tuesday 2 45 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 45
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "put dentist on my calendar for this thursday at 10 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 10
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "put doctor s appointment in my calendar for 5 forty next thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 50
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 52,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "put eye doctor appointment saturday at 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 25
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "put hair appointment on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "put insanity on my calendar at 6 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put jason work on my calendar thursday 9 am to 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "put julie camil in my calendar for tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "put mathematics paper one on tuesday 13",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "put shopping day on april 1st at 10 am on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put swimming in my calendar tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "put swimming tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "put tennis game for friday at 1 on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "put test appointment in my calendar tomorrow at 7",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "put walk sing appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "put work on my calendar tomorrow from 8 30 to 5 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 38,
+          "endPos": 41
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "put yoga on my calendar for mondays and wednesdays at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "remind all attendees of tomorrow ' s lunch that we have changed the venue",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "Subject",
+          "startPos": 37,
+          "endPos": 41
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 72
+        }
+      ]
+    },
+    {
+      "text": "remove dentist appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "remove final tutoring from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "reschedule appointment with stephanie at next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "reschedule appointment with stephanie to next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 41,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "reschedule meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "reschedule my 3:30 dentist appointment to 4",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "reschedule my 3:30 dentist appointment today for 4pm tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 49,
+          "endPos": 51
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 53,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258 now",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258 right away",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve the conference room for 1 pm thursday because i need to have a meeting with amber",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "reserve the conference room for 3pm tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "return",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return please",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return to previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "return to the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "room 100 is location for this afternoon ' s meeting please notify others",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 19
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "running late for meeting - notify others",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "running late for the board meeting alert catherine daniel and all the other attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "running late to my meeting please let jennifer know",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "schedule a breakfast meeting at 8 am tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule a buisness lunch for my department at pf chang on wednesday at 11 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 42
+        },
+        {
+          "entity": "Location",
+          "startPos": 47,
+          "endPos": 54
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 59,
+          "endPos": 67
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 72,
+          "endPos": 79
+        }
+      ]
+    },
+    {
+      "text": "schedule a calendar event for my sister",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a chiropractors appointment on july 7th at 4 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "schedule a dental appointment tomorrow afternoon at five thirty pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule a dentist appointment for tomorrow night at 7 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "schedule a dinner for tonight at 8 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctor s office appointment for march 12th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctors appointment at 15 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctors appointment with madden on march 12th at 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 55
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 60,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "schedule a lunch date with mom every tuesday at noon for the next 5 weeks",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 51
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 61,
+          "endPos": 72
+        }
+      ]
+    },
+    {
+      "text": "schedule a lunch meeting with my lead",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "schedule a massage on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a meeting for next thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting for this friday 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting for tomorrow at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting on nov. 3 from 3-4pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting with andy",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a meeting with han lu 8 am next tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting with ryan from 3-4pm on october 25th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "schedule a run at the lake with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "Location",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "schedule a shopping trip with shawntia on friday at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "schedule a soccer game for next friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "schedule a vet appointment at 9 am on saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule a visit to the market this saturday at 10 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "schedule a workout with madden to my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for 10 30 in the morning on january 20 1st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 52,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment for me on tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me tomorrow at 3 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for my mom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment for noon tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for one o clock today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for saturday at 8 dinner with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 40
+        },
+        {
+          "entity": "Subject",
+          "startPos": 42,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for saturday at one 30 pm to measure house",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 48
+        },
+        {
+          "entity": "Subject",
+          "startPos": 53,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for thursday at 3 pm haircut",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 43
+        },
+        {
+          "entity": "Subject",
+          "startPos": 45,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for tomorrow at one o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment from june 18th to june 20th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 37
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 42,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on monday from noon to 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment on november 5th at 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on october 31st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on thursday october second at 8 forty am mom s medical appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 63
+        },
+        {
+          "entity": "Subject",
+          "startPos": 65,
+          "endPos": 89
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to call meredith at 12",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to groom my dogs at petco on friday at 6 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 39
+        },
+        {
+          "entity": "Location",
+          "startPos": 44,
+          "endPos": 48
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 53,
+          "endPos": 58
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 63,
+          "endPos": 66
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to see cj on thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment with madden at 10 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden for wednesday the 20 4th at 9 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 59
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 64,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden today at 2 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden tomorrow at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with mom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event for scrum with madden at 10 am saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "schedule an event for the 5th of july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule an event on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule appointment at eight p m tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule appointment for madden account payment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule appointment yearly check up friday march one 10 am one hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 52
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 58
+        },
+        {
+          "entity": "Duration",
+          "startPos": 60,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "schedule art show on calendar for noon on march 6th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule ben baig for saturday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "schedule camping for friday to sunday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule college for tomorrow at 5 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule conference room with mary cooper for thursday at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 53
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 58,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "schedule dentist appointment with madden for may the 20th at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 56
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 61,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner on the 8th at 6 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner with madden at 6 pm on june 4th at buffalo wild wings",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "Location",
+          "startPos": 51,
+          "endPos": 68
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner with madden every friday at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule dry cleaning pick up at three thirty pm today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule group meeting with madden on march 3rd at 4 00 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "schedule hair appointment on monday at 2 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "schedule holiday for the thirty first of july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule holiday on the 31st july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with madden for 11 30 am on wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with madden on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with pura at noon on wednesday may 20 minutes",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 48
+        },
+        {
+          "entity": "Duration",
+          "startPos": 50,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "schedule mechanics exam at 12 pm on friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule miranda s graduation from 11 to 3 on may 28th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule my vacation from today 5pm to tomorrow 5pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 48,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule therapy appointment at 8 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "schedule wanda s graduation for saturday at 11 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule wedding anniversary on friday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule work for 7 am tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "schedule work on thursday the thirty first from three to seven thirty",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 52
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 57,
+          "endPos": 68
+        }
+      ]
+    },
+    {
+      "text": "schedule yoga class from 2 pm to 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 28
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "search a meeting subject project proposal rehearsal",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 25,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "search jesse 's calendar for availability",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "search the meeting with title employee orientation",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "send a message out to cancel my 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 22,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "send a message to johnny and jessie that our meeting today will be later by 30 minutes",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 41,
+          "endPos": 85
+        }
+      ]
+    },
+    {
+      "text": "send a message to the meeting attendees that the meeting will now start at 8 30 am",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 45,
+          "endPos": 81
+        }
+      ]
+    },
+    {
+      "text": "send a notice to douglas the first will be attending the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "send a notice to paul that xu wen will attend the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 27,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "send a text to the people going to the meeting that the location has changed",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 52,
+          "endPos": 75
+        }
+      ]
+    },
+    {
+      "text": "send reminder of 9 am meeting to all participants 15 minutes later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "Message",
+          "startPos": 50,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with my sister in my main calendar.",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with pura",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an appointment with pura tomorrow at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with tom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an event in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up meeting with pura for every tuesday at 1 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "set up meeting with thomson",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up the appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "should you schedule to after lunch",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "show jean calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me brenda 's schedule for friday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "show me heather 's calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me my calendar for monday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "show me my google calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "show me my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "show me my schedule tonight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "show me the calendar at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "show me the confirmed attendees",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "show me the duration of the weekly sharing",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting about briefing session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting about online session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting with paul",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me the place of the work smart training",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 25,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "show me the previous meeting with tiffany",
+      "intent": "ShowPreviousCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "show me victoria 's calendar for monday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "show me where my next appointment is",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "show me who will attend family gathering",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "show me who will be at planning meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "show meeting participants",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "show my schedule at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "show time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "start meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start my conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start my meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start the meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "tell attendees i am late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "tell everyone the meeting is now in room 204",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 14,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "tell me about my meeting today",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "tell me about my next meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "tell me about my planned trip",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "tell me about my schedule with afternoon",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "tell me about my sunday schedule",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "tell me all about dinner date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "tell me how long is my 4 oclock meeting",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "tell me how long is today ' s lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "tell me how much free time i have before next appt",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 41,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "tell me how much time before my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "tell me the duration of the product introducation",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "tell me the events scheduled at calendar constitution hall",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 41,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "tell next meeting that i'm running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "the next appointment after that",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "this meeting should be changed to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "time before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "time for lunch errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "time remaining",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "today ' s lunch will be how long",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 0,
+          "endPos": 4
+        },
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "total lunch break time today please",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "update appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update lunch appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "update meeting from 8am-12pm to 7am-11am today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 39
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 41,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "update my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update my calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "update my calendar from 2 pm to 4 pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 37,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "update my calendar from 6pm to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 31,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "update my camping appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "update my next appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "update my tomorrow 6pm meeting to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 21
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "update party",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "view emily calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "view ethan 's calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "we make an appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "we should go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "what ' s after that on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s going on this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "what ' s happening today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what ' s in my calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s my 1st appointment tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what ' s my 1st meeting tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what ' s my next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "what ' s my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule like tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s next on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s on my calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my schedule",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s on my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my schedule today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s the meeting today between 10 and 12:00",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "what allotted time is for hair dresser",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what am i doing next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what am i doing on june ninth",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what am i doing tonight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "what appointments do i have tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what are my appointments for this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what are my appointments today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "what are my meetings at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what are the next 3 events on my calendar",
+      "intent": "ShowNextCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what are the particulars for the picnic next week",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "what are the plans for the dinner date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what can you do",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what day is lego land scheduled for",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "what did the sister say about meeting on sunday",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "what do i have for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what do i have from 2 to 4 on saturday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 20
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what do i have from monday through wednesday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "what do i have going on today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have next",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what do i have on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what do i have on sunday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what do i have this afternoon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have to do this afternoon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what do i have to do tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "what have i got on tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what i am doing next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what i'm doing this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what is anna 's availability next tuesday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "what is destiny ' s event for next week",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "what is henry doing on monday at noon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "what is logan 's schedule this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what is my 1st meeting today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is my meeting with ming xu about",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is my next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what is my next event",
+      "intent": "ShowNextCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what is my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what is my schedule tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is next in calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "what is on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is that meeting with ashley and jane berlin about",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is the location of next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is the meeting with daniel robert regarding",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is the schedule before that",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what is the time now",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what is timothy doing today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what meet rooms do i have",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "what meetings do i have next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what the place of the weekly meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what time do i have work tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what time do i work today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what time is beth over today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what time is my cooking class tonight",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "what time is my first meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 16,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what time is my last meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "what time is my meeting today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what time is my mobile devices exam tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "what time is my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "what time is my wallet team meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what time is oshwin's interview",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "what time is the ice cream social",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what time is the trade show this saturday",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "what was my first appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "what's going on this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what's happening tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what's my first meeting tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what's my name",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what's the weather today",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what's your name",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "when ' s my 1st appointment tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when ' s my 1st meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when ' s my doctor ' s appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next doctors appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "when am i free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when am i free today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "when am i watching england",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "when and where is my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when do i break up from school",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "Location",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "when do i have exam",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "when do i have free time today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "when do i meet with charles",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when do i work tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "when is aaron free tomorrow",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "when is bryan free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when is concert on my calendar",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is dylan available",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when is ifeomas basketball today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 25
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when is lunch with frank",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "when is my 1st meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "when is my appointment with willie",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my daily stand up with ethan",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when is my fifth kick-off",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when is my meeting with kenneth",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my meeting with martha and deborah",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next appointment with douglas",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next event",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next hair cut appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with edward",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with miss kathleen",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with ms lawrence",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next trip to kew garde",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 19
+        },
+        {
+          "entity": "Location",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "when is my physio",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "when is my picnic lunch today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "when is samuel available tomorrow",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "when is sports day for the girls",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when is the next dentist appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when is the social",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "when is the wedding tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "when will jordan be free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when's my haircut",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "when's my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "when's my next trip",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "where ' s my meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where ' s my next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where ' s my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where am i going this weekend",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "where am i going tonight",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "where am i meeting austin and john",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where am i on may the twenty first",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where am i tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 11,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "where are my meetings today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where do i go for my meeting tomorrow at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "where do i go tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "where do i have to be next",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where do i have to be today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where do i need to be next",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where do i need to go today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where does my meeting take place",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where i'm doing this weekend",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "where is dinner with abigail liu",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "where is it",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is margot lunch",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "where is meeting tomorrow at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is meeting with shirley",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my 11 am appointment tomorrow happening",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is my 11 am meeting tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is my current meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my dentist appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "where is my eleven o'clock meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where is my first appointment tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is my forth event with brandon friday",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "where is my forth event with christopher on thursday",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 44,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "where is my meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my meeting with kayla",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next appointment with miss doris",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next appointment with olivia",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next dentist appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "where is my next event",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next meeting with ms natalie",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my third shiproom with tiffany",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where is that meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is the meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is the meeting at 11 am tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is the performance review meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow ' s 11 am meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow meeting at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow 's event",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where shall we meet",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "where's my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "which is my next event",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "which weekend am i shopping with sarah",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 6,
+          "endPos": 12
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "which will be my next flight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who ' s in my 1st meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 14,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "who all will be present at the next 5 meetings",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who am i meeting at 10 am tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "who am i meeting for dinner",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "who do i have next",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 14,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "who else is going to the 2pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "who else will be in banking meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "who is attending 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "who is attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is attending the meeting on wednesday",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "who is attending the meetings",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is coming the the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 42,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "who is going to attend the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "who is going to the meeting at 2 pm tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "who is going to tomorrow ' s meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "who is in my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "who is in that meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is in the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is my first meeting with tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who is my morning meeting with",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "who is on my list for the 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "who is participating tomorrow at 2 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who is the 2 pm meeting with",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "who responded to meeting request",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who shall be joining the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "who will attend the meeting at 4",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "who will be at the kids game",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who will be attending picnic",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who will be in banking meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "who's going to be at those two events",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will amber join office meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "will amy be at today ' s meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "will anthony be at the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will bobby shen be at next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "will ethan, yutien and a.j. be at the picnic",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 38,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "will george be in the hr meeting at 1 o' clock",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "will jane be at the 3 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "will jimmy parker be attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will john be at marketing meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "will johnny be at office meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "will nancy be at the morning briefing meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 27
+        },
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "will nicholas be attending the management meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 31,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "will paul be going to the meeting on friday",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "will roy be at our weekly team meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "will teresa be at my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "will thomas be in insurance meeting monday at noon",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "will timothy be coming to the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will tyler be free on friday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "will virginia be attending my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "will zachary be in the finance meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 37
+        }
+      ]
+    }
+  ],
+  "settings": []
+}

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/luisCalendarModelResponse_fr.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/luisCalendarModelResponse_fr.json
@@ -1,0 +1,13545 @@
+{
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "test_Calendar",
+  "desc": "",
+  "culture": "fr-fr",
+  "tokenizerVersion": "1.0.0",
+  "intents": [
+    {
+      "name": "AcceptEventEntry"
+    },
+    {
+      "name": "ChangeCalendarEntry"
+    },
+    {
+      "name": "CheckAvailability"
+    },
+    {
+      "name": "ConnectToMeeting"
+    },
+    {
+      "name": "ContactMeetingAttendees"
+    },
+    {
+      "name": "CreateCalendarEntry"
+    },
+    {
+      "name": "DeleteCalendarEntry"
+    },
+    {
+      "name": "FindCalendarDetail"
+    },
+    {
+      "name": "FindCalendarEntry"
+    },
+    {
+      "name": "FindCalendarWhen"
+    },
+    {
+      "name": "FindCalendarWhere"
+    },
+    {
+      "name": "FindCalendarWho"
+    },
+    {
+      "name": "FindDuration"
+    },
+    {
+      "name": "FindMeetingRoom"
+    },
+    {
+      "name": "GoBack"
+    },
+    {
+      "name": "None"
+    },
+    {
+      "name": "ShowNextCalendar"
+    },
+    {
+      "name": "ShowPreviousCalendar"
+    },
+    {
+      "name": "TimeRemaining"
+    }
+  ],
+  "entities": [
+    {
+      "name": "DestinationCalendar",
+      "roles": []
+    },
+    {
+      "name": "Duration",
+      "roles": []
+    },
+    {
+      "name": "FromDate",
+      "roles": []
+    },
+    {
+      "name": "FromTime",
+      "roles": []
+    },
+    {
+      "name": "Location",
+      "roles": []
+    },
+    {
+      "name": "MeetingRoom",
+      "roles": []
+    },
+    {
+      "name": "Message",
+      "roles": []
+    },
+    {
+      "name": "MoveEarlierTimeSpan",
+      "roles": []
+    },
+    {
+      "name": "MoveLaterTimeSpan",
+      "roles": []
+    },
+    {
+      "name": "OrderReference",
+      "roles": []
+    },
+    {
+      "name": "PositionReference",
+      "roles": []
+    },
+    {
+      "name": "SlotAttribute",
+      "roles": []
+    },
+    {
+      "name": "Subject",
+      "roles": []
+    },
+    {
+      "name": "ToDate",
+      "roles": []
+    },
+    {
+      "name": "ToTime",
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [
+    {
+      "name": "RelationshipName",
+      "subLists": [
+        {
+          "canonicalForm": "aunt",
+          "list": []
+        },
+        {
+          "canonicalForm": "aunts",
+          "list": []
+        },
+        {
+          "canonicalForm": "boss",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "brother-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "brothers",
+          "list": []
+        },
+        {
+          "canonicalForm": "child",
+          "list": []
+        },
+        {
+          "canonicalForm": "children",
+          "list": []
+        },
+        {
+          "canonicalForm": "colleague",
+          "list": []
+        },
+        {
+          "canonicalForm": "colleagues",
+          "list": []
+        },
+        {
+          "canonicalForm": "cousin",
+          "list": []
+        },
+        {
+          "canonicalForm": "cousins",
+          "list": []
+        },
+        {
+          "canonicalForm": "dad",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughter-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "daughters",
+          "list": []
+        },
+        {
+          "canonicalForm": "families",
+          "list": []
+        },
+        {
+          "canonicalForm": "family",
+          "list": []
+        },
+        {
+          "canonicalForm": "father",
+          "list": []
+        },
+        {
+          "canonicalForm": "father in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "father-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "friend",
+          "list": []
+        },
+        {
+          "canonicalForm": "friends",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandchild",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandchildren",
+          "list": []
+        },
+        {
+          "canonicalForm": "granddaughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandfather",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandma",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandmother",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandparent",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandparents",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandson",
+          "list": []
+        },
+        {
+          "canonicalForm": "grandsons",
+          "list": []
+        },
+        {
+          "canonicalForm": "husband",
+          "list": []
+        },
+        {
+          "canonicalForm": "in-laws",
+          "list": []
+        },
+        {
+          "canonicalForm": "kids",
+          "list": []
+        },
+        {
+          "canonicalForm": "mom",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "mother-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "neighbor",
+          "list": []
+        },
+        {
+          "canonicalForm": "neighbors",
+          "list": []
+        },
+        {
+          "canonicalForm": "nephew",
+          "list": []
+        },
+        {
+          "canonicalForm": "niece",
+          "list": []
+        },
+        {
+          "canonicalForm": "parent",
+          "list": []
+        },
+        {
+          "canonicalForm": "parents",
+          "list": []
+        },
+        {
+          "canonicalForm": "partner",
+          "list": []
+        },
+        {
+          "canonicalForm": "siblings",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "sister-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "sisters",
+          "list": []
+        },
+        {
+          "canonicalForm": "son",
+          "list": []
+        },
+        {
+          "canonicalForm": "son in law",
+          "list": []
+        },
+        {
+          "canonicalForm": "son-in-law",
+          "list": []
+        },
+        {
+          "canonicalForm": "step daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "step-daughter",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepfather",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepmother",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepsister",
+          "list": []
+        },
+        {
+          "canonicalForm": "stepson",
+          "list": []
+        },
+        {
+          "canonicalForm": "students",
+          "list": []
+        },
+        {
+          "canonicalForm": "teachers",
+          "list": []
+        },
+        {
+          "canonicalForm": "uncle",
+          "list": []
+        },
+        {
+          "canonicalForm": "uncles",
+          "list": []
+        },
+        {
+          "canonicalForm": "wife",
+          "list": []
+        },
+        {
+          "canonicalForm": "manager",
+          "list": []
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "patternAnyEntities": [],
+  "regex_entities": [],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    },
+    {
+      "name": "number",
+      "roles": []
+    },
+    {
+      "name": "ordinal",
+      "roles": []
+    },
+    {
+      "name": "personName",
+      "roles": []
+    }
+  ],
+  "model_features": [],
+  "regex_features": [],
+  "patterns": [],
+  "utterances": [
+    {
+      "text": "2 hours meeting with ladawn padilla at 5 on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Duration",
+          "startPos": 0,
+          "endPos": 6
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 39
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 44,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "2 pm meeting tomorrow - who else is going",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 0,
+          "endPos": 3
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "2 pm meeting with who",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 0,
+          "endPos": 3
+        }
+      ]
+    },
+    {
+      "text": "a new meeting location find one",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "about how long will the meeting last",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "accept all meetings for christmas party next week.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "accept an appointment",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept dinner",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "accept my meeting at 7pm today",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "accept my meeting at tomorrow 10am",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment from 3pm to 5pm.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 30
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment on january 18th in palace meeting room.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 37
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 42,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "accept the appointment sent by lucas",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the event",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the event for tonight.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "accept the event on feb. 18 in beijing.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 26
+        },
+        {
+          "entity": "Location",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "accept the event sent by yolanda wong.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the meeting held on tomorrow at room 301",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 39,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "accept the meeting organized by jack lauren.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept the meeting with mary and tom held on wednesday",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "accept the meeting with tom chen.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept this appointment with jane and mary on next tuesday.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "accept this event.",
+      "intent": "AcceptEventEntry",
+      "entities": []
+    },
+    {
+      "text": "accept this lunch meeting.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "accept today's event at 3pm.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "accept today's meeting",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "add a meeting with herman to my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "add an appointment on may 8th at shanghai",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 28
+        },
+        {
+          "entity": "Location",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add applied motion to my calendar 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add appt with mickey li for dinner on march 5th at 5 pm at dennys",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 54
+        },
+        {
+          "entity": "Location",
+          "startPos": 59,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "add balboa practice to my calendar at 3 30 today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 38,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "add ballet to my calendar wednesday at five thirty to six thirty pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 49
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 54,
+          "endPos": 66
+        }
+      ]
+    },
+    {
+      "text": "add baseball game on friday to calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "add chicago bulls versus washington wizards to my calendar tomorrow at seven pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 42
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 59,
+          "endPos": 66
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 71,
+          "endPos": 78
+        }
+      ]
+    },
+    {
+      "text": "add choir practice on saturday at 7 pm to my personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 45,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "add choreography to my family calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 23,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "add chorus concert to calendar for may 1st at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add church to personal calendar on sundays at 9",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 14,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "add coffee on august 12th at 2 pm with herman for one hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        },
+        {
+          "entity": "Duration",
+          "startPos": 50,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "add dance on tuesday at four o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 19
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add date night on the 5th at 7pm every month",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment on tuesday june at the 1st clinic",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        },
+        {
+          "entity": "Location",
+          "startPos": 47,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment to my calendar at 3:30 for the 8th of may",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 42,
+          "endPos": 45
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 55,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointment to my calendar tomorrow from 3 to 4:30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 53,
+          "endPos": 53
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 58,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "add dentist appointments to my calendar at 3 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "add dinner to personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "add dinner with mom to personal",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 9
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "add doctors appointment on march 13 at 2 pm at the tricare virginia beach clinic",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "Location",
+          "startPos": 51,
+          "endPos": 79
+        }
+      ]
+    },
+    {
+      "text": "add go shopping with sam meng on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "add haircut to my google calendar tomorrow at 2 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 10
+        },
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 18,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add kane s dr appt to calendar for 3 friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add maple beach to my calendar at 10 on sunday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add me to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "add me to the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "add megan training to calendar on july 4th at 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "add office party on march 8th from 6 p to 9 p",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 37
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "add order cabinets to my calendar today at 2 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "add ow huth middle school meet and greet on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 4,
+          "endPos": 24
+        },
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "add pay credit card to calendar may twentieth",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "add pay pearl fees on my calendar tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "add picture day at school to my calendar for friday, november the 8th from 8 am to 9:30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "Location",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 68
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 75,
+          "endPos": 78
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 83,
+          "endPos": 86
+        }
+      ]
+    },
+    {
+      "text": "add solo gig at lincombe hall on the 7th of march at 8 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "Location",
+          "startPos": 16,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 48
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 53,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add team meeting to my calendar at 10pm with xiaoming wang",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "add ultimate frisbee on sunday at 2 pm for 2 hours",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "Duration",
+          "startPos": 43,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "add vacation to my calendar from july 4th until july 29th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 48,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar at 3 pm on friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar friday from 8 for an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 33
+        },
+        {
+          "entity": "Duration",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar sunday 10 till 5",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add work to calendar thursday 8 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add work to my calendar monday 6 am to 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "add work to my calendar today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "alert attendees meeting is at 8 30",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 16,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "alert attendees of dinner meeting that i will be late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 32
+        },
+        {
+          "entity": "Message",
+          "startPos": 39,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "alert quality control meeting participants that i am 15 minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 28
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "alert quality control meeting participants that the meeting will be 30 minutes later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 28
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 83
+        }
+      ]
+    },
+    {
+      "text": "am i available",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "am i available at 10 am on monday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "am i available on monday at 9 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i available tomorrow at 5 30 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "am i busy on the 6th of february",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i busy on this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "am i busy this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "am i free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "am i free at 5 pm today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "am i free at 7 p . m .",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "am i free for drinks monday at 5",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "am i free for drinks monday at 5 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "am i free for hiking on saturday at 8 am",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "am i free from 3 pm - 10 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 18
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "am i free on monday at 9 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "am i free on saturday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "am i free on the 12th of july",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "am i free to drive with kim on thurs at 3 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "am i free today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "am i free tomorrow 3 pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "am i free tonight",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "am i free tuesday at 7 am",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 10,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "append dad's birthday every july 21st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "appending group meeting next monday at 11am for an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "Duration",
+          "startPos": 48,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "at 10 am do i have a 30 minutes meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 3,
+          "endPos": 7
+        },
+        {
+          "entity": "Duration",
+          "startPos": 21,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "attend the fy19 celebration party sent by daisy chan.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "attend the lunch meeting at 10:30 am.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "attend the meeting held at 3pm next tuesday at the conference center.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 42
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 51,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "attendees who will join the 5 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "back one step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "back the last step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "bing find me a conference room in the bravern this afternoon",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 38,
+          "endPos": 44
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "book a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "book a meeting",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "book blue meeting room",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "book the conference room for thursday at one i want to meet with benjamin",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "bring forward my 4 o'clock appointment 2 hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 25
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "call conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call genpact conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call harris conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call into conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call into marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "call into meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "call the morning breifing conference number",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "call the weekly marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "can you cancel the 1st one",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 19,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "can you change it to 5 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "can you check my dad 's calendar for free time this week",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 47,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "can you go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "can you move this appointment to 5pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "can you reserve room 258 right away",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "can you show me the time remaining before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "can you tell me about master chief",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "can you tell me if my husband is free on sunday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "can you tell me something about shakespeare",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "cancel 1 pm staff meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 10
+        },
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "cancel all events",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel appointment today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "cancel appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel calendar entry",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel dinner",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "cancel doctor ' s appointment monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "cancel event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel event tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "cancel lunch next wednesday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "cancel meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel meeting with abigail 3 pm today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "cancel meeting with bob marlon 3pm today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "cancel my adventureworks trip to seattle",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "Location",
+          "startPos": 33,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "cancel my appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my appointment at 9 pm",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "cancel my appointment for october 4",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "cancel my driving lesson tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "cancel my event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel my meeting at shanghai on monday at 10 am",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "cancel my next appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "cancel my singing appointment on monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "cancel my three o'clock appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "cancel that appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel that meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the group meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "cancel the meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the meeting with julie",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel the pickup food from ted",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "cancel the untitled event on may twenty eighth",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "cancel this meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "cancel today ' s appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "cancel tomorrow ' s plan",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change 10 am meeting to start 20 minutes later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 30,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "change 4pm lunch appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 9
+        },
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change 5pm appointment 1 hour earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 7,
+          "endPos": 9
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 23,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "change an appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change big event to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 15
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change dentist appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change dentist appt to an hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 18
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 23,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "change developmental agenda for lunch tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change it to 5pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 13,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change location",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 7,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change lunch appt to 2",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 16
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 21,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "change lunch date from 11 - 12 to 12 - 1 30",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "change marathon training from 8:00am to 1:00pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 40,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change marketing meeting from every tuesday to every wednesdays",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 42
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 47,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "change meeting from 2-3pm to 4-5pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 24
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 29,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "change meeting from 2pm-3pm to 4pm-5pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 31,
+          "endPos": 33
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 37
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my 11pm appointment's location to cal anderson park",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "SlotAttribute",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "Location",
+          "startPos": 41,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "change my 3pm event to 4pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 6pm event to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 7 30 pm appointment to 8 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "change my 7pm event to 6pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change my 8 till 9 appointment to 11 till 12",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 10
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 17
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my 9 30 till 10 30 appointment to 9 30 till 5",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 44
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 51,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "change my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change my dentist appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "change my dentist appointment from 3:30 to 4",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 43,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "change my meeting at night to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "change my next meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "change my schedule",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "change my ten am appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change my vacation from ending on friday to monday",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 39
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 44,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "change recital to start half an hour earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 13
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "change shave tomorrow 8 30",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 13,
+          "endPos": 20
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "change the appointment ending at 4 to end at 5 instead",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 33
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "change the end date of my trip from the 3rd to the 4th",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 42
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 51,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "change the end time of my 3 o'clock meeting to 3 30 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "change the location of my singing appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 18
+        },
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "change the time",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "change the time to eleven thirty am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 19,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "change the title of my 11am appointment to soccer practice",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 26
+        },
+        {
+          "entity": "Subject",
+          "startPos": 43,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "change the title of my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 11,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "change this appointment's location",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "change thursday team meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "change time",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "SlotAttribute",
+          "startPos": 7,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "change today 's meeting from 6pm to tomorrow 9am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "change today 's meeting from 6pm to tomorrow 9pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "change tomorrow ' s appointment from 10am to wednesday at 9 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 7,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 37,
+          "endPos": 40
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 45,
+          "endPos": 53
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 58,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "check janice 's calendar for this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "check kronos calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check meeting room for tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "check my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check my family calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 9,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "check my mom's schedule",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "check on the time to see when i go to school and pick up luca",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "clear all my appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear all of my appointments",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear all of my appointments today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "clear all the appointments from my calendar for today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 48,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "clear my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear my calendar for january 29th",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "clear my schedule",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "clear my schedule for tomorrow",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "clear my schedule today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "conference join",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to 10 00 conf call with bryan",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "connect me to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to conference call with debra",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "connect me to the budget meeting conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "connect me to the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me to the marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "connect me with conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect me with my 2 o clock meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "connect to conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "connect to conference call now",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "connect to weekly marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "create a calendar appointment at 3:30 tomorrow for half an hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        },
+        {
+          "entity": "Duration",
+          "startPos": 51,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "create a event with eden roth at 4pm today for 30 mins",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 41
+        },
+        {
+          "entity": "Duration",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "create a meeting at 7:00pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "create a meeting at 8am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "create a meeting for tomorrow 6pm with lucy chen",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "create a meeting with tom34@outlook.com",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "create appointment for 30 minutes",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Duration",
+          "startPos": 23,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "create appointment from tuesday to wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 30
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "create calendar : tomorrow morning from 9 to 11 at 1103 room for internal meeting",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 46
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 51,
+          "endPos": 59
+        },
+        {
+          "entity": "Subject",
+          "startPos": 65,
+          "endPos": 80
+        }
+      ]
+    },
+    {
+      "text": "decline my meeting on monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "delay the meeting event by 1 hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "delay the next meeting by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 26,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "delete an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete birthday calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "delete calendar event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete event",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete my schedule",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete my schedule for today",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "delete that appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the 1st one from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "delete the appointment with jeffrey",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the appointment with mom",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete the scheduled meeting with zachary",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "delete this appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "detail about tomorrow's meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "detailed information about the next meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "details about the meeting with grace",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "details about the meeting with karen and tom",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "dial into conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "dial marketing meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "did hellen come to 3 pm's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "did mark sign up to the tomorrow's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "did martin come to today's meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "discard the appointment with george",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "discard the meeting",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "display olivia 's availability",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "do i have any appointments today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "do i have any free time this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "do i have any meetings today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "do i have any spare time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "do i have anything from 11 to 2",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 25
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "do i have anything on wednesday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "do i have anything today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "drop my appointment for monday",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "duration of machine learning talk",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "edit calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "extend meeting from 9 am to 12 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find a free meeting room for next tuesday",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "find a meeting about group meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "find a meeting about plan",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "find a meeting at 7pm from melissa",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from darren about status update",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from deborah about team session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 34,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "find a meeting from donna",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find a meeting subject daily meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with subject weekly report",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with title second lesson from amanda",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "find a meeting with title sharing from steven",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "find an available meeting room from 3 to 5 tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "find attendees who will attend 8 o ' clock meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "find me an empty conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "find me the meetings at 6",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "find me the meetings at 9 o'clock",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find the meeting around 5 to 8 pm",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "find the meeting around 5 to 8pm",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "find the meeting with judith",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find the meeting with timothy",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "find the meetings mary",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "find the next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "get me on the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "get to my next event",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "give me details of the next appointment",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 23,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back a step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back one step",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back please",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "go back to the last step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "go back to the main menu",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "go back to the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "hello world",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "help me to book a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "help me to book a meeting room from 10 am to 3 pm",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "help me to book the room 102",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "help me to find a meeting room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "how long do i have for lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how long is going to last that meeting",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how long is it until the 14th of march",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how long is my 4 o'clock meeting",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how long is my dentist appointment",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "how long is my facial time",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how long is my lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how long is my meeting at 4",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "how long is the event",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how long is the movie jurassic world",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how long till disneyland paris",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "how long till my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "how long till the next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how long until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 18,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "how long until the social",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "how long will i wait for the next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "how long will my dentist appointment last",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how many days is it until christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "how many days left until the opening ceremony",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many days till april",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how many days till christmas",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how many days until june the fifteenth",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how many days until june the fifteenth 2019",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "how many days until march twenty six",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "how many days until my doctor ' s appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many days until thanksgiving",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "how many days until the 10th of december",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "how many hours",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how many hours left till the closing ceremony",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "how many hours remaining till next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "how many hours until my doc appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how many minutes before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 27,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "how many minutes free do i have before next scheduled appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "how much longer do i have before pick up luca from school",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "how much longer do i have until pick up luca from school",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "how much longer until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much longer until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 25,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much time as of now is set for the bill payments",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 39,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "how much time as set for the bill payments",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "how much time before lunch",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how much time before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "how much time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "how much time between schedule thursday meetings next week",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time do i have before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have before my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 34,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have for a lunch break today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 40
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have free until my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 38,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have to take back the movie",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until i have to meet with michael",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 40,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until i start the meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until my doc appt",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "how much time do i have until my meeting with larry",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time do i have until my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "how much time do we have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "how much time does my meetings take up",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "how much time for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "how much time is there before office meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "how much time is there for errands during my lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 33
+        },
+        {
+          "entity": "Subject",
+          "startPos": 45,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "how much time open today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time out on lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "how much time remaining till next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 29,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "how much time to i have for lunch today",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "how much time until my meeting with lori",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "how much time until next scheduled appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time until noon",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "how much time will i have to pick up groceries",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "how's the weather today",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "i need to check the previous appointment",
+      "intent": "ShowPreviousCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need to delete this appointment from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "i need to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i need to join conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "i need to join the conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "i need to know about my date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need to know about my meeting",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "i need to know about my next appointment",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "i need you to find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "i need you to provide me the details of the meeting i have scheduled with my colleague amanda",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "i want to delete an appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "i want to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i want to know the time left for my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "i want to meet with bruce lee so book the conference room for thursday at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 62,
+          "endPos": 69
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 74,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "i want to meet with donna please book for thursday the conference room at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 74,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "i want to take a look at the attendee list",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "i would like to go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "i would like to know if my mother is available today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 47,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "i'll attend the meeting at 2pm tomorrow in room 304",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "MeetingRoom",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "i'll attend the meeting this afternoon.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "i'll attend this upcoming event in redmond.",
+      "intent": "AcceptEventEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 35,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "i'm looking for a conference room",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "is bruce young attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "is carolyn available tuesday afternoon",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "is charles wong going to be at the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "is debra available on saturday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is gerald busy this weekend",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "is it going to last long",
+      "intent": "FindDuration",
+      "entities": []
+    },
+    {
+      "text": "is joe going to be at the next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is madison busy",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "is my lunch long enough for errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "is nicholas available friday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "is raymond free on monday evening",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "is rebecca busy thursday at 4",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "is russell free on friday at 4pm",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "is saturday free",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 3,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "is theresa free october 9th",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "is this room busy at 5 pm",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "is this room busy tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "is victoria participating next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "is virginia free on monday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "join budget conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "join conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join conference call",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join current budget conf call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "join current conference",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join current conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join lync meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join meeting now",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 13,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "join my meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join my next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "join next link meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "join next meeting on link",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "join the budget meeting conference call",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "join the conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join the meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "join the next lync meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "Subject",
+          "startPos": 14,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "let 5 pm meeting starting at 3",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 29,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "let me see who will attend party planning meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "let next meeting starting at 10am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "let's find a new meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "link join my next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "link join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "list the attendees of the next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 26,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "list the participants for the 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "locate another meeting location",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "locate the next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "location of 11 am meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "location of the next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "look up my next appointment for me",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "lync join next meeting",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "make appointment for 5 30 tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "make appointment for 7 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "make appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make appointment on monday.",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "make appointment on personal calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "make appointment to play squash on thursday at 7 20",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 30
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "make appointment to see doctor culver august the 22nd 2013 1 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 36
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 57
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 59,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "make appointment with tom roth.",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make appt for 3 pm on christmas",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "make me a calendar event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me a dentist appointment wednesday at two forty five",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me an appointment for next weekend",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment for ten forty next monday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment for the next week thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "make me an appointment on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "make me an appointment tomorrow at 2 30 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "make next meeting to start 1 hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "make the appointment ending at 2 go until 4 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "make the meeting ending at 10 go until 11",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 28
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "make the meeting to start 1 hour later",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 26,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "make the meeting to start 40 minutes earlier",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 26,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "march 15 dinner at refectory at 6 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 0,
+          "endPos": 7
+        },
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "Location",
+          "startPos": 19,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "meet ming wang for lunch on tuesday at noon",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "meet with a.j. lee saturday at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "meet with carol lee at home on march 10th at 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 23,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "meeting at 3 pm today locations",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "meeting room changed to new location send to meeting attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "meeting will start soon remind everybody involved",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "meeting with ben randie tomorrow at noon",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "meeting with ellen fung on monday at 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 37,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "meeting with jia li monday 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "meeting with morrison sun at 2 pm saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "meeting with morrison yang at 4",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "message colleagues that meeting needs to be moved to 8 : 30 am",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 24,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "message everyone advising that i will be late to the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 31,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "message nancy and tell him to postpone the meeting because i ' m going to be 30 minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 30,
+          "endPos": 91
+        }
+      ]
+    },
+    {
+      "text": "minutes in lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "modify the meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "modify the second meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "move 3pm meeting to 4pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 5,
+          "endPos": 7
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 20,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "move appt with rebecca to next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "move meeting from 9pm-10pm to 8pm-9pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 25
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 30,
+          "endPos": 32
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 36
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 38,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "move my 1 pm appointment up 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 28,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "move my 10 past 10 doctor ' s appointment to 10",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 40
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 45,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "move my 10pm meeting to 9pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 24,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "move my 12 pm meeting to 2",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my 4 pm to 5 pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 16,
+          "endPos": 19
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 21,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my 9 am doctor ' s appointment to 10 am",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "move my 9pm meeting to 8pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 10
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 23,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "move my meeting back by an hour",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 24,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "move my meeting to 6pm from 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 19,
+          "endPos": 21
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "move my meeting up by half an hour",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting out by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 28,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting out thirty minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 25,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting up by 10 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 27,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "move my next meeting up by 30 minutes",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 27,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "move my text meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "move my twelve p . m . meeting forward two hours",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 21
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 39,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "move my twelve p. m. thirty minutes up",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 8,
+          "endPos": 19
+        },
+        {
+          "entity": "MoveEarlierTimeSpan",
+          "startPos": 21,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "move shoe appointment to tuesday at one",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 5,
+          "endPos": 20
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 25,
+          "endPos": 31
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "my 9 o ' clock meeting can ' t start until 9 15 can you let everyone know",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "my next meeting with emily is when",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 3,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "new appointment for tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "new appointment in calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new appointment in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new appointment next wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "new appointment today 6 pm see dead people",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 20
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 25
+        },
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "new appointment tomorrow at 3 pm at sunken",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "Location",
+          "startPos": 36,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "new calendar appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar entry",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new calendar item",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "new location for meeting this afternoon let others attendees know meeting is now in room 100",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 38
+        },
+        {
+          "entity": "Message",
+          "startPos": 66,
+          "endPos": 91
+        }
+      ]
+    },
+    {
+      "text": "next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 0,
+          "endPos": 3
+        }
+      ]
+    },
+    {
+      "text": "nokia conference room join",
+      "intent": "ConnectToMeeting",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 0,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "notify all attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "notify all attendees about the change",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "notify attendees of office meeting that i will be a little later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 40,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "notify diana that i ' ll be late to our meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 18,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "notify friday's 2 pm that we are cancelling the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 7,
+          "endPos": 12
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "notify kimberly that i will be late for our 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 21,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "notify noah that our meeting is pushed back 30 minutes",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 17,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "notify others that i am going to be late to meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 19,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "notify people of meeting on tue that it will begin 15-30 min later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 28,
+          "endPos": 30
+        },
+        {
+          "entity": "Message",
+          "startPos": 37,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "obtain the appointment with frank",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "ok find out if that is possible by sending a meeting change notification to all attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": []
+    },
+    {
+      "text": "on saturday at 7 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 3,
+          "endPos": 10
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "over run of time in confer room - all attendees to be notified of meeting being moved to next room - will explain why later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 66,
+          "endPos": 97
+        }
+      ]
+    },
+    {
+      "text": "personal calendar 5/1/2013 meet mom for yard sale",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 0,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 25
+        },
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "place an appointment in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "please advise i am late for 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 14,
+          "endPos": 22
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "please alert 3 o ' clock meeting attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 13,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "please alert attendees meeting is at 8:30",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "please alert those attending the meeting that i am running a few minutes late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 46,
+          "endPos": 76
+        }
+      ]
+    },
+    {
+      "text": "please go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "please inform colleagues running late and meeting half hour later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "please inform colleagues we will be meeting at 8 : 30 due to being late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "please inform joshua that i will be late for our meeting today",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 26,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "please inform meeting attendees that i am running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 37,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "please inform the thomas that i will be late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 30,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "please inform work contact group that i am running late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 38,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "please let all in work group know meeting to start at 9 15",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 34,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "please let them know i'm late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "please move this to 3 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "please notify everyone i ' m running late to the 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "please notify george that i will be late for the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 26,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "please open my date with stephanie and tell me about it",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "please remind the attendee that i am running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 32,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "please return back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "please show me how much time i have to run errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 39,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "please tell me how long i have for lunch",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "postpone my 4 pm meeting today until 5 pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 37,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "postpone my four p. m. meeting today until five p. m.",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 21
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 31,
+          "endPos": 35
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 43,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "provide the time change for the meeting to all participants",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 8,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "push my trip july 16th out 5 days",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 21
+        },
+        {
+          "entity": "MoveLaterTimeSpan",
+          "startPos": 27,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "put anniversary on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "put an appointment tomorrow morning",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put captains in my calendar for saturday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "put dance on my calendar for monday 7 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "put dance on my calendar from 6 to 7",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 8
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 35,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "put delainey on to doctor reddy on october 20th at 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 30
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "put dental appointment on my calendar saturday march 22nd at twelve pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 56
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 61,
+          "endPos": 69
+        }
+      ]
+    },
+    {
+      "text": "put dentist appointment in my calendar for tomorrow at one pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 50
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 55,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "put dentist appointment in my calendar tuesday 2 45 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 45
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "put dentist on my calendar for this thursday at 10 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 10
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "put doctor s appointment in my calendar for 5 forty next thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 23
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 50
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 52,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "put eye doctor appointment saturday at 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 25
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "put hair appointment on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "put insanity on my calendar at 6 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put jason work on my calendar thursday 9 am to 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "put julie camil in my calendar for tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "put mathematics paper one on tuesday 13",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "put shopping day on april 1st at 10 am on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "put swimming in my calendar tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "put swimming tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 11
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "put tennis game for friday at 1 on calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "put test appointment in my calendar tomorrow at 7",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 19
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "put walk sing appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "put work on my calendar tomorrow from 8 30 to 5 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 38,
+          "endPos": 41
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "put yoga on my calendar for mondays and wednesdays at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 4,
+          "endPos": 7
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "remind all attendees of tomorrow ' s lunch that we have changed the venue",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 24,
+          "endPos": 31
+        },
+        {
+          "entity": "Subject",
+          "startPos": 37,
+          "endPos": 41
+        },
+        {
+          "entity": "Message",
+          "startPos": 48,
+          "endPos": 72
+        }
+      ]
+    },
+    {
+      "text": "remove dentist appointment",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "remove final tutoring from my calendar",
+      "intent": "DeleteCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "reschedule appointment with stephanie at next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "reschedule appointment with stephanie to next week",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 41,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "reschedule meeting",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "reschedule my 3:30 dentist appointment to 4",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "reschedule my 3:30 dentist appointment today for 4pm tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 14,
+          "endPos": 17
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 43
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 49,
+          "endPos": 51
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 53,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258 now",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve room 258 right away",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "MeetingRoom",
+          "startPos": 8,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "reserve the conference room for 1 pm thursday because i need to have a meeting with amber",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "reserve the conference room for 3pm tomorrow",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "return",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return please",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "return to previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "return to the previous step",
+      "intent": "GoBack",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "room 100 is location for this afternoon ' s meeting please notify others",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 19
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "running late for meeting - notify others",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "running late for the board meeting alert catherine daniel and all the other attendees",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 11
+        },
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "running late to my meeting please let jennifer know",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 0,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "schedule a breakfast meeting at 8 am tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule a buisness lunch for my department at pf chang on wednesday at 11 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 42
+        },
+        {
+          "entity": "Location",
+          "startPos": 47,
+          "endPos": 54
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 59,
+          "endPos": 67
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 72,
+          "endPos": 79
+        }
+      ]
+    },
+    {
+      "text": "schedule a calendar event for my sister",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a chiropractors appointment on july 7th at 4 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "schedule a dental appointment tomorrow afternoon at five thirty pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule a dentist appointment for tomorrow night at 7 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "schedule a dinner for tonight at 8 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctor s office appointment for march 12th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 52
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctors appointment at 15 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a doctors appointment with madden on march 12th at 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 55
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 60,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "schedule a lunch date with mom every tuesday at noon for the next 5 weeks",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 51
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 61,
+          "endPos": 72
+        }
+      ]
+    },
+    {
+      "text": "schedule a lunch meeting with my lead",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "schedule a massage on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 17
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a meeting for next thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting for this friday 11 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 33
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting for tomorrow at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting on nov. 3 from 3-4pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting with andy",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule a meeting with han lu 8 am next tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule a meeting with ryan from 3-4pm on october 25th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 54
+        }
+      ]
+    },
+    {
+      "text": "schedule a run at the lake with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "Location",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "schedule a shopping trip with shawntia on friday at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "schedule a soccer game for next friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "schedule a vet appointment at 9 am on saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 33
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule a visit to the market this saturday at 10 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "schedule a workout with madden to my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for 10 30 in the morning on january 20 1st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 52,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for 9 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment for me on tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for me tomorrow at 3 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for my mom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment for noon tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for one o clock today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for saturday at 8 dinner with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 40
+        },
+        {
+          "entity": "Subject",
+          "startPos": 42,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for saturday at one 30 pm to measure house",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 48
+        },
+        {
+          "entity": "Subject",
+          "startPos": 53,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for thursday at 3 pm haircut",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 43
+        },
+        {
+          "entity": "Subject",
+          "startPos": 45,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment for tomorrow at one o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 40,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment from june 18th to june 20th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 37
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 42,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on monday from noon to 4 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment on november 5th at 3 30",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on october 31st",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment on thursday october second at 8 forty am mom s medical appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 49
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 63
+        },
+        {
+          "entity": "Subject",
+          "startPos": 65,
+          "endPos": 89
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to call meredith at 12",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to groom my dogs at petco on friday at 6 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 39
+        },
+        {
+          "entity": "Location",
+          "startPos": 44,
+          "endPos": 48
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 53,
+          "endPos": 58
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 63,
+          "endPos": 66
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment to see cj on thursday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an appointment with madden at 10 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden for wednesday the 20 4th at 9 30 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 59
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 64,
+          "endPos": 70
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden today at 2 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with madden tomorrow at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule an appointment with mom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule an event for scrum with madden at 10 am saturday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 26
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 43,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "schedule an event for the 5th of july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule an event on the calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "schedule appointment at eight p m tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 32
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule appointment for madden account payment",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 32,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "schedule appointment yearly check up friday march one 10 am one hour",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 35
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 52
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 54,
+          "endPos": 58
+        },
+        {
+          "entity": "Duration",
+          "startPos": 60,
+          "endPos": 67
+        }
+      ]
+    },
+    {
+      "text": "schedule art show on calendar for noon on march 6th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 34,
+          "endPos": 37
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 42,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule ben baig for saturday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 29
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "schedule camping for friday to sunday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 26
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule college for tomorrow at 5 am",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule conference room with mary cooper for thursday at one",
+      "intent": "FindMeetingRoom",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 53
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 58,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "schedule dentist appointment with madden for may the 20th at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 45,
+          "endPos": 56
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 61,
+          "endPos": 64
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner on the 8th at 6 thirty p m",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner with madden at 6 pm on june 4th at buffalo wild wings",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "Location",
+          "startPos": 51,
+          "endPos": 68
+        }
+      ]
+    },
+    {
+      "text": "schedule dinner with madden every friday at 5 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "schedule dry cleaning pick up at three thirty pm today",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 47
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 49,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule group meeting with madden on march 3rd at 4 00 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 38,
+          "endPos": 46
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 51,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "schedule hair appointment on monday at 2 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 34
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "schedule holiday for the thirty first of july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "schedule holiday on the 31st july",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 15
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with madden for 11 30 am on wednesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 43,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with madden on tuesday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "schedule lunch with pura at noon on wednesday may 20 minutes",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 13
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 28,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 48
+        },
+        {
+          "entity": "Duration",
+          "startPos": 50,
+          "endPos": 59
+        }
+      ]
+    },
+    {
+      "text": "schedule mechanics exam at 12 pm on friday",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 27,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "schedule miranda s graduation from 11 to 3 on may 28th",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 41,
+          "endPos": 41
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 46,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule my vacation from today 5pm to tomorrow 5pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 30
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 39,
+          "endPos": 46
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 48,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "schedule therapy appointment at 8 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 32,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "schedule wanda s graduation for saturday at 11 o clock",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "schedule wedding anniversary on friday evening",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 39,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "schedule work for 7 am tomorrow",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 18,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "schedule work on thursday the thirty first from three to seven thirty",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 12
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 48,
+          "endPos": 52
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 57,
+          "endPos": 68
+        }
+      ]
+    },
+    {
+      "text": "schedule yoga class from 2 pm to 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 18
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 28
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "search a meeting subject project proposal rehearsal",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 25,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "search jesse 's calendar for availability",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "search the meeting with title employee orientation",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "send a message out to cancel my 3 pm meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 22,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "send a message to johnny and jessie that our meeting today will be later by 30 minutes",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 41,
+          "endPos": 85
+        }
+      ]
+    },
+    {
+      "text": "send a message to the meeting attendees that the meeting will now start at 8 30 am",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 45,
+          "endPos": 81
+        }
+      ]
+    },
+    {
+      "text": "send a notice to douglas the first will be attending the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 25,
+          "endPos": 63
+        }
+      ]
+    },
+    {
+      "text": "send a notice to paul that xu wen will attend the meeting",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 27,
+          "endPos": 56
+        }
+      ]
+    },
+    {
+      "text": "send a text to the people going to the meeting that the location has changed",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 52,
+          "endPos": 75
+        }
+      ]
+    },
+    {
+      "text": "send reminder of 9 am meeting to all participants 15 minutes later",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "ToTime",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "Message",
+          "startPos": 50,
+          "endPos": 65
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with my sister in my main calendar.",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 43,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with pura",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an appointment with pura tomorrow at 3 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 39
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 44,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "set up an appointment with tom",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an event",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up an event in my calendar",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up meeting with pura for every tuesday at 1 pm",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "set up meeting with thomson",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "set up the appointment",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "should you schedule to after lunch",
+      "intent": "CreateCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "show jean calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me brenda 's schedule for friday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "show me heather 's calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me my calendar for monday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "show me my google calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "DestinationCalendar",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "show me my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "show me my schedule tonight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "show me the calendar at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "show me the confirmed attendees",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "show me the duration of the weekly sharing",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting about briefing session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting about online session",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "show me the meeting with paul",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "show me the place of the work smart training",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 25,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "show me the previous meeting with tiffany",
+      "intent": "ShowPreviousCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "show me victoria 's calendar for monday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "show me where my next appointment is",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "show me who will attend family gathering",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 24,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "show me who will be at planning meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 47
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 52,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "show meeting participants",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "show my schedule at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "show time before next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "start meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start my conference",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start my meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "start the meeting",
+      "intent": "ConnectToMeeting",
+      "entities": []
+    },
+    {
+      "text": "tell attendees i am late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "tell everyone the meeting is now in room 204",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "Message",
+          "startPos": 14,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "tell me about my meeting today",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "tell me about my next meeting",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "tell me about my planned trip",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "tell me about my schedule with afternoon",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "tell me about my sunday schedule",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "tell me all about dinner date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "tell me how long is my 4 oclock meeting",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "tell me how long is today ' s lunch break",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "Subject",
+          "startPos": 30,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "tell me how much free time i have before next appt",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 41,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "tell me how much time before my next meeting",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 32,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "tell me the duration of the product introducation",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 28,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "tell me the events scheduled at calendar constitution hall",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "Location",
+          "startPos": 41,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "tell next meeting that i'm running late",
+      "intent": "ContactMeetingAttendees",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 5,
+          "endPos": 8
+        },
+        {
+          "entity": "Message",
+          "startPos": 23,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "the next appointment after that",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "this meeting should be changed to tomorrow",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "ToDate",
+          "startPos": 34,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "time before my next appointment",
+      "intent": "TimeRemaining",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "time for lunch errands",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "time remaining",
+      "intent": "TimeRemaining",
+      "entities": []
+    },
+    {
+      "text": "today ' s lunch will be how long",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 0,
+          "endPos": 4
+        },
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "total lunch break time today please",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 6,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "update appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update lunch appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "update meeting from 8am-12pm to 7am-11am today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 22
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 32,
+          "endPos": 34
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 36,
+          "endPos": 39
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 41,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "update my appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "update my calendar",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "update my calendar from 2 pm to 4 pm today",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 27
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 32,
+          "endPos": 35
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 37,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "update my calendar from 6pm to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 26
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 31,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "update my camping appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "update my next appointment",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "update my tomorrow 6pm meeting to 7pm",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 19,
+          "endPos": 21
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 34,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "update party",
+      "intent": "ChangeCalendarEntry",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "view emily calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "view ethan 's calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "we make an appointment for me",
+      "intent": "CreateCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "we should go back",
+      "intent": "GoBack",
+      "entities": []
+    },
+    {
+      "text": "what ' s after that on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s going on this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "what ' s happening today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what ' s in my calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s my 1st appointment tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what ' s my 1st meeting tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what ' s my next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "what ' s my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule like tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "what ' s my schedule tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s next on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my calendar",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s on my calendar for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my schedule",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what ' s on my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what ' s on my schedule today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what ' s the meeting today between 10 and 12:00",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 25
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 35,
+          "endPos": 36
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 42,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "what allotted time is for hair dresser",
+      "intent": "FindDuration",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 26,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what am i doing next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what am i doing on june ninth",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what am i doing tonight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "what appointments do i have tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what are my appointments for this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what are my appointments today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "what are my meetings at night",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what are the next 3 events on my calendar",
+      "intent": "ShowNextCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what are the particulars for the picnic next week",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 33,
+          "endPos": 38
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 40,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "what are the plans for the dinner date with stephanie",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 27,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what can you do",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what day is lego land scheduled for",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "what did the sister say about meeting on sunday",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 41,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "what do i have for today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what do i have from 2 to 4 on saturday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 20
+        },
+        {
+          "entity": "ToTime",
+          "startPos": 25,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what do i have from monday through wednesday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 25
+        },
+        {
+          "entity": "ToDate",
+          "startPos": 35,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "what do i have going on today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have next",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "what do i have on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what do i have on sunday",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 18,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "what do i have this afternoon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 15,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have to do this afternoon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what do i have to do tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what do i have tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "what have i got on tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what i am doing next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what i'm doing this weekend",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what is anna 's availability next tuesday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "what is destiny ' s event for next week",
+      "intent": "FindCalendarDetail",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "what is henry doing on monday at noon",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "what is logan 's schedule this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what is my 1st meeting today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is my meeting with ming xu about",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is my next appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what is my next event",
+      "intent": "ShowNextCalendar",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "what is my schedule for tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what is my schedule tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is next in calendar",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 8,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "what is on my calendar today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is that meeting with ashley and jane berlin about",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is the location of next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 24,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what is the meeting with daniel robert regarding",
+      "intent": "FindCalendarDetail",
+      "entities": []
+    },
+    {
+      "text": "what is the schedule before that",
+      "intent": "FindCalendarEntry",
+      "entities": []
+    },
+    {
+      "text": "what is the time now",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what is timothy doing today",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "what meet rooms do i have",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "what meetings do i have next week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what the place of the weekly meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "what time do i have work tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 23
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what time do i work today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what time is beth over today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 21
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "what time is my cooking class tonight",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 30,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "what time is my first meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 16,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "what time is my last meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "what time is my meeting today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "what time is my mobile devices exam tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "what time is my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 16,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "what time is my wallet team meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "what time is oshwin's interview",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "what time is the ice cream social",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "what time is the trade show this saturday",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 26
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "what was my first appointment",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "what's going on this week",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what's happening tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "what's my first meeting tomorrow",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "what's my name",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what's the weather today",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "what's your name",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "when ' s my 1st appointment tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 28,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when ' s my 1st meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when ' s my doctor ' s appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next doctors appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when ' s my next meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "when am i free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when am i free today",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "when am i watching england",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "when and where is my next meeting",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when do i break up from school",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 17
+        },
+        {
+          "entity": "Location",
+          "startPos": 24,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "when do i have exam",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "when do i have free time today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "when do i meet with charles",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when do i work tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "when is aaron free tomorrow",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "when is bryan free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when is concert on my calendar",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is dylan available",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when is ifeomas basketball today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 25
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 27,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when is lunch with frank",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "when is my 1st meeting tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 13
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 23,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "when is my appointment with willie",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my daily stand up with ethan",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when is my fifth kick-off",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 11,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "when is my meeting with kenneth",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my meeting with martha and deborah",
+      "intent": "FindCalendarWhen",
+      "entities": []
+    },
+    {
+      "text": "when is my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next appointment with douglas",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next event",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next hair cut appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with edward",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with miss kathleen",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next meeting with ms lawrence",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "when is my next trip to kew garde",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        },
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 19
+        },
+        {
+          "entity": "Location",
+          "startPos": 24,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "when is my physio",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "when is my picnic lunch today",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 11,
+          "endPos": 22
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 24,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "when is samuel available tomorrow",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 25,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "when is sports day for the girls",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 8,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "when is the next dentist appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "when is the social",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "when is the wedding tomorrow",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 18
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 20,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "when will jordan be free",
+      "intent": "CheckAvailability",
+      "entities": []
+    },
+    {
+      "text": "when's my haircut",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "when's my next appointment",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "when's my next trip",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 10,
+          "endPos": 13
+        },
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "where ' s my meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where ' s my next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where ' s my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where am i going this weekend",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "where am i going tonight",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "where am i meeting austin and john",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where am i on may the twenty first",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where am i tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 11,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "where are my meetings today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where do i go for my meeting tomorrow at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 41,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "where do i go tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "where do i have to be next",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where do i have to be today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where do i need to be next",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where do i need to go today",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where does my meeting take place",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where i'm doing this weekend",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "where is dinner with abigail liu",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "where is it",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is margot lunch",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 9,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "where is meeting tomorrow at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 17,
+          "endPos": 24
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is meeting with shirley",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my 11 am appointment tomorrow happening",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is my 11 am meeting tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is my current meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my dentist appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 12,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "where is my eleven o'clock meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 12,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where is my first appointment tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is my forth event with brandon friday",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "where is my forth event with christopher on thursday",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 44,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "where is my meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my meeting with kayla",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is my next appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next appointment with miss doris",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next appointment with olivia",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next dentist appointment",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        },
+        {
+          "entity": "Subject",
+          "startPos": 17,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "where is my next event",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my next meeting with ms natalie",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "where is my third shiproom with tiffany",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 12,
+          "endPos": 16
+        },
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "where is that meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is the meeting",
+      "intent": "FindCalendarWhere",
+      "entities": []
+    },
+    {
+      "text": "where is the meeting at 11 am tomorrow",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 24,
+          "endPos": 28
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "where is the performance review meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 13,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow ' s 11 am meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 22,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow meeting at 11 am",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 29,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "where is tomorrow 's event",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 9,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "where shall we meet",
+      "intent": "FindMeetingRoom",
+      "entities": []
+    },
+    {
+      "text": "where's my next meeting",
+      "intent": "FindCalendarWhere",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "which is my next event",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 12,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "which weekend am i shopping with sarah",
+      "intent": "FindCalendarWhen",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 6,
+          "endPos": 12
+        },
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "which will be my next flight",
+      "intent": "FindCalendarEntry",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who ' s in my 1st meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 14,
+          "endPos": 16
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "who all will be present at the next 5 meetings",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 31,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who am i meeting at 10 am tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 24
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 26,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "who am i meeting for dinner",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 21,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "who do i have next",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 14,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "who else is going to the 2pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 25,
+          "endPos": 27
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "who else will be in banking meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 20,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "who is attending 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 17,
+          "endPos": 20
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "who is attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is attending the meeting on wednesday",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 32,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "who is attending the meetings",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is coming the the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 30,
+          "endPos": 37
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 42,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "who is going to attend the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 35,
+          "endPos": 42
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 47,
+          "endPos": 50
+        }
+      ]
+    },
+    {
+      "text": "who is going to the meeting at 2 pm tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "who is going to tomorrow ' s meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 16,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "who is in my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 13,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "who is in that meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is in the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who is my first meeting with tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "PositionReference",
+          "startPos": 10,
+          "endPos": 14
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 29,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who is my morning meeting with",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "who is on my list for the 2 pm meeting tomorrow",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 26,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 39,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "who is participating tomorrow at 2 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 21,
+          "endPos": 28
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 33,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "who is the 2 pm meeting with",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 11,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "who responded to meeting request",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "who shall be joining the meeting tomorrow at 2 pm",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 40
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 45,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "who will attend the meeting at 4",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 31,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "who will be at the kids game",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who will be attending picnic",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "who will be in banking meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 15,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "who's going to be at those two events",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will amber join office meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 29
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 31,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "will amy be at today ' s meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "will anthony be at the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will bobby shen be at next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 22,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "will ethan, yutien and a.j. be at the picnic",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 38,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "will george be in the hr meeting at 1 o' clock",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 22,
+          "endPos": 31
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 36,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "will jane be at the 3 pm meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "will jimmy parker be attending the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will john be at marketing meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 16,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "will johnny be at office meeting today",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 31
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 33,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "will nancy be at the morning briefing meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromTime",
+          "startPos": 21,
+          "endPos": 27
+        },
+        {
+          "entity": "Subject",
+          "startPos": 29,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "will nicholas be attending the management meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 31,
+          "endPos": 48
+        }
+      ]
+    },
+    {
+      "text": "will paul be going to the meeting on friday",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 37,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "will roy be at our weekly team meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 19,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "will teresa be at my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "will thomas be in insurance meeting monday at noon",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 18,
+          "endPos": 34
+        },
+        {
+          "entity": "FromDate",
+          "startPos": 36,
+          "endPos": 41
+        },
+        {
+          "entity": "FromTime",
+          "startPos": 46,
+          "endPos": 49
+        }
+      ]
+    },
+    {
+      "text": "will timothy be coming to the meeting",
+      "intent": "FindCalendarWho",
+      "entities": []
+    },
+    {
+      "text": "will tyler be free on friday",
+      "intent": "CheckAvailability",
+      "entities": [
+        {
+          "entity": "FromDate",
+          "startPos": 22,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "will virginia be attending my next meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "OrderReference",
+          "startPos": 30,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "will zachary be in the finance meeting",
+      "intent": "FindCalendarWho",
+      "entities": [
+        {
+          "entity": "Subject",
+          "startPos": 23,
+          "endPos": 37
+        }
+      ]
+    }
+  ],
+  "settings": []
+}

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/malformedManifestTemplate.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/malformedManifestTemplate.json
@@ -53,7 +53,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#CreateCalendarEntry",
                 "Calendar#FindMeetingRoom"
@@ -80,7 +80,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
@@ -98,7 +98,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
@@ -129,7 +129,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#TimeRemaining"
               ]
@@ -163,7 +163,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -210,7 +210,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/manifestInvalidIntent.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/manifestInvalidIntent.json
@@ -53,7 +53,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#MISSINGINTENT",
                 "Calendar#FindMeetingRoom"
@@ -80,7 +80,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
@@ -98,7 +98,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
@@ -129,7 +129,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#TimeRemaining"
               ]
@@ -163,7 +163,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -210,7 +210,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/manifestInvalidLUISModel.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/TestData/manifestInvalidLUISModel.json
@@ -53,7 +53,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#CreateCalendarEntry",
                 "MISSINGLUISMODEL#FindMeetingRoom"
@@ -80,7 +80,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
@@ -98,7 +98,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
@@ -129,7 +129,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#TimeRemaining"
               ]
@@ -163,7 +163,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -210,7 +210,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]

--- a/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/manifestTemplate.json
+++ b/sdk/csharp/tests/microsoft.bot.builder.solutions.tests/Skills/manifestTemplate.json
@@ -53,21 +53,21 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#CreateCalendarEntry",
                 "Calendar#FindMeetingRoom"
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#CreateCalendarEntry",
                 "Calendar#FindMeetingRoom"
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#CreateCalendarEntry",
                 "Calendar#FindMeetingRoom"
@@ -94,21 +94,21 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#AcceptEventEntry",
                 "Calendar#DeleteCalendarEntry"
@@ -126,19 +126,19 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#ConnectToMeeting"
               ]
@@ -169,19 +169,19 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#TimeRemaining"
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#TimeRemaining"
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#TimeRemaining"
               ]
@@ -215,7 +215,7 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -226,7 +226,7 @@
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -237,7 +237,7 @@
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#FindCalendarDetail",
                 "Calendar#FindCalendarEntry",
@@ -284,19 +284,19 @@
         "triggers": {
           "utteranceSources": [
             {
-              "locale": "en",
+              "locale": "en-us",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]
             },
             {
-              "locale": "de",
+              "locale": "de-de",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]
             },
             {
-              "locale": "fr",
+              "locale": "fr-fr",
               "source": [
                 "Calendar#ChangeCalendarEntry"
               ]


### PR DESCRIPTION
PR updates test to reflect the recent change to use full locale (en-us) rather than just (en) in Manifests and strengthens tests around this area to ensure it's fully covered in testing.

Updated to use the luis model locale not the one in cogmodels to simplify implementation.