### PR TITLE
Update build.cognitive-models.ps1 to reflect camel case for property names

### DIFF
--- a/build/build.cognitive-models.ps1
+++ b/build/build.cognitive-models.ps1
@@ -20,13 +20,13 @@ $dispatchModel = [pscustomobject]@{
 }
 
 $languageModel = [pscustomobject]@{
-    appid = ""
-    authoringkey = ""
+    appId = ""
+    authoringKey = ""
     authoringRegion = ""
     id = ""
     name = ""
     region = ""
-    subscriptionkey = ""
+    subscriptionKey = ""
     version = ""
 }
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
This changes the casing to camel case for some cognitive models properties so that is consistent throughout. In our test environment this only affects any multilanguage apps that call this script. Once this is closed the variable groups for the Core/Skill/Enterprise/Hospitality VA and Calendar/Email/POI/To-Do Skills need to be updated to appropriately reflect this.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
