### PR TITLE
add emulator url to deploy scripts

### DIFF
--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -271,7 +271,7 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
-	
+
 	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
 	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }

--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,9 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -271,7 +271,7 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
-	
+
 	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
 	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,9 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -271,7 +271,7 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
-	
+
 	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
 	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,9 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/calendarskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/calendarskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/calendarskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/calendarskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/emailskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/emailskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/emailskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/emailskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/automotiveskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/automotiveskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/automotiveskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/automotiveskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/eventskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/eventskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/eventskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/eventskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/itsmskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/itsmskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/itsmskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/itsmskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/musicskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/musicskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/musicskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/musicskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/newsskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/phoneskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/phoneskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/phoneskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/phoneskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/experimental/weatherskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/pointofinterestskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/pointofinterestskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/pointofinterestskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/pointofinterestskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/skills/csharp/todoskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/todoskill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/skills/csharp/todoskill/Deployment/Scripts/deploy.ps1
+++ b/skills/csharp/todoskill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,8 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {

--- a/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline

--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
@@ -218,9 +218,9 @@ if ($outputs)
 	$outputMap = @{}
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
-    # Update AD app with homepage
+	# Update AD app with homepage
 	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
-    az ad app update --id $appId --homepage $botWebAppUrl
+	az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -271,7 +271,7 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
-	
+
 	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
 	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }

--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
@@ -219,7 +219,8 @@ if ($outputs)
 	$outputs.PSObject.Properties | Foreach-Object { $outputMap[$_.Name] = $_.Value }
 
     # Update AD app with homepage
-    az ad app update --id $appId --homepage "https://$($outputs.botWebAppName.value).azurewebsites.net"
+	$botWebAppUrl = "https://$($outputs.botWebAppName.value).azurewebsites.net"
+    az ad app update --id $appId --homepage $botWebAppUrl
 
 	# Update appsettings.json
 	Write-Host "> Updating appsettings.json ..." -NoNewline
@@ -270,6 +271,9 @@ if ($outputs)
 	Write-Host "    - Microsoft App Password: $($appPassword)" -ForegroundColor Magenta
 
 	Write-Host "> Deployment complete." -ForegroundColor Green
+	
+	Write-Host "Test your deployed bot on the bot framework emulator with the following link (copy and paste link into windows -> run to open the emulator with your deployed bot configured)" -ForegroundColor Green
+	Write-Host "bfemulator://livechat.open?botUrl=$($botWebAppUrl)/api/messages&msaAppId=$($appId)&msaAppPassword=$($appPassword)" -ForegroundColor Green
 }
 else
 {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
So users can open emulator after deployment and ensure the right endpoint, appid and password are configured.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
