### PR TITLE
[Botskills] Add LUIS HTTP functionality

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -83,7 +83,20 @@ export class ConnectSkill {
                         luisFile = `${luFile.toLowerCase()}is`;
                         luFilePath = join(this.configuration.luisFolder, culture, luFile);
                     }
-                } else {
+                }
+                else if (currentApp.url.startsWith('http')) {
+                    try {
+                        const remoteLuFile = await this.getRemoteLu(currentApp.url);
+                        let luisAppName: string = currentApp.url.split('/').reverse()[0];
+
+                        const luPath = join(this.configuration.luisFolder, culture, luisAppName.endsWith('.lu') ? luisAppName : luisAppName + '.lu');
+                        writeFileSync(luPath, remoteLuFile);
+                        luFilePath = luPath;
+                    } catch (error) {
+                        console.log(error);
+                    }
+                }
+                else {
                     luFilePath = currentApp.url;
                 }
                 
@@ -161,6 +174,16 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
             return await this.childProcessUtils.execute(cmd, commandArgs);
         } catch (err) {
             throw new Error(`The execution of the ${ cmd } command failed with the following error:\n${ err }`);
+        }
+    }
+
+    private async getRemoteLu(path: string): Promise<string> {
+        try {
+            return get({
+                uri: path
+            });
+        } catch (err) {
+            throw new Error(`There was a problem while getting the remote lu file:\n${err}`);
         }
     }
 


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
To test `botskills` with pipelines, the lu files has to be deployed.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
* In the `manifestV2`, the url of the `.lu` file has to be provided on the `url` property if you want to use the LUIS HTTP functionality. 

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will add tests for this functionality

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
