### PR TITLE
[Calendar] remove duplicated utterances in .lu file

### DIFF
--- a/skills/csharp/calendarskill/Deployment/Resources/LU/de-de/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/de-de/Calendar.lu
@@ -1062,7 +1062,6 @@
 
 ## FindMeetingRoom
 - einen neuen Besprechungsort finden
-- Fügen Sie eine  {SlotAttribute=Zimmer}  zu meinem  {FromTime=15.00 Uhr} Sitzung
 - bin gehen, um morgen auf einem anderen Zustand zu arbeiten, muss ich ein Zimmer in buchen  {MeetingRoom=Johan} Street
 - Eine  {MeetingRoom=Zimmer} .
 - Sind  {MeetingRoom=Zimmer} 
@@ -1412,7 +1411,6 @@
 - kann ich die  {MeetingRoom=Damenzimmer a1/1657} für tommorow?
 - kann ich senden, um die  {MeetingRoom=großes Zimmer 4} ?
 - kann ich diesen Montag zum  {MeetingRoom=Flitterwochen-Suite} ?
-- können Sie eine  {SlotAttribute=Zimmer}  An  {FromDate=Morgen} s  {Subject=Dev-Meeting} 
 - können Sie eine  {MeetingRoom=Konferenzraum} in der Nähe des Stadtzentrums
 - können Sie ein Zimmer buchen  {MeetingRoom=4/3342} in der Nähe des Stadtzentrums Hotel
 - können Sie reservieren  {MeetingRoom=Zimmer 258} Sofort
@@ -1564,7 +1562,6 @@
 -  {MeetingRoom=ändern Sie nur den Zimmernamen} 
 - bestellen Sie  {MeetingRoom=Zimmer 669}  In  {MeetingRoom=Ostflügel} für 16 Uhr
 - organisieren Sie ein Meeting in der  {MeetingRoom=Gandhi}  Zimmer im  {FloorNumber=3. Stock}  auf der  {Building=greenpark Hotel} 
-- bitte fügen Sie eine  {SlotAttribute=Tagungsraum}  zum  {Subject=tägliches Scrum-Meeting} 
 - Bitte fügen Sie eine Reservierung hinzu, um  {MeetingRoom=Konferenzraum 2} 
 - Bitte buchen Sie 2 Zimmer, die nicht weit von  {MeetingRoom=stella es zimmer} .
 - bitte buchen Sie ein Zimmer im taj banjaraa  {MeetingRoom=2/2241} im 2. Stock.

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/en-us/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/en-us/Calendar.lu
@@ -1138,7 +1138,6 @@
 
 ## FindMeetingRoom
 - a new meeting location find one
-- add a {SlotAttribute=room} to my {FromTime=3pm} meeting
 - am goin to work tomorrow on another state, i need to book a room in {MeetingRoom=johan} street
 - an {MeetingRoom=room}.
 - are {MeetingRoom=room}
@@ -1488,7 +1487,6 @@
 - can i book the {MeetingRoom=queens room a1/1657} for tommorow?
 - can i send to reserve the {MeetingRoom=big room 4}?
 - can i stay this monday to the {MeetingRoom=honeymoon suite}?
-- can you add a {SlotAttribute=room} to {FromDate=tomorrow}'s {Subject=dev meeting}
 - can you book a {MeetingRoom=conference room} near to city center
 - can you book a room {MeetingRoom=4/3342} near to city center hotel
 - can you reserve {MeetingRoom=room 258} right away
@@ -1640,7 +1638,6 @@
 - {MeetingRoom=only change the room name}
 - order a {MeetingRoom=room 669} in {MeetingRoom=east wing} for 4 pm
 - organize a meeting in the {MeetingRoom=gandhi} room in the {FloorNumber=3rd floor} on the {Building=greenpark hotel}
