### PR TITLE
removing hardcoded language param in contentModerator

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/ContentModeratorMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/ContentModeratorMiddleware.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Bot.Solutions.Middleware
                 client.Endpoint = $"{region}.api.cognitive.microsoft.com";
 
                 var screenResult = client.TextModeration.ScreenText(
-                    language: "eng",
                     textContentType: "text/plain",
                     textContent: textStream,
                     autocorrect: true,


### PR DESCRIPTION
The content moderator api will auto detect language (I have tested with Spanish and English) so we do not need to hard code it to english, enabling the middleware to be used by other locales.