### PR TITLE
[VA] end skill dialog

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
@@ -95,9 +95,9 @@ namespace VirtualAssistantSample.Bots
             }
         }
 
-        protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        protected override async Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
         {
-            return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
+            await _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
         }
     }
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
@@ -94,5 +94,10 @@ namespace VirtualAssistantSample.Bots
                     }
             }
         }
+
+        protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
+        }
     }
 }

--- a/templates/csharp/VA/VA/Bots/DefaultActivityHandler.cs
+++ b/templates/csharp/VA/VA/Bots/DefaultActivityHandler.cs
@@ -95,9 +95,9 @@ namespace $safeprojectname$.Bots
             }
         }
 
-        protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        protected override async Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
         {
-            return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
+            await _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
         }
     }
 }

--- a/templates/csharp/VA/VA/Bots/DefaultActivityHandler.cs
+++ b/templates/csharp/VA/VA/Bots/DefaultActivityHandler.cs
@@ -94,5 +94,10 @@ namespace $safeprojectname$.Bots
                     }
             }
         }
+
+        protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2970

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Overwrite OnEndOfConversationActivityAsync

### To Reproduce

Before: 
- Connect VA and POI in master
- Ask POI until finish
- POI(SkillDialog) is still active

After:
- A new trace shows up and POI is finished:
![image](https://user-images.githubusercontent.com/2876650/73806000-3f296280-4803-11ea-832a-3e4e6aa10f5c.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
