### PR TITLE
[Botskills] Add 'migrate' command

### DIFF
--- a/tools/botskills/src/botskills-migrate.ts
+++ b/tools/botskills/src/botskills-migrate.ts
@@ -38,7 +38,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 
 program
     .name('botskills migrate')
-    .description('migrate all the skills currently connected to your assistant to the new configuration settings (appSettings.json)')
+    .description('Migrate all the skills currently connected to your assistant to the new configuration settings (appSettings.json)')
     .option('--sourceFile [path]', '[OPTIONAL] Path to your skills file from that you want to migrate (defaults to \'skills.json\' inside your assistant\'s folder)')
     .option('--destFile [path]', '[OPTIONAL] Path to your app settings file to migrate the skills (defaults to \'appsettings.json\' inside your assistant\'s folder)')
     .option('--verbose', '[OPTIONAL] Output detailed information about the processing of the tool')

--- a/tools/botskills/src/botskills-migrate.ts
+++ b/tools/botskills/src/botskills-migrate.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as program from 'commander';
+import { existsSync } from 'fs';
+import { extname, isAbsolute, join, resolve } from 'path';
+import { MigrateSkill } from './functionality';
+import { ConsoleLogger, ILogger} from './logger';
+import { IMigrateConfiguration  } from './models';
+
+const logger: ILogger = new ConsoleLogger();
+
+function showErrorHelp(): void {
+    program.outputHelp((str: string): string => {
+        logger.error(str);
+
+        return '';
+    });
+    process.exit(1);
+}
+
+function existFile(file: string): boolean {
+    const filePath: string = isAbsolute(file) ? file : join(resolve('./'), file);
+    if (!existsSync(filePath)) {
+
+        return false;
+    }
+
+    return true;
+}
+
+program.Command.prototype.unknownOption = (flag: string): void => {
+    logger.error(`Unknown arguments: ${ flag }`);
+    showErrorHelp();
+};
+
+program
+    .name('botskills migrate')
+    .description('Migrate all the Skills connected in your assistant to the new schema')
+    .option('--sourceFile [path]', '[OPTIONAL] Path to your skills file from that you want to migrate (defaults to \'skills.json\' inside your assistant\'s folder)')
+    .option('--destFile [path]', '[OPTIONAL] Path to your app settings file to migrate the skills (defaults to \'appsettings.json\' inside your assistant\'s folder)')
+    .action((cmd: program.Command, actions: program.Command): undefined => undefined);
+
+const args: program.Command = program.parse(process.argv);
+
+let destFile: string = '';
+let sourceFile: string = '';
+
+logger.isVerbose = args.verbose;
+
+// destFile validation
+if (!args.destFile) {
+    args.destFile = join('src', 'appsettings.json');
+    if (!existFile(args.destFile)) {
+        args.destFile = 'appsettings.json';
+        if (!existFile(args.destFile)) {
+            logger.error(`The 'destFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--destFile' argument.`);
+            process.exit(1);
+        }
+    }
+} else if (extname(args.destFile) !== '.json') {
+    logger.error(`The 'destFile' argument should be a JSON file.`);
+    process.exit(1);
+} else {
+    if (!existFile(args.destFile)) {
+        logger.error(`The 'destFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--destFile' argument.`);
+        process.exit(1);
+    }
+}
+
+destFile = isAbsolute(args.destFile) ? args.destFile : join(resolve('./'), args.destFile);
+
+
+// sourceFile validation
+if (!args.sourceFile) {
+    args.sourceFile = join('src', 'skills.json');
+    if (!existFile(args.sourceFile)) {
+        args.sourceFile = 'skills.json';
+        if (!existFile(args.sourceFile)) {
+            logger.error(`The 'sourceFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--sourceFile' argument.`);
+            process.exit(1);
+        }
+    }
+} else if (extname(args.sourceFile) !== '.json') {
+    logger.error(`The 'sourceFile' argument should be a JSON file.`);
+    process.exit(1);
+} else {
+    if (!existFile(args.sourceFile)) {
+        logger.error(`The 'sourceFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--sourceFile' argument.`);
+        process.exit(1);
+    }
+}
+
+sourceFile = isAbsolute(args.sourceFile) ? args.sourceFile : join(resolve('./'), args.sourceFile);
+
+// Initialize an instance of IListConfiguration to send the needed arguments to the listSkill function
+const configuration: IMigrateConfiguration = {
+    destFile: destFile,
+    logger: logger,
+    sourceFile: sourceFile
+};
+new MigrateSkill(logger).migrateSkill(configuration);
+
+process.exit(0);

--- a/tools/botskills/src/botskills-migrate.ts
+++ b/tools/botskills/src/botskills-migrate.ts
@@ -99,7 +99,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
 
 sourceFile = isAbsolute(args.sourceFile) ? args.sourceFile : join(resolve('./'), args.sourceFile);
 
