### PR TITLE
[POI] add tests for interruption

### DIFF
--- a/skills/csharp/pointofinterestskill/Bots/DefaultActivityHandler.cs
+++ b/skills/csharp/pointofinterestskill/Bots/DefaultActivityHandler.cs
@@ -97,6 +97,5 @@ namespace PointOfInterestSkill.Bots
         {
             public const string Location = "Location";
         }
-
     }
 }

--- a/skills/csharp/pointofinterestskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/pointofinterestskill/Dialogs/MainDialog.cs
@@ -177,7 +177,7 @@ namespace PointOfInterestSkill.Dialogs
                     {
                         case General.Intent.Cancel:
                             {
-                                await innerDc.Context.SendActivityAsync(_responseManager.GetResponse(POIMainResponses.CancelMessage));
+                                await innerDc.Context.SendActivityAsync(_responseManager.GetResponse(POISharedResponses.CancellingMessage));
                                 await innerDc.CancelAllDialogsAsync();
                                 await innerDc.BeginDialogAsync(InitialDialogId);
                                 interrupted = true;

--- a/skills/csharp/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
+++ b/skills/csharp/pointofinterestskill/Dialogs/PointOfInterestDialogBase.cs
@@ -931,9 +931,7 @@ namespace PointOfInterestSkill.Dialogs
             }
             else
             {
-                var localeConfig = Services.GetCognitiveModels();
-                localeConfig.LuisServices.TryGetValue("PointOfInterest", out var poiService);
-                var poiResult = await poiService.RecognizeAsync<PointOfInterestLuis>(promptContext.Context, CancellationToken.None);
+                var poiResult = promptContext.Context.TurnState.Get<PointOfInterestLuis>(StateProperties.POILuisResultKey);
                 var topIntent = poiResult.TopIntent();
 
                 if (topIntent.score > 0.5 && topIntent.intent != PointOfInterestLuis.Intent.None)

--- a/skills/csharp/tests/pointofinterestskill.tests/Flow/PointOfInterestDialogTests.cs
+++ b/skills/csharp/tests/pointofinterestskill.tests/Flow/PointOfInterestDialogTests.cs
@@ -287,6 +287,47 @@ namespace PointOfInterestSkill.Tests.Flow
         }
 
         /// <summary>
+        /// Find nearest parking and cancel.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [TestMethod]
+        public async Task ParkingNearestAndCancelTest()
+        {
+            await GetTestFlow()
+                .Send(string.Empty)
+                .AssertReplyOneOf(this.ParseReplies(POIMainResponses.PointOfInterestWelcomeMessage))
+                .Send(BaseTestUtterances.LocationEvent)
+                .Send(FindParkingUtterances.FindParkingNearest)
+                .AssertReply(AssertContains(null, new string[] { CardStrings.Details }))
+                .Send(GeneralTestUtterances.Cancel)
+                .AssertReply(AssertContains(POISharedResponses.CancellingMessage, null))
+                .StartTestAsync();
+        }
+
+        /// <summary>
+        /// Find nearest parking and help.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [TestMethod]
+        public async Task ParkingNearestAndHelpTest()
+        {
+            await GetTestFlow()
+                .Send(string.Empty)
+                .AssertReplyOneOf(this.ParseReplies(POIMainResponses.PointOfInterestWelcomeMessage))
+                .Send(BaseTestUtterances.LocationEvent)
+                .Send(FindParkingUtterances.FindParkingNearest)
+                .AssertReply(AssertContains(null, new string[] { CardStrings.Details }))
+                .Send(GeneralTestUtterances.Help)
+                .AssertReply(AssertContains(POIMainResponses.HelpMessage, null))
+                .AssertReply(AssertContains(null, new string[] { CardStrings.Details }))
+                .Send(BaseTestUtterances.ShowDirections)
+                .AssertReply(AssertContains(null, new string[] { CardStrings.Route }))
+                .Send(BaseTestUtterances.StartNavigation)
+                .AssertReply(CheckForEvent())
+                .StartTestAsync();
+        }
+
+        /// <summary>
         /// Find parking nearby.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/skills/csharp/tests/pointofinterestskill.tests/Flow/Utterances/GeneralTestUtterances.cs
+++ b/skills/csharp/tests/pointofinterestskill.tests/Flow/Utterances/GeneralTestUtterances.cs
@@ -16,11 +16,17 @@ namespace PointOfInterestSkill.Tests.Flow.Utterances
         {
             AddIntent(BaseTestUtterances.No, Intent.Reject);
             AddIntent(SelectNone, Intent.SelectNone);
+            AddIntent(Help, Intent.Help);
+            AddIntent(Cancel, Intent.Cancel);
         }
 
         public static string UnknownIntent { get; } = "what's the weather?";
 
         public static string SelectNone { get; } = "none of these";
+
+        public static string Help { get; } = "help";
+
+        public static string Cancel { get; } = "cancel";
 
         public static double TopIntentScore { get; } = 0.9;
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Add more tests

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* add ParkingNearestAndCancelTest, ParkingNearestAndHelpTest
* remove redundant luis call
* use POISharedResponses.CancellingMessage instead of POIMainResponses.CancelMessage

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

Yes

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
