### PR TITLE
[Skills] Unify CurrentUICulture

### DIFF
--- a/skills/csharp/calendarskill/Adapters/CalendarSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/calendarskill/Adapters/CalendarSkillWebSocketBotAdapter.cs
@@ -29,8 +29,6 @@ namespace CalendarSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
-
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(CalendarSharedResponses.CalendarErrorMessage);
                 await context.SendActivityAsync(activity);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Calendar Skill Error: {exception.Message} | {exception.StackTrace}"));

--- a/skills/csharp/calendarskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/calendarskill/Adapters/DefaultAdapter.cs
@@ -28,8 +28,6 @@ namespace CalendarSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
-
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(CalendarSharedResponses.CalendarErrorMessage);
                 await context.SendActivityAsync(activity);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Calendar Skill Error: {exception.Message} | {exception.StackTrace}"));

--- a/skills/csharp/emailskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/emailskill/Adapters/DefaultAdapter.cs
@@ -30,7 +30,6 @@ namespace EmailSkill.Adapters
         {
             OnTurnError = async (turnContext, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(turnContext.Activity.Locale);
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(EmailSharedResponses.EmailErrorMessage);
                 await turnContext.SendActivityAsync(activity);
                 await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Email Skill Error: {exception.Message} | {exception.StackTrace}"));

--- a/skills/csharp/emailskill/Adapters/EmailSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/emailskill/Adapters/EmailSkillWebSocketBotAdapter.cs
@@ -29,7 +29,6 @@ namespace EmailSkill.Adapters
         {
             OnTurnError = async (turnContext, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(turnContext.Activity.Locale);
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(EmailSharedResponses.EmailErrorMessage);
                 await turnContext.SendActivityAsync(activity);
                 await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Email Skill Error: {exception.Message} | {exception.StackTrace}"));

--- a/skills/csharp/experimental/automotiveskill/Adapters/AutomotiveSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/experimental/automotiveskill/Adapters/AutomotiveSkillWebSocketBotAdapter.cs
@@ -28,7 +28,7 @@ namespace AutomotiveSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(AutomotiveSkillSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Automotive Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/automotiveskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/automotiveskill/Adapters/DefaultAdapter.cs
@@ -27,7 +27,7 @@ namespace AutomotiveSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(AutomotiveSkillSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Automotive Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/bingsearchskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/csharp/experimental/bingsearchskill/Adapters/CustomSkillAdapter.cs
@@ -28,7 +28,7 @@ namespace BingSearchSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/bingsearchskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/bingsearchskill/Adapters/DefaultAdapter.cs
@@ -27,7 +27,7 @@ namespace BingSearchSkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/eventskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/eventskill/Adapters/DefaultAdapter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using EventSkill.Responses.Shared;
 using EventSkill.Services;
 using Microsoft.Bot.Builder;
@@ -26,6 +27,7 @@ namespace EventSkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/eventskill/Adapters/EventSkillAdapter.cs
+++ b/skills/csharp/experimental/eventskill/Adapters/EventSkillAdapter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using EventSkill.Responses.Shared;
 using EventSkill.Services;
 using Microsoft.Bot.Builder;
@@ -27,6 +28,7 @@ namespace EventSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/hospitalityskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/hospitalityskill/Adapters/DefaultAdapter.cs
@@ -27,6 +27,7 @@ namespace HospitalitySkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/hospitalityskill/Adapters/HospitalitySkillAdapter.cs
+++ b/skills/csharp/experimental/hospitalityskill/Adapters/HospitalitySkillAdapter.cs
@@ -28,6 +28,7 @@ namespace HospitalitySkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/itsmskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/csharp/experimental/itsmskill/Adapters/CustomSkillAdapter.cs
@@ -28,6 +28,7 @@ namespace ITSMSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/itsmskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/itsmskill/Adapters/DefaultAdapter.cs
@@ -27,6 +27,7 @@ namespace ITSMSkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/musicskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/csharp/experimental/musicskill/Adapters/CustomSkillAdapter.cs
@@ -28,7 +28,7 @@ namespace MusicSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/musicskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/musicskill/Adapters/DefaultAdapter.cs
@@ -27,7 +27,7 @@ namespace MusicSkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/newsskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/newsskill/Adapters/DefaultAdapter.cs
@@ -25,7 +25,7 @@ namespace NewsSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(MainStrings.ERROR);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"News Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/newsskill/Adapters/NewsSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/experimental/newsskill/Adapters/NewsSkillWebSocketBotAdapter.cs
@@ -26,7 +26,7 @@ namespace NewsSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(MainStrings.ERROR);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"News Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/phoneskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/phoneskill/Adapters/DefaultAdapter.cs
@@ -28,7 +28,7 @@ namespace PhoneSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(PhoneSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Phone Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/phoneskill/Adapters/PhoneSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/experimental/phoneskill/Adapters/PhoneSkillWebSocketBotAdapter.cs
@@ -29,7 +29,7 @@ namespace PhoneSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(PhoneSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Phone Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/restaurantbookingskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Adapters/DefaultAdapter.cs
@@ -27,6 +27,7 @@ namespace RestaurantBookingSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(RestaurantBookingSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Restaurant Booking Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/restaurantbookingskill/Adapters/RestaurantSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Adapters/RestaurantSkillWebSocketBotAdapter.cs
@@ -28,6 +28,7 @@ namespace RestaurantBookingSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(RestaurantBookingSharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Restaurant Booking Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/weatherskill/Adapters/CustomSkillAdapter.cs
+++ b/skills/csharp/experimental/weatherskill/Adapters/CustomSkillAdapter.cs
@@ -26,7 +26,7 @@ namespace WeatherSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/experimental/weatherskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/experimental/weatherskill/Adapters/DefaultAdapter.cs
@@ -25,7 +25,7 @@ namespace WeatherSkill.Bots
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(SharedResponses.ErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/pointofinterestskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/pointofinterestskill/Adapters/DefaultAdapter.cs
@@ -27,6 +27,7 @@ namespace PointOfInterestSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(POISharedResponses.PointOfInterestErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"PointOfInterest Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/pointofinterestskill/Adapters/POISkillWebSocketBotAdapter.cs
+++ b/skills/csharp/pointofinterestskill/Adapters/POISkillWebSocketBotAdapter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.Dialogs;
@@ -27,6 +28,7 @@ namespace PointOfInterestSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
+                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale ?? "en-us");
                 await context.SendActivityAsync(responseManager.GetResponse(POISharedResponses.PointOfInterestErrorMessage));
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"PointOfInterest Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);

--- a/skills/csharp/todoskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/todoskill/Adapters/DefaultAdapter.cs
@@ -27,8 +27,6 @@ namespace ToDoSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
-
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(ToDoSharedResponses.ToDoErrorMessage, context);
                 await context.SendActivityAsync(activity);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"To Do Skill Error: {exception.Message} | {exception.StackTrace}"));

--- a/skills/csharp/todoskill/Adapters/ToDoSkillWebSocketBotAdapter.cs
+++ b/skills/csharp/todoskill/Adapters/ToDoSkillWebSocketBotAdapter.cs
@@ -28,10 +28,7 @@ namespace ToDoSkill.Adapters
         {
             OnTurnError = async (context, exception) =>
             {
-                CultureInfo.CurrentUICulture = new CultureInfo(context.Activity.Locale);
-
                 var activity = localeTemplateEngineManager.GenerateActivityForLocale(ToDoSharedResponses.ToDoErrorMessage, context);
-
                 await context.SendActivityAsync(activity);
                 await context.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"To Do Skill Error: {exception.Message} | {exception.StackTrace}"));
                 telemetryClient.TrackException(exception);


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Fix when Locale is null.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* All templateEngine do not set
* All responseManager set CurrentUICulture 

(Although there is SetLocaleMiddleware, OnTurnError will catch all errors include ones in middleware, so CurrentUICulture  should be set)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
