### PR TITLE
Fixing strings that were reverted by commit 6d40fa8a

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.de.resx
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.de.resx
@@ -127,6 +127,6 @@
     <value>entlassen</value>
   </data>
   <data name="FeedbackReceivedMessage" xml:space="preserve">
-    <value>Vielen Dank für Ihr Feedback!</value>
+    <value>Danke, ich freue mich über Ihr Feedback.</value>
   </data>
 </root>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.es.resx
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.es.resx
@@ -127,6 +127,6 @@
     <value>Despedir</value>
   </data>
   <data name="FeedbackReceivedMessage" xml:space="preserve">
-    <value>Gracias por sus comentarios!</value>
+    <value>Gracias, agradezco sus comentarios.</value>
   </data>
 </root>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.fr.resx
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.fr.resx
@@ -127,6 +127,6 @@
     <value>Rejeter</value>
   </data>
   <data name="FeedbackReceivedMessage" xml:space="preserve">
-    <value>Merci pour vos commentaires!</value>
+    <value>Merci, j'apprécie vos commentaires.</value>
   </data>
 </root>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.it.resx
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.it.resx
@@ -127,6 +127,6 @@
     <value>Licenziare</value>
   </data>
   <data name="FeedbackReceivedMessage" xml:space="preserve">
-    <value>Grazie per il tuo feedback!</value>
+    <value>Grazie, apprezzo il tuo feedback.</value>
   </data>
 </root>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.resx
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Feedback/FeedbackResponses.resx
@@ -127,6 +127,6 @@
     <value>Dismiss</value>
   </data>
   <data name="FeedbackReceivedMessage" xml:space="preserve">
-    <value>Thanks for your feedback!</value>
+    <value>Thanks, I appreciate your feedback.</value>
   </data>
 </root>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
