### PR TITLE
fix interruption logic for main dialog

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -177,21 +177,18 @@ namespace VirtualAssistantSample.Dialogs
                 (var dispatchIntent, var dispatchScore) = dispatchResult.TopIntent();
 
                 // Check if we need to switch skills.
-                if (isSkill)
+                if (isSkill && IsSkillIntent(dispatchIntent) && dispatchIntent.ToString() != dialog.Id && dispatchScore > 0.9)
                 {
-                    if (dispatchIntent.ToString() != dialog.Id && dispatchScore > 0.9)
+                    EnhancedBotFrameworkSkill identifiedSkill;
+                    if (_skillsConfig.Skills.TryGetValue(dispatchIntent.ToString(), out identifiedSkill))
                     {
-                        EnhancedBotFrameworkSkill identifiedSkill;
-                        if (_skillsConfig.Skills.TryGetValue(dispatchIntent.ToString(), out identifiedSkill))
-                        {
-                            var prompt = _templateEngine.GenerateActivityForLocale("SkillSwitchPrompt", new { Skill = identifiedSkill.Name });
-                            await innerDc.BeginDialogAsync(_switchSkillDialog.Id, new SwitchSkillDialogOptions(prompt, identifiedSkill));
-                            interrupted = true;
-                        }
-                        else
-                        {
-                            throw new ArgumentException($"{dispatchIntent.ToString()} is not in the skills configuration");
-                        }
+                        var prompt = _templateEngine.GenerateActivityForLocale("SkillSwitchPrompt", new { Skill = identifiedSkill.Name });
+                        await innerDc.BeginDialogAsync(_switchSkillDialog.Id, new SwitchSkillDialogOptions(prompt, identifiedSkill));
+                        interrupted = true;
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"{dispatchIntent.ToString()} is not in the skills configuration");
                     }
                 }
 
@@ -323,7 +320,15 @@ namespace VirtualAssistantSample.Dialogs
                 var dispatchResult = stepContext.Context.TurnState.Get<DispatchLuis>(StateProperties.DispatchResult);
                 (var dispatchIntent, var dispatchScore) = dispatchResult.TopIntent();
 
-                if (dispatchIntent == DispatchLuis.Intent.q_Faq)
+                if (IsSkillIntent(dispatchIntent))
+                {
+                    var dispatchIntentSkill = dispatchIntent.ToString();
+                    var skillDialogArgs = new SkillDialogArgs { SkillId = dispatchIntentSkill };
+
+                    // Start the skill dialog.
+                    return await stepContext.BeginDialogAsync(dispatchIntentSkill, skillDialogArgs);
+                }
+                else if (dispatchIntent == DispatchLuis.Intent.q_Faq)
                 {
                     stepContext.SuppressCompletionMessage(true);
 
@@ -334,14 +339,6 @@ namespace VirtualAssistantSample.Dialogs
                     stepContext.SuppressCompletionMessage(true);
 
                     return await stepContext.BeginDialogAsync("Chitchat");
-                }
-                else if (!dispatchIntent.ToString().Equals(DispatchLuis.Intent.None.ToString(), StringComparison.InvariantCultureIgnoreCase))
-                {
-                    var dispatchIntentSkill = dispatchIntent.ToString();
-                    var skillDialogArgs = new SkillDialogArgs { SkillId = dispatchIntentSkill };
-
-                    // Start the skill dialog.
-                    return await stepContext.BeginDialogAsync(dispatchIntentSkill, skillDialogArgs);
                 }
                 else
                 {
@@ -408,6 +405,19 @@ namespace VirtualAssistantSample.Dialogs
             }
 
             return await next();
+        }
+
+        private bool IsSkillIntent(DispatchLuis.Intent dispatchIntent)
+        {
+            if (dispatchIntent.ToString().Equals(DispatchLuis.Intent.l_General.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
+                dispatchIntent.ToString().Equals(DispatchLuis.Intent.q_Faq.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
+                dispatchIntent.ToString().Equals(DispatchLuis.Intent.q_Chitchat.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
+                dispatchIntent.ToString().Equals(DispatchLuis.Intent.None.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily211" />
+    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily212" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily210" />
+    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily211" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily210" />
+    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.8.0-daily211" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Fix MainDialog for interruption logic

I'll be cutting a new build for the M.B.S lib so please don't merge it (creating it as a draft now)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
