### PR TITLE
[Botskills] Improve manifest schema version warning

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -147,7 +147,7 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
             return manifestVersion.V2;
         }
         else {
-            throw new Error('The Skill Manifest is not compatible with any version supported.');
+            throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
         }
     }
 


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The validation warning of the manifest schema didn't specify that the versions less than 2.1 are not supported, so we improve it.

### Changes
* The warning text was changed to be more precise.


### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
