### PR TITLE
Adding additional manifest for 2.0 and 2.1

### DIFF
--- a/samples/csharp/skill/SkillSample/wwwroot/manifest/manifest-1.0.json
+++ b/samples/csharp/skill/SkillSample/wwwroot/manifest/manifest-1.0.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "SampleSkill",
+  "name": "SampleSkill",
+  "description": "SampleSkill description",
+  "publisherName": "Your Company",
+  "version": "1.0",
+  "iconUrl": "https://{YOUR_SKILL_URL}/SampleSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "sample",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the SampleSkill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "activities": {
+    "sampleAction": {
+      "description": "Sample action which accepts an input object and returns an object back.",
+      "type": "event",
+      "name": "SampleAction",
+      "value": {
+        "$ref": "#/definitions/inputObject"
+      },
+      "resultValue": {
+        "$ref": "#/definitions/responseObject"
+      }
+    },
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  },
+  "definitions": {
+    "inputObject": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The users name."
+        }
+      }
+    },
+    "responseObject": {
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "type": "integer",
+          "description": "A customer identifier."
+        }
+      }
+    }
+  }
+}

--- a/samples/csharp/skill/SkillSample/wwwroot/manifest/manifest-1.1.json
+++ b/samples/csharp/skill/SkillSample/wwwroot/manifest/manifest-1.1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.1.preview-0.json",
+  "$id": "SampleSkill",
+  "name": "SampleSkill",
+  "description": "SampleSkill description",
+  "publisherName": "Your Company",
+  "version": "1.1",
+  "iconUrl": "https://{YOUR_SKILL_URL}/SampleSkill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "sample",
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "production",
+      "protocol": "BotFrameworkV3",
+      "description": "Production endpoint for the SampleSkill",
+      "endpointUrl": "https://{YOUR_SKILL_URL}/api/messages",
+      "msAppId": "{YOUR_SKILL_APPID}"
+    }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "SampleSkillLuModel-en",
+          "name": "CalendarSkill LU (English)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "English language model for the skill"
+        }
+      ],
+      "de-de": [
+        {
+          "id": "SampleSkillLuModel-de",
+          "name": "CalendarSkill LU (German)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "German language model for the skill"
+        }
+      ],
+      "es-es": [
+        {
+          "id": "SampleSkillLuModel-es",
+          "name": "CalendarSkill LU (Spanish)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "Spanish language model for the skill"
+        }
+      ],
+      "fr-fr": [
+        {
+          "id": "SampleSkillLuModel-fr",
+          "name": "CalendarSkill LU (French)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "French language model for the skill"
+        }
+      ],
+      "it-it": [
+        {
+          "id": "SampleSkillLuModel-it",
+          "name": "CalendarSkill LU (Italian)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "Italian language model for the skill"
+        }
+      ],
+      "zh-cn": [
+        {
+          "id": "SampleSkillLuModel-zh",
+          "name": "CalendarSkill LU (Chinese)",
+          "contentType": "application/lu",
+          "url": "file://SkillSample.lu",
+          "description": "Chinese language model for the skill"
+        }
+      ]
+    },
+    "intents": {
+      "Sample": "#/activities/message",
+      "*": "#/activities/message"
+    }
+  },
+  "activities": {
+    "sampleAction": {
+      "description": "Sample action which accepts an input object and returns an object back.",
+      "type": "event",
+      "name": "SampleAction",
+      "value": {
+        "$ref": "#/definitions/inputObject"
+      },
+      "resultValue": {
+        "$ref": "#/definitions/responseObject"
+      }
+    },
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  },
+  "definitions": {
+    "inputObject": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The users name."
+        }
+      }
+    },
+    "responseObject": {
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "type": "integer",
+          "description": "A customer identifier."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reflecting on the 2.0 and 2.1 manifest schemas and 2.1 manifest not being signed off yet it's important we provide a manifest for each version that is compliant thus ensuring P-VA can use 2.0 and botskills will use 2.1

