### PR TITLE
MultiProviderAuthDialog fixes in lib and skill sample/template

### DIFF
--- a/samples/csharp/skill/SkillSample/Dialogs/SkillDialogBase.cs
+++ b/samples/csharp/skill/SkillSample/Dialogs/SkillDialogBase.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Util;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.DependencyInjection;
 using SkillSample.Models;
 using SkillSample.Services;
@@ -36,12 +37,12 @@ namespace SkillSample.Dialogs
             StateAccessor = conversationState.CreateProperty<SkillState>(nameof(SkillState));
 
             // NOTE: Uncomment the following if your skill requires authentication
-            // if (!settings.OAuthConnections.Any())
+            // if (!Settings.OAuthConnections.Any())
             // {
             //    throw new Exception("You must configure an authentication connection before using this component.");
             // }
 
-            // AddDialog(new MultiProviderAuthDialog(settings.OAuthConnections));
+            // AddDialog(new MultiProviderAuthDialog(Settings.OAuthConnections));
         }
 
         protected BotSettings Settings { get; set; }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Choices;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Responses;
 
@@ -25,13 +22,11 @@ namespace Microsoft.Bot.Solutions.Authentication
         private string _selectedAuthType = string.Empty;
         private List<OAuthConnection> _authenticationConnections;
         private ResponseManager _responseManager;
-        private MicrosoftAppCredentials _appCredentials;
 
