### PR TITLE
[Docs] fix links, add data.urls.SkillManualAuth

### DIFF
--- a/docs/_data/urls.yml
+++ b/docs/_data/urls.yml
@@ -1,0 +1,1 @@
+SkillManualAuth: 'skills/handbook/authentication#manual-authentication-steps'

--- a/docs/_docs/skills/handbook/botskills.md
+++ b/docs/_docs/skills/handbook/botskills.md
@@ -51,7 +51,7 @@ For further information, see the [Connect command documentation]({{site.repo}}/t
 ### Disconnect Skills
 {:.no_toc}
 
-The `disconnect` command allows you to disconnect a Skill from your Virtual Assistant. You can always check the Skills already connected to your Virtual Assistant using the [`list` command](#List-Connected-Skills). Remember to specify the coding language of your Virtual Assistant using `--cs` or `--ts`.
+The `disconnect` command allows you to disconnect a Skill from your Virtual Assistant. You can always check the Skills already connected to your Virtual Assistant using the [`list` command](#list-connected-skills). Remember to specify the coding language of your Virtual Assistant using `--cs` or `--ts`.
 
 Here is an example:
 ```bash

--- a/docs/_docs/skills/samples/calendar.md
+++ b/docs/_docs/skills/samples/calendar.md
@@ -149,7 +149,7 @@ This skill uses the following authentication scopes:
 - **People.Read**    
 - **Contacts.Read**
 
-You must use [these steps]({{site.baseurl}}/skills/handbook/authentication/#manual-authentication) to manually configure Authentication for the Calendar Skill. Due to a change in the Skill architecture this is not currently automated.
+You must use [these steps]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to manually configure Authentication for the Calendar Skill. Due to a change in the Skill architecture this is not currently automated.
 
 > Ensure you configure all of the scopes detailed above.
 
@@ -211,10 +211,10 @@ The Calendar skill provides additional support to search and book meeting rooms.
 |primaryKey  | The primaryKey of the given CosmosDb Account  | Yes |
 |appId  | A registed app in Azure App registrations Service | Yes |
 
-You can access all the required parameters from the [Deployment](#Deployment) step. <br>
+You can access all the required parameters from the [Deployment](#deployment) step. <br>
 **Note:** When running the script, you will be asked to sign in with your account which can access the meeting room data in the MSGraph.
 
-Follow the general instructions [here]({{site.baseurl}}/skills/handbook/authentication#manual-authentication) to configure this using the scopes shown above.
+Follow the general instructions [here]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to configure this using the scopes shown above.
 
 ## Events
 {:.toc}

--- a/docs/_docs/skills/samples/email.md
+++ b/docs/_docs/skills/samples/email.md
@@ -121,7 +121,7 @@ This skill uses the following authentication scopes:
 - **People.Read**
 - **Contacts.Read**
 
-You must use [these steps]({{site.baseurl}}/skills/handbook/authentication/#manual-authentication) to manually configure Authentication for the Email Skill. Due to a change in the Skill architecture this is not currently automated. 
+You must use [these steps]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to manually configure Authentication for the Email Skill. Due to a change in the Skill architecture this is not currently automated. 
 
 > Ensure you configure all of the scopes detailed above.
 

--- a/docs/_docs/skills/samples/phone.md
+++ b/docs/_docs/skills/samples/phone.md
@@ -95,7 +95,7 @@ This skill uses the following authentication scopes:
 - `People.Read`
 - `Contacts.Read`
 
-You must use [these steps]({{site.baseurl}}/skills/handbook/authentication/#manual-authentication) to manually configure Authentication for the Calendar Skill. Due to a change in the Skill architecture this is not currently automated.
+You must use [these steps]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to manually configure Authentication for the Calendar Skill. Due to a change in the Skill architecture this is not currently automated.
 
 > Ensure you configure all of the scopes detailed above.
 

--- a/docs/_docs/skills/samples/to-do.md
+++ b/docs/_docs/skills/samples/to-do.md
@@ -95,7 +95,7 @@ This skill uses the following authentication scopes:
 - **User.ReadBasic.All**
 - **Tasks.ReadWrite**
 
-You must use [these steps]({{site.baseurl}}/skills/handbook/authentication/#manual-authentication) to manually configure Authentication for the ToDo Skill. Due to a change in the Skill architecture this is not currently automated.
+You must use [these steps]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to manually configure Authentication for the ToDo Skill. Due to a change in the Skill architecture this is not currently automated.
 
 > Ensure you configure all of the scopes detailed above.
 

--- a/docs/_docs/skills/tutorials/create-skill/csharp/9-next-steps.md
+++ b/docs/_docs/skills/tutorials/create-skill/csharp/9-next-steps.md
@@ -24,7 +24,7 @@ Now that you've created your skill, try the one of these tutorials:
             <div class="btn btn-primary">Get started</div>
         </div>
     </a>
-    <a href="{{site.baseurl}}/virtual-assistant/tutorials/enable-speech/1-intro/" class="card">
+    <a href="{{site.baseurl}}/clients-and-channels/tutorials/enable-speech/1-intro/" class="card">
         <div class="card-body">
             <img src="{{site.baseurl}}/assets/images/icons/speech.png" alt="Speech icon" width="48px">
             <h4 class="card-title">Enable Speech</h4>
@@ -34,7 +34,7 @@ Now that you've created your skill, try the one of these tutorials:
             <div class="btn btn-primary">Get started</div>
         </div>
     </a>
-    <a href="{{site.baseurl}}/virtual-assistant/tutorials/enable-teams/1-intro/" class="card">
+    <a href="{{site.baseurl}}/clients-and-channels/tutorials/enable-teams/1-intro/" class="card">
         <div class="card-body">
             <img src="{{site.baseurl}}/assets/images/icons/teams.png" alt="Microsoft Teams icon" width="48px">
             <h4 class="card-title">Extend to Microsoft Teams</h4>

--- a/docs/_docs/skills/tutorials/create-skill/typescript/4-provision-your-azure-resources.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/4-provision-your-azure-resources.md
@@ -2,7 +2,7 @@
 layout: tutorial
 category: Skills
 subcategory: Create
-language: TypeScript
+language: typescript
 title: Provision your Azure resources
 order: 4
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ title: Bot Framework Solutions Documentation
 {:.no_toc}
 For Ignite 2019 we released **Virtual Assistant** v0.7-beta. The primary updates include support for Bot Framework SDK v4.6 and Language Generation (LG), a new documentation site to share tutorials and references, an Enterprise Assistant solution accelerator, and more.
 
-Learn more in the [what's new]({{site.baseurl}}/overview/whats-new/0.7-beta/) overview.
+Learn more in the [what's new]({{site.baseurl}}/overview/whats-new/0.7-beta/Summary) overview.
 
 ## Step-by-Step Tutorials
 {:.no_toc}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Related #2966

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* fix links
* add data.urls.SkillManualAuth
* use gem liquify

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

Via htmlproofer

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
