### PR TITLE
[Lib]Fix input hint for LG response activity

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Responses/LocaleTemplateEngineManager.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Responses/LocaleTemplateEngineManager.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Bot.Solutions.Responses
         /// <param name="localeOverride">Optional override for locale.</param>
         /// <returns>Activity.</returns>
         /// <remarks>
-        /// The InputHint property of the returning activity is set to be null so caller will have to assign the InputHint explicitly.
+        /// The InputHint property of the returning activity is set to be null if it's acceptingInput so
+        /// when the activity is being used in a prompt it'll be set to expectingInput.
         /// </remarks>
         public Activity GenerateActivityForLocale(string templateName, object data = null, string localeOverride = null)
         {
@@ -74,7 +75,11 @@ namespace Microsoft.Bot.Solutions.Responses
             {
                 var activity = ActivityFactory.CreateActivity(TemplateEnginesPerLocale[locale].EvaluateTemplate(templateName, data).ToString());
 
-                activity.InputHint = null;
+                // Set the inputHint to null when it's acceptingInput so prompt can override it when expectingInput
+                if (activity.InputHint == InputHints.AcceptingInput)
+                {
+                    activity.InputHint = null;
+                }
 
                 return activity;
             }
@@ -97,7 +102,11 @@ namespace Microsoft.Bot.Solutions.Responses
                     {
                         var activity = ActivityFactory.CreateActivity(TemplateEnginesPerLocale[fallBackLocale].EvaluateTemplate(templateName, data).ToString());
 
-                        activity.InputHint = null;
+                        // Set the inputHint to null when it's acceptingInput so prompt can override it when expectingInput
+                        if (activity.InputHint == InputHints.AcceptingInput)
+                        {
+                            activity.InputHint = null;
+                        }
 
                         return activity;
                     }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Responses/LocaleTemplateEngineManager.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Responses/LocaleTemplateEngineManager.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Bot.Solutions.Responses
         /// <param name="data">Data for Language Generation to use during response generation.</param>
         /// <param name="localeOverride">Optional override for locale.</param>
         /// <returns>Activity.</returns>
+        /// <remarks>
+        /// The InputHint property of the returning activity is set to be null so caller will have to assign the InputHint explicitly.
+        /// </remarks>
         public Activity GenerateActivityForLocale(string templateName, object data = null, string localeOverride = null)
         {
             if (templateName == null)
@@ -69,7 +72,11 @@ namespace Microsoft.Bot.Solutions.Responses
             // Do we have a template engine for this locale?
             if (TemplateEnginesPerLocale.ContainsKey(locale))
             {
-                return ActivityFactory.CreateActivity(TemplateEnginesPerLocale[locale].EvaluateTemplate(templateName, data).ToString());
+                var activity = ActivityFactory.CreateActivity(TemplateEnginesPerLocale[locale].EvaluateTemplate(templateName, data).ToString());
+
+                activity.InputHint = null;
+
+                return activity;
             }
             else
             {
@@ -88,7 +95,11 @@ namespace Microsoft.Bot.Solutions.Responses
                 {
                     if (TemplateEnginesPerLocale.ContainsKey(fallBackLocale))
                     {
-                        return ActivityFactory.CreateActivity(TemplateEnginesPerLocale[fallBackLocale].EvaluateTemplate(templateName, data).ToString());
+                        var activity = ActivityFactory.CreateActivity(TemplateEnginesPerLocale[fallBackLocale].EvaluateTemplate(templateName, data).ToString());
+
+                        activity.InputHint = null;
+
+                        return activity;
                     }
                 }
             }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

The returning activity of GenerateActivityForLocale function has the inputHint always set to be acceptingInput because of an SDK change. We are setting it to be null so it's up to the caller to set the inputHint explicitly. 

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
