### PR TITLE
[Sdk] use delegate instead of string in FeedbackOptions

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackConstants.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackConstants.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Solutions.Feedback
+{
+    public static class FeedbackConstants
+    {
+        // The name of the event when a feedback is received
+        public static readonly string FeedbackEvent = "Feedback";
+
+        public static readonly string FeedbackTag = "feedbackTag";
+
+        public static readonly string FeedbackValue = "feedbackValue";
+
+        public static readonly string FeedbackComent = "feedbackComment";
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackRecord.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackRecord.cs
@@ -5,7 +5,7 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Solutions.Feedback
 {
-    public class FeedbackRecord
+    internal class FeedbackRecord
     {
         /// <summary>
         /// Gets or sets the activity for which feedback was requested.
@@ -16,12 +16,12 @@ namespace Microsoft.Bot.Solutions.Feedback
         public Activity Request { get; set; }
 
         /// <summary>
-        /// Gets or sets feedback value submitted by user.
+        /// Gets or sets feedback submitted by user.
         /// </summary>
         /// <value>
-        /// Feedback value submitted by user.
+        /// Feedback submitted by user.
         /// </value>
-        public string Feedback { get; set; }
+        public CardAction Feedback { get; set; }
 
         /// <summary>
         /// Gets or sets free-form comment submitted by user.

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Feedback/FeedbackMiddlewareTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Feedback/FeedbackMiddlewareTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Adapters;
@@ -80,8 +81,8 @@ namespace Microsoft.Bot.Solutions.Tests.Feedback
                 .Send(negativeFeedback)
                 .AssertReply((activity) =>
                 {
+                    Assert.AreEqual(activity.AsMessageActivity().Text, "Thanks, I appreciate your feedback. Please add any additional comments in the chat.");
                     var card = activity.AsMessageActivity().Attachments[0].Content as HeroCard;
-                    Assert.AreEqual(card.Text, "Thanks for your feedback! Please add any additional comments in the chat.");
                     Assert.AreEqual(card.Buttons.Count, 1);
                 })
                 .Send("comment")
@@ -154,8 +155,8 @@ namespace Microsoft.Bot.Solutions.Tests.Feedback
                 .Send(neutralFeedback)
                 .AssertReply((activity) =>
                 {
+                    Assert.AreEqual(activity.AsMessageActivity().Text, "Please add any additional comments in the chat.");
                     var card = activity.AsMessageActivity().Attachments[0].Content as HeroCard;
-                    Assert.AreEqual(card.Text, "Please add any additional comments in the chat.");
                     Assert.AreEqual(card.Buttons.Count, 1);
                 })
                 .Send("comment")
@@ -180,16 +181,16 @@ namespace Microsoft.Bot.Solutions.Tests.Feedback
                 {
                     if ((string)action.Value == neutralFeedback)
                     {
-                        return (FeedbackResponses.CommentPrompt, true);
+                        return (context.Activity.CreateReply(FeedbackResponses.CommentPrompt), true);
                     }
                     else
                     {
-                        return (FeedbackResponses.FeedbackReceivedMessage, false);
+                        return (context.Activity.CreateReply(FeedbackResponses.FeedbackReceivedMessage), false);
                     }
                 },
                 CommentReceivedMessage = (ITurnContext context, string tag, CardAction action, string comment) =>
                 {
-                    return comment;
+                    return context.Activity.CreateReply(comment);
                 },
             };
             return options;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2516

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* Change FeedbackRecord to internal
* Use delegate instead of string in FeedbackOptions
* FeedbackReceivedMessageDelegate returns a bool to indicate whether prompt for comments
(Struggle between generalization and simplicity..)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

* Add DefaultOptions_CommentDirectly, CustomOptions_Neutral

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
