### PR TITLE
Add New Skill Manifest to all Skills

### DIFF
--- a/skills/csharp/Skills.sln
+++ b/skills/csharp/Skills.sln
@@ -1,4 +1,4 @@
-﻿﻿
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29102.190
@@ -51,7 +51,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ToDoSkill.Tests", "tests\to
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ITSMSkill.Tests", "tests\itsmskill.tests\ITSMSkill.Tests.csproj", "{C3304FB4-D4D5-412F-9312-1ECE4DE573DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HospitalitySkill.Tests", "tests\HospitalitySkill.Tests\HospitalitySkill.Tests.csproj", "{E3E37DC8-1AEC-4368-A7F0-62F93A82FDD0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HospitalitySkill.Tests", "tests\HospitalitySkill.Tests\HospitalitySkill.Tests.csproj", "{E3E37DC8-1AEC-4368-A7F0-62F93A82FDD0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{CD5DDB01-5D23-4FF2-B2DE-3014D3987D37}"
 EndProject

--- a/skills/csharp/calendarskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/calendarskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "CalendarSkill",
+  "name": "Calendar Skill",
+  "description": "The Calendar skill provides calendaring related capabilities and supports Office and Google calendars.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/CalendarSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "calendar",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Calendar Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "CalendarLuModel-en",
+          "name": "CalendarSkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-en.lu",
+          "description": "English language model for the skill"
+        }
+      ],
+      "de-de": [
+        {
+          "id": "CalendarLuModel-de",
+          "name": "CalendarSkill LU (German)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-de.lu",
+          "description": "German language model for the skill"
+        }
+      ],
+      "es-es": [
+        {
+          "id": "CalendarLuModel-es",
+          "name": "CalendarSkill LU (Spanish)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-es.lu",
+          "description": "Spanish language model for the skill"
+        }
+      ],
+      "fr-fr": [
+        {
+          "id": "CalendarLuModel-fr",
+          "name": "CalendarSkill LU (French)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-fr.lu",
+          "description": "French language model for the skill"
+        }
+      ],
+      "it-it": [
+        {
+          "id": "CalendarLuModel-it",
+          "name": "CalendarSkill LU (Italian)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-it.lu",
+          "description": "Italian language model for the skill"
+        }
+      ],
+      "zh-cn": [
+        {
+          "id": "CalendarLuModel-zh",
+          "name": "CalendarSkill LU (Chinese)",
+          "contentType": "application/lu",
+          "url": "file://Calendar-zh.lu",
+          "description": "Chinese language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "CreateCalendarEntry": "#/activities/message",
+      "FindMeetingRoom": "#/activities/message",
+      "AcceptEventEntry": "#/activities/message",
+      "DeleteCalendarEntry": "#/activities/message",
+      "ConnectToMeeting": "#/activities/message",
+      "TimeRemaining": "#/activities/message",
+      "FindCalendarDetail": "#/activities/message",
+      "FindCalendarEntry": "#/activities/message",
+      "FindCalendarWhen": "#/activities/message",
+      "FindCalendarWhere": "#/activities/message",
+      "FindCalendarWho": "#/activities/message",
+      "FindDuration": "#/activities/message",
+      "ChangeCalendarEntry": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": { }
+}

--- a/skills/csharp/calendarskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/calendarskill/wwwroot/manifest/manifest.json
@@ -96,5 +96,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": { }
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/emailskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/emailskill/wwwroot/manifest/manifest.json
@@ -91,5 +91,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/emailskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/emailskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "EmailSkill",
+  "name": "Email Skill",
+  "description": "The Email skill provides email related capabilities and supports Office and Google calendars.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/EmailSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "email",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Email Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "EmailLuModel-en",
+          "name": "EmailSkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Email-en.lu",
+          "description": "English language model for the skill"
+        }
+      ],
+      "de-de": [
+        {
+          "id": "EmailLuModel-de",
+          "name": "EmailSkill LU (German)",
+          "contentType": "application/lu",
+          "url": "file://Email-de.lu",
+          "description": "German language model for the skill"
+        }
+      ],
+      "es-es": [
+        {
+          "id": "EmailLuModel-es",
+          "name": "EmailSkill LU (Spanish)",
+          "contentType": "application/lu",
+          "url": "file://Email-es.lu",
+          "description": "Spanish language model for the skill"
+        }
+      ],
+      "fr-fr": [
+        {
+          "id": "EmailLuModel-fr",
+          "name": "EmailSkill LU (French)",
+          "contentType": "application/lu",
+          "url": "file://Email-fr.lu",
+          "description": "French language model for the skill"
+        }
+      ],
+      "it-it": [
+        {
+          "id": "EmailLuModel-it",
+          "name": "EmailSkill LU (Italian)",
+          "contentType": "application/lu",
+          "url": "file://Email-it.lu",
+          "description": "Italian language model for the skill"
+        }
+      ],
+      "zh-cn": [
+        {
+          "id": "EmailLuModel-zh",
+          "name": "EmailSkill LU (Chinese)",
+          "contentType": "application/lu",
+          "url": "file://Email-zh.lu",
+          "description": "Chinese language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "SendEmail": "#/activities/message",
+      "Forward": "#/activities/message",
+      "Reply": "#/activities/message",
+      "SearchMessages": "#/activities/message",
+      "CheckMessages": "#/activities/message",
+      "ReadAloud": "#/activities/message",
+      "QueryLastText": "#/activities/message",
+      "Delete": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/automotiveskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/automotiveskill/wwwroot/manifest/manifest.json
@@ -39,5 +39,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/automotiveskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/automotiveskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "AutomotiveSkill",
+  "name": "Automotive Skill",
+  "description": "The Automotive skill provides automotive related capabilities such as control of vehicle settings.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/AutomotiveSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "automotive",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Automotive Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "AutomotiveSkillLuModel-en",
+          "name": "SettingsDispatch LU (English)",
+          "contentType": "application/lu",
+          "url": "file://SettingsDispatch-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "VEHICLE_SETTINGS_CHANGE": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/bingsearchskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/bingsearchskill/wwwroot/manifest/manifest.json
@@ -41,5 +41,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/bingsearchskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/bingsearchskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "BingSkill",
+  "name": "Bing Skill",
+  "description": "The Bing Search skill provides general Bing capabilities.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/BingSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "bing",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Bing Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "BingSkillLuModel-en",
+          "name": "BingSearchSkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://BingSearchSkill-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "GetCelebrityInfo": "#/activities/message",
+      "SearchMovieInfo": "#/activities/message",
+      "QueryQna": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/hospitalityskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/hospitalityskill/wwwroot/manifest/manifest.json
@@ -44,5 +44,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/hospitalityskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/hospitalityskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "HospitalitySkill",
+  "name": "Hospitality Skill",
+  "description": "The Hospitality skill provides capabilities that are needed in a hotel room, such as checking out, changing your reservation, and requesting items.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/Hospitality.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "hospitality",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Hospitality Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "HospitalitySkillLuModel-en",
+          "name": "Hospitality LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Hospitality-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "CheckOut": "#/activities/message",
+      "ExtendStay": "#/activities/message",
+      "GetReservation": "#/activities/message",
+      "LateCheckOut": "#/activities/message",
+      "RequestItem": "#/activities/message",
+      "RoomService": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/itsmskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/itsmskill/wwwroot/manifest/manifest.json
@@ -43,5 +43,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/itsmskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/itsmskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "ItsmSkill",
+  "name": "ITSM Skill",
+  "description": "The IT Service Management Skill provides ticket and knowledge base related capabilities and supports SerivceNow.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/ItsmSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "itsm",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the ITSM Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "ITSMSkillLuModel-en",
+          "name": "ITSM LU (English)",
+          "contentType": "application/lu",
+          "url": "file://ITSM-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "TicketCreate": "#/activities/message",
+      "TicketUpdate": "#/activities/message",
+      "TicketShow": "#/activities/message",
+      "TicketClose": "#/activities/message",
+      "KnowledgeShow": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/musicskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/musicskill/wwwroot/manifest/manifest.json
@@ -39,5 +39,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/musicskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/musicskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "MusicSkill",
+  "name": "Music Skill",
+  "description": "The Music Skill searches for music using Spotify",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/MusicSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "music",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Music Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "MusicSkillLuModel-en",
+          "name": "Music LU (English)",
+          "contentType": "application/lu",
+          "url": "file://MusicSkill-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "PlayMusic": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/newsskill/wwwroot/manifest.json
+++ b/skills/csharp/experimental/newsskill/wwwroot/manifest.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "NewsSkill",
+  "name": "News Skill",
+  "description": "The News experimental skill provides simple retrieval of News from Bing Search.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/NewsSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "news",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the News Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "NewsSkillLuModel-en",
+          "name": "News LU (English)",
+          "contentType": "application/lu",
+          "url": "file://news-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "FindArticles": "#/activities/message",
+      "TrendingArticles": "#/activities/message",
+      "SetFavoriteTopics": "#/activities/message",
+      "ShowFavoriteTopics": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/newsskill/wwwroot/manifest.json
+++ b/skills/csharp/experimental/newsskill/wwwroot/manifest.json
@@ -42,5 +42,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/phoneskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/phoneskill/wwwroot/manifest/manifest.json
@@ -39,5 +39,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/phoneskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/phoneskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "PhoneSkill",
+  "name": "Phone Skill",
+  "description": "The Phone experimental skill provides phone related capabilities and supports Office and Google contacts.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/PhoneSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "phone",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Phone Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "PhoneSkillLuModel-en",
+          "name": "Phone LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Phone-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "OutgoingCall": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/restaurantbookingskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/restaurantbookingskill/wwwroot/manifest/manifest.json
@@ -39,5 +39,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/restaurantbookingskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/restaurantbookingskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "RestaurantBookingSkill",
+  "name": "Restaurant Booking Skill",
+  "description": "The Restaurant Booking experimental skill provides an example of Restaurant Booking.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/RestaurantBookingSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "restaurant booking",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Restaurant Booking Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "RestaurantSkillLuModel-en",
+          "name": "Restaurant LU (English)",
+          "contentType": "application/lu",
+          "url": "file://restaurant-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "Reservation": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/experimental/weatherskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/weatherskill/wwwroot/manifest/manifest.json
@@ -39,5 +39,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/experimental/weatherskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/experimental/weatherskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "WeatherSkill",
+  "name": "Weather Skill",
+  "description": "The Weather skill provides an example of displaying the current weather using AccuWeather.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/WeatherSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "weather",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the Weather Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "WeatherSkillLuModel-en",
+          "name": "Weather LU (English)",
+          "contentType": "application/lu",
+          "url": "file://WeatherSkill-en.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "CheckWeatherValue": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/pointofinterestskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/pointofinterestskill/wwwroot/manifest/manifest.json
@@ -86,5 +86,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/skills/csharp/pointofinterestskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/pointofinterestskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "PointOfInterestSkill",
+  "name": "Point Of Interest Skill",
+  "description": "The Point of Interest skill provides PoI search capabilities leveraging Azure Maps and Foursquare.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/PointOfInterestSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "poi",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the PoI Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "PointOfInterestSkillLuModel-en",
+          "name": "PoISkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-en.lu",
+          "description": "English language model for the skill"
+        }
+      ],
+      "de-de": [
+        {
+          "id": "PointOfInterestSkillLuModel-de",
+          "name": "PoISkill LU (German)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-de.lu",
+          "description": "German language model for the skill"
+        }
+      ],
+      "es-es": [
+        {
+          "id": "PointOfInterestSkillLuModel-es",
+          "name": "PoISkill LU (Spanish)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-es.lu",
+          "description": "Spanish language model for the skill"
+        }
+      ],
+      "fr-fr": [
+        {
+          "id": "PointOfInterestSkillLuModel-fr",
+          "name": "PoISkill LU (French)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-fr.lu",
+          "description": "French language model for the skill"
+        }
+      ],
+      "it-it": [
+        {
+          "id": "PointOfInterestSkillLuModel-it",
+          "name": "PoISkill LU (Italian)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-it.lu",
+          "description": "Italian language model for the skill"
+        }
+      ],
+      "zh-cn": [
+        {
+          "id": "PointOfInterestSkillLuModel-zh",
+          "name": "PoISkill LU (Chinese)",
+          "contentType": "application/lu",
+          "url": "file://PointOfInterest-zh.lu",
+          "description": "Chinese language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "GetDirections": "#/activities/message",
+      "FindPointOfInterest": "#/activities/message",
+      "FindParking": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/todoskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/todoskill/wwwroot/manifest/manifest.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "ToDoSkill",
+  "name": "ToDo Skill",
+  "description": "The ToDo skill provides task related capabilities and supports Office based tasks.",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/ToDoSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "todo",
+    "task",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the ToDo Skill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "ToDoLuModel-en",
+          "name": "ToDoSkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-en.lu",
+          "description": "English language model for the skill"
+        }
+      ],
+      "de-de": [
+        {
+          "id": "ToDoLuModel-de",
+          "name": "ToDoSkill LU (German)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-de.lu",
+          "description": "German language model for the skill"
+        }
+      ],
+      "es-es": [
+        {
+          "id": "ToDoLuModel-es",
+          "name": "ToDoSkill LU (Spanish)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-es.lu",
+          "description": "Spanish language model for the skill"
+        }
+      ],
+      "fr-fr": [
+        {
+          "id": "ToDoLuModel-fr",
+          "name": "ToDoSkill LU (French)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-fr.lu",
+          "description": "French language model for the skill"
+        }
+      ],
+      "it-it": [
+        {
+          "id": "ToDoLuModel-it",
+          "name": "ToDoSkill LU (Italian)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-it.lu",
+          "description": "Italian language model for the skill"
+        }
+      ],
+      "zh-cn": [
+        {
+          "id": "ToDoLuModel-zh",
+          "name": "ToDoSkill LU (Chinese)",
+          "contentType": "application/lu",
+          "url": "file://ToDo-zh.lu",
+          "description": "Chinese language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "AddToDo": "#/activities/message",
+      "ShowToDo": "#/activities/message",
+      "MarkToDo": "#/activities/message",
+      "DeleteToDo": "#/activities/message",      
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {}
+}

--- a/skills/csharp/todoskill/wwwroot/manifest/manifest.json
+++ b/skills/csharp/todoskill/wwwroot/manifest/manifest.json
@@ -88,5 +88,10 @@
       "*": "#/activities/message"
     }
   },
-  "activities": {}
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }


### PR DESCRIPTION
### New Skill Manifest

SDK has introduced a new Skill Manifest as part of their GA of Skills. Updated all Skills with the new manifest alongside the existing manifestTemplate.json file which will be removed in the next release.

No actions are defined as support for these hasn't been implemented in each skill therefore only activity/utterance invocation is supported as per before.