-// Initialize an instance of IListConfiguration to send the needed arguments to the listSkill function
+// Initialize an instance of IMigrateConfiguration to send the needed arguments to the migrateSkill function
 const configuration: IMigrateConfiguration = {
     destFile: destFile,
     logger: logger,

--- a/tools/botskills/src/botskills-migrate.ts
+++ b/tools/botskills/src/botskills-migrate.ts
@@ -38,7 +38,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 
 program
     .name('botskills migrate')
-    .description('Migrate all the Skills connected in your assistant to the new schema')
+    .description('migrate all the skills currently connected to your assistant to the new configuration settings (appSettings.json)')
     .option('--sourceFile [path]', '[OPTIONAL] Path to your skills file from that you want to migrate (defaults to \'skills.json\' inside your assistant\'s folder)')
     .option('--destFile [path]', '[OPTIONAL] Path to your app settings file to migrate the skills (defaults to \'appsettings.json\' inside your assistant\'s folder)')
     .option('--verbose', '[OPTIONAL] Output detailed information about the processing of the tool')

--- a/tools/botskills/src/botskills-migrate.ts
+++ b/tools/botskills/src/botskills-migrate.ts
@@ -41,6 +41,7 @@ program
     .description('Migrate all the Skills connected in your assistant to the new schema')
     .option('--sourceFile [path]', '[OPTIONAL] Path to your skills file from that you want to migrate (defaults to \'skills.json\' inside your assistant\'s folder)')
     .option('--destFile [path]', '[OPTIONAL] Path to your app settings file to migrate the skills (defaults to \'appsettings.json\' inside your assistant\'s folder)')
+    .option('--verbose', '[OPTIONAL] Output detailed information about the processing of the tool')
     .action((cmd: program.Command, actions: program.Command): undefined => undefined);
 
 const args: program.Command = program.parse(process.argv);

--- a/tools/botskills/src/botskills.ts
+++ b/tools/botskills/src/botskills.ts
@@ -39,7 +39,8 @@ program
     .command('disconnect', 'disconnect a specific skill from your assitant bot')
     .command('update', 'update a specific skill from your assistant bot')
     .command('refresh', 'refresh the connected skills')
-    .command('list', 'list the connected skills in the assistant');
+    .command('list', 'list the connected skills in the assistant')
+    .command('migrate', 'migrate the Skills connected in your assistant to the new schema');
 
 const args: program.Command = program.parse(process.argv);
 // args should be undefined is subcommand is executed

--- a/tools/botskills/src/functionality/index.ts
+++ b/tools/botskills/src/functionality/index.ts
@@ -8,3 +8,4 @@ export { DisconnectSkill } from './disconnectSkill';
 export { ListSkill } from './listSkill';
 export { RefreshSkill } from './refreshSkill';
 export { UpdateSkill } from './updateSkill';
+export { MigrateSkill } from './migrateSkill';

--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -31,7 +31,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
                 return false;
             }
 
-            // Take VA Skills configurations
+            // Take source file Skills configurations
             const sourceAssistantSkills: ISkillFileV1 = JSON.parse(readFileSync(configuration.sourceFile, 'UTF8'));
             if (sourceAssistantSkills.skills === undefined || sourceAssistantSkills.skills.length === 0) {
                 this.logger.message('There are no Skills in the source file.');

--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -66,7 +66,8 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             destFile.BotFrameworkSkills = destAssistantSkills;
             writeFileSync(configuration.destFile, JSON.stringify(destFile, undefined, 4));
 
-            this.logger.success(`Successfully migrated all the skills for the new version`);
+            this.logger.success(`Successfully migrated all the skills for the new version.`);
+            this.logger.warning(`You may now delete the source file.`);
             return true;
         } catch (err) {
             this.logger.error(`There was an error while migrating the Skills:\n ${ err }`);

--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { ConsoleLogger, ILogger} from '../logger';
+import { IMigrateConfiguration, IAppSetting, ISkill, ISkillManifestV1, ISkillFileV1 } from '../models';
+import { isInstanceOfISkillManifestV1 } from '../utils/validationUtils';
+
+export class MigrateSkill {
+    public logger: ILogger;
+    public constructor(logger?: ILogger) {
+        this.logger = logger || new ConsoleLogger();
+    }
+    public async migrateSkill(configuration: IMigrateConfiguration): Promise<boolean> {
+        try {
+            // Validate configuration.destFile
+            if (!existsSync(configuration.destFile)) {
+                this.logger.error(`The 'destFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--destFile' argument.`);
+
+                return false;
+            }
+
+            // Validate configuration.sourceFile
+            if (!existsSync(configuration.sourceFile)) {
+                this.logger.error(`The 'sourceFile' argument is absent or leads to a non-existing file.
+Please make sure to provide a valid path to your Assistant Skills configuration file using the '--sourceFile' argument.`);
+
+                return false;
+            }
+
+            // Take VA Skills configurations
+            const sourceAssistantSkills: ISkillFileV1 = JSON.parse(readFileSync(configuration.sourceFile, 'UTF8'));
+            if (sourceAssistantSkills.skills === undefined || sourceAssistantSkills.skills.length === 0) {
+                this.logger.message('There are no Skills in the source file.');
+
+                return false;
+            }
+
+            const destFile: IAppSetting = JSON.parse(readFileSync(configuration.destFile, 'UTF8'));
+
+            const destAssistantSkills: ISkill[] = destFile.BotFrameworkSkills || [];
+
+            sourceAssistantSkills.skills.forEach((skill): void => {
+                if (isInstanceOfISkillManifestV1(skill)){
+
+                    if (destAssistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.Id === skill.id)) {
+                        this.logger.warning(`The skill '${ skill.name }' is already registered.`);
+                        return;
+                    }
+                    let migratedSkill: ISkill = 
+                    {
+                        Id: skill.id,
+                        AppId: skill.msaAppId,
+                        SkillEndpoint: skill.endpoint,
+                        Name: skill.name
+                    };
+    
+                    destAssistantSkills.push(migratedSkill);
+                }
+                else {
+                    throw new Error(`A skill has an incorrect format, please check that all the skills intended to be migrated has the V1 format`);
+                }
+            });
+
+            destFile.BotFrameworkSkills = destAssistantSkills;
+            writeFileSync(configuration.destFile, JSON.stringify(destFile, undefined, 4));
+
+            this.logger.success(`Successfully migrated all the skills for the new version`);
+            return true;
+        } catch (err) {
+            this.logger.error(`There was an error while migrating the Skills:\n ${ err }`);
+
+            return false;
+        }
+    }
+}