-        public MultiProviderAuthDialog(List<OAuthConnection> authenticationConnections, MicrosoftAppCredentials appCredentials = null, List<OAuthPromptSettings> promptSettings = null)
+        public MultiProviderAuthDialog(List<OAuthConnection> authenticationConnections, List<OAuthPromptSettings> promptSettings = null)
             : base(nameof(MultiProviderAuthDialog))
         {
             _authenticationConnections = authenticationConnections ?? throw new ArgumentNullException(nameof(authenticationConnections));
-            _appCredentials = appCredentials;
 
             _responseManager = new ResponseManager(
                 new string[] { "en", "de", "es", "fr", "it", "zh" },
@@ -90,7 +85,7 @@ namespace Microsoft.Bot.Solutions.Authentication
         {
             var activity = pc.Recognized.Value;
             if (activity != null &&
-               ((activity.Type == ActivityTypes.Event && activity.Name == "tokens/response") ||
+               ((activity.Type == ActivityTypes.Event && activity.Name == TokenEvents.TokenResponseEventName) ||
                (activity.Type == ActivityTypes.Invoke && activity.Name == "signin/verifyState")))
             {
                 return Task.FromResult(true);
@@ -101,70 +96,7 @@ namespace Microsoft.Bot.Solutions.Authentication
 
         private async Task<DialogTurnResult> FirstStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            if (!string.IsNullOrEmpty(stepContext.Context.Activity.ChannelId) && stepContext.Context.Activity.ChannelId == "directlinespeech")
-            {
-                // Speech channel doesn't support OAuthPrompt./OAuthCards so we rely on tokens being set by the Linked Accounts technique
-                // Therefore we don't use OAuthPrompt and instead attempt to directly retrieve the token from the store.
-                if (stepContext.Context.Activity.From == null || string.IsNullOrWhiteSpace(stepContext.Context.Activity.From.Id))
-                {
-                    throw new ArgumentNullException("Missing From or From.Id which is required for token retrieval.");
-                }
-
-                if (_appCredentials == null)
-                {
-                    throw new ArgumentNullException("AppCredentials were not passed which are required for speech enabled authentication scenarios.");
-                }
-
-                var client = new OAuthClient(new Uri(OAuthClientConfig.OAuthEndpoint), _appCredentials);
-                var connectionName = _authenticationConnections.First().Name;
-
-                try
-                {
-                    // Attempt to retrieve the token directly, we can't prompt the user for which Token to use so go with the first
-                    // Moving forward we expect to have a "default" choice as part of Linked Accounts,.
-                    var tokenResponse = await client.UserToken.GetTokenWithHttpMessagesAsync(
-                        stepContext.Context.Activity.From.Id,
-                        connectionName,
-                        stepContext.Context.Activity.ChannelId,
-                        null,
-                        null,
-                        cancellationToken).ConfigureAwait(false);
-
-                    if (tokenResponse?.Body != null && !string.IsNullOrEmpty(tokenResponse.Body.Token))
-                    {
-                        var providerTokenResponse = await CreateProviderTokenResponseAsync(stepContext.Context, tokenResponse.Body).ConfigureAwait(false);
-                        return await stepContext.EndDialogAsync(providerTokenResponse, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        throw new Exception($"Empty token response for user: {stepContext.Context.Activity.From.Id}, connectionName: {connectionName}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    TelemetryClient.TrackEvent("DirectLineSpeechTokenRetrievalFailure", new Dictionary<string, string> { { "Exception", ex.Message } });
-                }
-
-                var noLinkedAccountResponse = _responseManager.GetResponse(
-                    AuthenticationResponses.NoLinkedAccount,
-                    new StringDictionary() { { "authType", connectionName } });
-
-                await stepContext.Context.SendActivityAsync(noLinkedAccountResponse).ConfigureAwait(false);
-
-                // Enable Direct Line Speech clients to receive an event that will tell them
-                // to trigger a sign-in flow when a token isn't present
-                var requestOAuthFlowEvent = stepContext.Context.Activity.CreateReply();
-                requestOAuthFlowEvent.Type = ActivityTypes.Event;
-                requestOAuthFlowEvent.Name = "RequestOAuthFlow";
-
-                await stepContext.Context.SendActivityAsync(requestOAuthFlowEvent).ConfigureAwait(false);
-
-                return new DialogTurnResult(DialogTurnStatus.Cancelled);
-            }
-
             return await stepContext.BeginDialogAsync(DialogIds.AuthPrompt).ConfigureAwait(false);
-
-            throw new Exception("Local authentication is not configured, please check the authentication connection section in your configuration file.");
         }
 
         private async Task<DialogTurnResult> PromptForProviderAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -283,28 +215,14 @@ namespace Microsoft.Bot.Solutions.Authentication
                 throw new ArgumentNullException(nameof(userId));
             }
 
-            if (!string.IsNullOrEmpty(context.Activity.ChannelId) && context.Activity.ChannelId == "directlinespeech")
+            var tokenProvider = context.Adapter as IUserTokenProvider;
+            if (tokenProvider != null)
             {
-                if (_appCredentials == null)
-                {
-                    throw new ArgumentNullException("AppCredentials were not passed which are required for speech enabled authentication scenarios.");
-                }
-
-                var client = new OAuthClient(new Uri(OAuthClientConfig.OAuthEndpoint), _appCredentials);
-                var result = await client.UserToken.GetTokenStatusAsync(userId, context.Activity?.ChannelId, includeFilter, cancellationToken).ConfigureAwait(false);
-                return result?.ToArray();
+                return await tokenProvider.GetTokenStatusAsync(context, userId, includeFilter, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                var tokenProvider = context.Adapter as IUserTokenProvider;
-                if (tokenProvider != null)
-                {
-                    return await tokenProvider.GetTokenStatusAsync(context, userId, includeFilter, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    throw new Exception("Adapter does not support IUserTokenProvider");
-                }
+                throw new Exception("Adapter does not support IUserTokenProvider");
             }
         }
 

--- a/templates/csharp/Skill/Skill/Dialogs/SkillDialogBase.cs
+++ b/templates/csharp/Skill/Skill/Dialogs/SkillDialogBase.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Authentication;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Util;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.DependencyInjection;
 using $safeprojectname$.Models;
 using $safeprojectname$.Services;
@@ -36,12 +37,12 @@ namespace $safeprojectname$.Dialogs
             StateAccessor = conversationState.CreateProperty<SkillState>(nameof(SkillState));
 
             // NOTE: Uncomment the following if your skill requires authentication
-            // if (!settings.OAuthConnections.Any())
+            // if (!Settings.OAuthConnections.Any())
             // {
             //    throw new Exception("You must configure an authentication connection before using this component.");
             // }
 
-            // AddDialog(new MultiProviderAuthDialog(settings.OAuthConnections));
+            // AddDialog(new MultiProviderAuthDialog(Settings.OAuthConnections));
         }
 
         protected BotSettings Settings { get; set; }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

remove the speech related stuff from MultiProviderAuthDialog since it's part of the SDK now
small fixes in skill sample/template

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