-- please add a {SlotAttribute=meeting room} to the {Subject=daily scrum meeting}
 - please add a reservation to {MeetingRoom=conference room 2}
 - please book 2 rooms which are not far away from {MeetingRoom=stella's room}.
 - please book a room at taj banjaraa {MeetingRoom=2/2241} at 2nd floor.

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/es-es/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/es-es/Calendar.lu
@@ -1050,7 +1050,6 @@
 ## FindMeetingRoom
 ## FindMeetingRoom
 - un nuevo lugar de reunión encontrar una
-- añadir un  {SlotAttribute=Habitación}  a mi  {FromTime=15:00} Reunión
 - voy a trabajar mañana en otro estado, necesito reservar una habitación en  {MeetingRoom=Johan} Calle
 - Un  {MeetingRoom=Habitación} .
 - Son  {MeetingRoom=Habitación} 
@@ -1400,7 +1399,6 @@
 - ¿puedo reservar el  {MeetingRoom=habitación queens a1/1657} para el tommorow?
 - ¿puedo enviar para reservar el  {MeetingRoom=habitación grande 4} ?
 - puedo quedarme este lunes a la  {MeetingRoom=suite de luna de miel} ?
-- puede añadir un  {SlotAttribute=Habitación}  Para  {FromDate=Mañana} 's  {Subject=reunión de desarrollo} 
 - se puede reservar un  {MeetingRoom=sala de conferencias} cerca del centro de la ciudad
 - se puede reservar una habitación  {MeetingRoom=4/3342} cerca del hotel del centro de la ciudad
 - puede reservar  {MeetingRoom=habitación 258} Ahora mismo
@@ -1552,7 +1550,6 @@
 -  {MeetingRoom=sólo cambiar el nombre de la habitación} 
 - ordenar un  {MeetingRoom=habitación 669}  En  {MeetingRoom=ala este} para las 4 pm
 - organizar una reunión en el  {MeetingRoom=Gandhi}  habitación en el  {FloorNumber=3a planta}  en el  {Building=hotel greenpark} 
-- por favor agregue un  {SlotAttribute=sala de reuniones}  a la  {Subject=reunión diaria de scrum} 
 - por favor agregue una reserva a  {MeetingRoom=Sala de conferencias 2} 
 - por favor reserve 2 habitaciones que no están lejos de  {MeetingRoom=habitación de Stella} .
 - por favor reserve una habitación en taj banjaraa  {MeetingRoom=2/2241} en el 2o piso.

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/fr-fr/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/fr-fr/Calendar.lu
@@ -1049,7 +1049,6 @@
 
 ## FindMeetingRoom
 - un nouveau lieu de réunion trouver un
-- ajouter un  {SlotAttribute=Chambre}  à mon  {FromTime=15h00} Réunion
 - suis goin travailler demain sur un autre état, j'ai besoin de réserver une chambre dans  {MeetingRoom=Johan} Rue
 - Un  {MeetingRoom=Chambre} .
 - Sont  {MeetingRoom=Chambre} 
@@ -1399,7 +1398,6 @@
 - puis-je réserver le  {MeetingRoom=chambre des reines a1/1657} pour tommorow?
 - puis-je envoyer pour réserver le  {MeetingRoom=grande salle 4} ?
 - puis-je rester ce lundi à la  {MeetingRoom=Nuptiale} ?
-- pouvez-vous ajouter un  {SlotAttribute=Chambre}  À  {FromDate=Demain} Est  {Subject=réunion dev} 
 - pouvez-vous réserver un  {MeetingRoom=salle de conférence} près du centre-ville
 - pouvez-vous réserver une chambre  {MeetingRoom=4/3342} à proximité de l'hôtel du centre-ville
 - pouvez-vous réserver  {MeetingRoom=chambre 258} Tout de suite
@@ -1551,7 +1549,6 @@
 -  {MeetingRoom=ne changer le nom de la chambre} 
 - commander un  {MeetingRoom=chambre 669}  Dans  {MeetingRoom=Aile} pour 16h00
 - organiser une réunion dans le  {MeetingRoom=Gandhi}  chambre dans le  {FloorNumber=3e étage}  sur le  {Building=hôtel greenpark} 
-- s'il vous plaît ajouter un  {SlotAttribute=salle de réunion}  à la  {Subject=réunion de mêlée quotidienne} 
 - s'il vous plaît ajouter une réservation à  {MeetingRoom=salle de conférence 2} 
 - s'il vous plaît réserver 2 chambres qui ne sont pas loin de  {MeetingRoom=chambre de stella} .
 - s'il vous plaît réserver une chambre à taj banjaraa  {MeetingRoom=2/2241} au 2ème étage.

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/it-it/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/it-it/Calendar.lu
@@ -65,10 +65,10 @@
 - inviare un invito a  {ContactName=Jane} 
 - inviare un invito a  {ContactName=jerry seinfeld} 
 - si prega di aggiungere una stanza al mio  {ToTime=Ore 19.00} Riunione
-- Fügen Sie eine  {SlotAttribute=Zimmer}  zu meinem  {ToTime=15.00 Uhr} Sitzung
-- Stadtzentrum hinzufügen  {MeetingRoom=2122}  An  {ToTime=10am} Sitzung
-- können Sie eine  {SlotAttribute=Zimmer}  An  {ToDate=Morgen} s  {Subject=Dev-Meeting} 
-- bitte fügen Sie eine  {SlotAttribute=Tagungsraum}  zum  {Subject=tägliches Scrum-Meeting} 
+- aggiungere un {SlotAttribute=Camera}  al mio {ToTime=Ore 15.00}  Riunione
+- aggiungere il centro della città {MeetingRoom=2122}  A {ToTime=Ore 10:00}  Riunione
+- è possibile aggiungere un {SlotAttribute=Camera}  A {ToDate=Domani}'s {Subject=dev incontro}
+- si prega di aggiungere un {SlotAttribute=sala riunioni}  al {Subject=riunione di mischia quotidiana}
 
 
 ## ChangeCalendarEntry
@@ -180,11 +180,11 @@
 - sposta la riunione delle {FromTime=15} alle {ToTime=16}
 - sposta riunione delle {FromTime=21}-{FromTime=22} alle {ToTime=20}-{ToTime=21} {ToDate=oggi}
 - sposta {Subject=riunione organizzazione festa} da {FromDate={FromTime=sabato}} a {ToDate=venerdì} all'{ToTime=13}
-- ändern Sie die  {SlotAttribute=Tagungsraum}  An  {MeetingRoom=london confroom excalibur} 
-- finden Sie eine neue  {SlotAttribute=Zimmer}  für meine  {FromTime=15.00 Uhr} Sitzung
-- ich möchte zu einem anderen wechseln  {SlotAttribute=Tagungsraum} 
-- ich möchte die  {SlotAttribute=Tagungsraum} 
-- bitte ändern Sie die  {SlotAttribute=Tagungsraum}  An  {MeetingRoom=2212} 
+- cambiare il {SlotAttribute=sala riunioni}  A {MeetingRoom=londra confroom excalibur}
+- trovare un nuovo {SlotAttribute=Camera}  per la mia {FromTime=Ore 15.00}  Riunione
+- voglio passare a un altro {SlotAttribute=sala riunioni}
+- mi piacerebbe cambiare il {SlotAttribute=sala riunioni}
+- si prega di cambiare il {SlotAttribute=sala riunioni}  A {MeetingRoom=2212}
 
 
 ## CheckAvailability
@@ -682,11 +682,11 @@
 - rimuovi {Subject=ripetizioni finali} dal mio calendario
 - rimuovi {Subject=visita dal dentista}
 - voglio cancellare un appuntamento
-- abbrechen die  {SlotAttribute=Tagungsraum} 
-- abbrechen die  {SlotAttribute=Zimmer}  Für  {Subject=tägliches Scrum-Meeting} 
-- löschen Sie die  {SlotAttribute=Zimmer}  für meine  {FromTime=16 Uhr} Sitzung
-- löschen Sie die  {SlotAttribute=Tagungsraum}  von meinem  {FromTime=18.00 Uhr} Sitzung
-- bitte stornieren Sie die  {SlotAttribute=Zimmer}  von meinem  {FromTime=19.00 Uhr} Sitzung
+- annullare il {SlotAttribute=sala riunioni}
+- annullare il {SlotAttribute=Camera}  Per {Subject=riunione di mischia quotidiana}
+- eliminare il {SlotAttribute=Camera}  per la mia {FromTime=Ore 16.00}  Riunione
+- eliminare il {SlotAttribute=sala riunioni}  della mia {FromTime=Ore 18.00}  Riunione
+- si prega di annullare il {SlotAttribute=Camera}  della mia {FromTime=Ore 19.00}  Riunione
 
 ## FindCalendarDetail
 - cosa è in programma per la {Subject=cena} con stephanie?
@@ -1043,7 +1043,6 @@
 
 ## FindMeetingRoom
 - un nuovo luogo di riunione trovarne uno
-- aggiungere un  {SlotAttribute=Camera}  al mio  {FromTime=Ore 15.00} Riunione
 - am goin a lavorare domani su un altro stato, ho bisogno di prenotare una stanza in  {MeetingRoom=Johan} via
 - Un  {MeetingRoom=Camera} .
 - Sono  {MeetingRoom=Camera} 
@@ -1989,12 +1988,12 @@ $RelationshipName:zii=
 $RelationshipName:moglie=
 
 $SlotAttributeName:room=
-- Zimmer
-- Tagungsraum
-- Konferenzraum
+- Camera
+- sala riunioni
+- sala conferenze
 
 $SlotAttributeName:time=
-- Zeit
+- Tempo
 
 > # RegEx entities
 $MeetingRoomKeywordsDesc:/((conf|conference|meeting)\s+)?(room|rm|office)/

--- a/skills/csharp/calendarskill/Deployment/Resources/LU/zh-cn/Calendar.lu
+++ b/skills/csharp/calendarskill/Deployment/Resources/LU/zh-cn/Calendar.lu
@@ -1000,7 +1000,6 @@
 
 ## FindMeetingRoom
 - 新的会议地点找到一个
-- 添加 {SlotAttribute=房间} 到我 {FromTime=下午3点} 会议
 - 我明天去工作的另一个国家，我需要预订一个房间 {MeetingRoom=约翰} 街
 - a {MeetingRoom=房间} .
 - 是 {MeetingRoom=房间} 
@@ -1350,7 +1349,6 @@
 - 我可以预订 {MeetingRoom=皇后室 a1/1657} 给汤莫罗？
 - 我可以发送预订 {MeetingRoom=大房间 4} ?
 - 我可以留在这个星期一 {MeetingRoom=蜜月套房} ?
-- 可以添加 {SlotAttribute=房间} 自 {FromDate=明天} 's {Subject=开发会议} 
 - 你能预订一个 {MeetingRoom=会议室} 靠近市中心
 - 你能预订一个房间吗？ {MeetingRoom=4/3342} 靠近市中心酒店
 - 你能预订吗？ {MeetingRoom=房间 258} 马上
@@ -1502,7 +1500,6 @@
 -  {MeetingRoom=只更改房间名称} 
 - 订购 {MeetingRoom=房间 669} 在 {MeetingRoom=东翼} 下午4点
 - 在 {MeetingRoom=甘地} 房间在 {FloorNumber=三楼} 在 {Building=绿色公园酒店} 
-- 请添加 {SlotAttribute=会议室} 到 {Subject=每日Scrum会议} 
 - 请添加预订到 {MeetingRoom=会议室 2} 
 - 请预订2间不远处的客房 {MeetingRoom=斯特拉的房间} .
 - 请预订塔吉班贾拉的房间 {MeetingRoom=2/2241} 在二楼


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
close #3032 
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Remove some duplicated utterances, and corrected a mistake for Italian .lu(some utterances labled as German)
### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