--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -66,8 +66,8 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             destFile.BotFrameworkSkills = destAssistantSkills;
             writeFileSync(configuration.destFile, JSON.stringify(destFile, undefined, 4));
 
-            this.logger.success(`Successfully migrated all the skills for the new version.`);
-            this.logger.warning(`You may now delete the source file.`);
+            this.logger.success(`Successfully migrated all the skills to the new version.`);
+            this.logger.warning(`You may now delete the skills.json file.`);
             return true;
         } catch (err) {
             this.logger.error(`There was an error while migrating the Skills:\n ${ err }`);

--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { ConsoleLogger, ILogger} from '../logger';
-import { IMigrateConfiguration, IAppSetting, ISkill, ISkillManifestV1, ISkillFileV1 } from '../models';
+import { IMigrateConfiguration, IAppSetting, ISkill, ISkillFileV1 } from '../models';
 import { isInstanceOfISkillManifestV1 } from '../utils/validationUtils';
 
 export class MigrateSkill {
@@ -50,15 +50,13 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
                         this.logger.warning(`The skill '${ skill.name }' is already registered.`);
                         return;
                     }
-                    let migratedSkill: ISkill = 
-                    {
+
+                    destAssistantSkills.push({
                         Id: skill.id,
                         AppId: skill.msaAppId,
                         SkillEndpoint: skill.endpoint,
                         Name: skill.name
-                    };
-    
-                    destAssistantSkills.push(migratedSkill);
+                    });
                 }
                 else {
                     throw new Error(`A skill has an incorrect format, please check that all the skills intended to be migrated has the V1 format`);

--- a/tools/botskills/src/models/index.ts
+++ b/tools/botskills/src/models/index.ts
@@ -16,6 +16,7 @@ export { IDisconnectConfiguration } from './disconnectConfiguration';
 export { IUpdateConfiguration } from './updateConfiguration';
 export { IDispatchFile, IDispatchService } from './dispatchFile';
 export { IListConfiguration } from './listConfiguration';
+export { IMigrateConfiguration } from './migrateConfiguration';
 export { ISkillFileV1 } from './manifestV1/skillFileV1';
 export {
     IAction,

--- a/tools/botskills/src/models/migrateConfiguration.ts
+++ b/tools/botskills/src/models/migrateConfiguration.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ILogger } from '../logger';
+
+export interface IMigrateConfiguration {
+    logger?: ILogger;
+    destFile: string;
+    sourceFile: string;
+}


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Since a new manifest schema was released, the old skills had to be migrated manually from the `skills.json` file to `appsettings.json` file. So we added the `migrate` command to automate this work.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
* Add `--sourceFile` argument where will be specified the file **from where** the skills will be migrated  (default is the `skills.json` file)
* Add `--destFile` argument where will be specified the file **where** the skills will be migrated (default is the `appsettings.json` file)


### Tests
*Is this covered by existing tests or new ones? If no, why not?*
They are not currently covered by tests. It's in the feature plan in order to finish with this feature.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will continue updating the documentation, fixing tests, updating the VA/Skill.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
