### PR TITLE
Fix Calendar LU file issue

### DIFF
--- a/skills/csharp/calendarskill/Deployment/Resources/LU/en-us/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/en-us/Calendar.lu
@@ -1793,7 +1793,6 @@
 - no thank you
 - no thanks
 - no way
-- no, i already have meeting {FromTime=3pm} {FromDate=tomorrow} afternoon
 - no, i won't
 - no, i'd like to meet her manager
 - no, please don't


### PR DESCRIPTION
Calendar LU file had two instances of the same utterance under the `RejectCalendar` intent
- `no, i already have meeting {FromTime=3pm} {FromDate=tomorrow} afternoon`

ludown CLI gracefully handled this situation whereby it ignored the extra instance however the new bf luis:convert CLI generates a malformed element whereby it duplicated the entities under the same utterance likely due to it grouping them together.

```json
{
      "text": "no, i already have meeting 3pm tomorrow afternoon",
      "intent": "RejectCalendar",
      "entities": [
        {
          "entity": "FromTime",
          "startPos": 27,
          "endPos": 29
        },
        {
          "entity": "FromDate",
          "startPos": 31,
          "endPos": 38
        },
        {
          "entity": "FromTime",
          "startPos": 27,
          "endPos": 29
        },
        {
          "entity": "FromDate",
          "startPos": 31,
          "endPos": 38
        }
      ]
},
```

Fix is to remove the duplicate utterance. Verified with a fresh deployment and doesn't apply to the other language versions.

Raised https://github.com/microsoft/botframework-cli/issues/509 in bf cli to track a tool improvement.