### PR TITLE
[BotBuilder-Libraries] Fix duplicate utterances text issue

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Manifest/SkillManifestGenerator.cs
+++ b/sdk/csharp/libraries/microsoft.bot.builder.solutions/Skills/Manifest/SkillManifestGenerator.cs
@@ -92,11 +92,13 @@ namespace Microsoft.Bot.Builder.Solutions.Skills
                         {
                             // We will retrieve all utterances from the referenced source and aggregate into one new aggregated list of utterances per action
                             action.Definition.Triggers.Utterances = new List<Utterance>();
-                            var utterancesToAdd = new List<string>();
+                            List<string> utterancesToAdd;
 
                             // Iterate through each utterance source, one per locale.
                             foreach (UtteranceSource utteranceSource in action.Definition.Triggers.UtteranceSources)
                             {
+                                utterancesToAdd = new List<string>();
+
                                 // There may be multiple intents linked to this
                                 foreach (var source in utteranceSource.Source)
                                 {

--- a/sdk/typescript/libraries/botbuilder-skills/src/skillManifestGenerator.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/skillManifestGenerator.ts
@@ -60,10 +60,12 @@ export class SkillManifestGenerator {
                     // We will retrieve all utterances from the referenced source
                     // and aggregate into one new aggregated list of utterances per action
                     action.definition.triggers.utterances = [];
-                    const utterancesToAdd: string[] = [];
+                    let utterancesToAdd: string[];
 
                     // Iterate through each utterance source, one per locale.
                     action.definition.triggers.utteranceSources.forEach((utteranceSource: IUtteranceSources): void => {
+
+                        utterancesToAdd = [];
                         // There may be multiple intents linked to this
                         utteranceSource.source.forEach((source: string): void => {
                             // Retrieve the intent mapped to this action trigger


### PR DESCRIPTION
Fix #2852 

### Purpose
*What is the context of this pull request? Why is it being done?*
When Inline Trigger Utterances is set in true with actions that use more than one language, the utterances text duplicates.

- C#:
![image](https://user-images.githubusercontent.com/37625424/71597680-f0611c80-2b22-11ea-8dfd-d76323bc225e.png)

- Typescript:
![image](https://user-images.githubusercontent.com/37625424/71597685-f7882a80-2b22-11ea-910f-ea95bc167b98.png)


### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We updated the SkillManifestGenerator initializating the `utterancesToAdd` list for each `utteranceSources`

After applying these changes, this was the results:
C#:
![image](https://user-images.githubusercontent.com/37625424/71597917-c4926680-2b23-11ea-824a-adad9a9d070a.png)

Typescript:
![image](https://user-images.githubusercontent.com/37625424/71598010-04594e00-2b24-11ea-8a28-6088e553e7ca.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\- 

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
