### PR TITLE
[Sdk] change voiceName to dictionary for SetSpeakMiddleware

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Bot.Solutions.Middleware
     /// </summary>
     public class SetSpeakMiddleware : IMiddleware
     {
-        public const string DefaultLocale = "en-US";
+        private const string DefaultLocale = "en-US";
 
-        public static readonly IDictionary<string, string> DefaultVoiceFonts = new Dictionary<string, string>()
+        private static readonly IDictionary<string, string> DefaultVoiceFonts = new Dictionary<string, string>()
         {
             { "de-DE", "Microsoft Server Speech Text to Speech Voice (de-DE, Hedda)" },
             { "en-US", "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)" },
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Solutions.Middleware
             { "zh-CN", "Microsoft Server Speech Text to Speech Voice (zh-CN, HuihuiRUS)" },
         };
 
-        public static readonly ISet<string> DefaultChannels = new HashSet<string>()
+        private static readonly ISet<string> DefaultChannels = new HashSet<string>()
         {
             Connector.Channels.DirectlineSpeech,
             Connector.Channels.Emulator,
@@ -47,12 +47,12 @@ namespace Microsoft.Bot.Solutions.Middleware
         /// <summary>
         /// Initializes a new instance of the <see cref="SetSpeakMiddleware"/> class.
         /// </summary>
-        /// <param name="locale">Default <see cref="DefaultLocale"/>.</param>
-        /// <param name="voiceFonts">Map voice font for locale. If null, use <see cref="DefaultVoiceFonts"/>.</param>
-        /// <param name="channels">Set SSML for these channels. If null, use <see cref="DefaultChannels"/>.</param>
-        public SetSpeakMiddleware(string locale = DefaultLocale, IDictionary<string, string> voiceFonts = null, ISet<string> channels = null)
+        /// <param name="locale">If null, use en-US.</param>
+        /// <param name="voiceFonts">Map voice font for locale like en-US to "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)".</param>
+        /// <param name="channels">Set SSML for these channels. If null, use <see cref="Connector.Channels.DirectlineSpeech"/> and <see cref="Connector.Channels.Emulator"/>.</param>
+        public SetSpeakMiddleware(string locale = null, IDictionary<string, string> voiceFonts = null, ISet<string> channels = null)
         {
-            _locale = locale;
+            _locale = locale ?? DefaultLocale;
             _voiceFonts = voiceFonts ?? DefaultVoiceFonts;
             _channels = channels ?? DefaultChannels;
         }

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Middleware/SetSpeakMiddlewareTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Middleware/SetSpeakMiddlewareTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions.Feedback;
+using Microsoft.Bot.Solutions.Middleware;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Solutions.Tests.Middleware
+{
+    [TestClass]
+    [TestCategory("UnitTests")]
+    public class SetSpeakMiddlewareTests
+    {
+        [TestMethod]
+        public async Task DefaultOptions_Default()
+        {
+            var storage = new MemoryStorage();
+            var convState = new ConversationState(storage);
+
+            var conversation = TestAdapter.CreateConversation("Name");
+            conversation.ChannelId = Connector.Channels.DirectlineSpeech;
+
+            var adapter = new TestAdapter(conversation)
+                .Use(new SetSpeakMiddleware());
+            adapter.Locale = string.Empty;
+
+            var response = "Response";
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                await context.SendActivityAsync(context.Activity.CreateReply(response));
+            })
+                .Send("foo")
+                .AssertReply((reply) =>
+                {
+                    var activity = (Activity)reply;
+                    var rootElement = XElement.Parse(activity.Speak);
+                    Assert.AreEqual(rootElement.Name.LocalName, "speak");
+                    Assert.AreEqual(rootElement.Attribute(XNamespace.Xml + "lang").Value, "en-US");
+                    var voiceElement = rootElement.Element("voice");
+                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)");
+                    Assert.AreEqual(voiceElement.Value, response);
+                })
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task DefaultOptions_ZhCN()
+        {
+            var storage = new MemoryStorage();
+            var convState = new ConversationState(storage);
+
+            var conversation = TestAdapter.CreateConversation("Name");
+            conversation.ChannelId = Connector.Channels.DirectlineSpeech;
+
+            var adapter = new TestAdapter(conversation)
+                .Use(new SetSpeakMiddleware());
+            adapter.Locale = "zh-cn";
+
+            var response = "Response";
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                await context.SendActivityAsync(context.Activity.CreateReply(response));
+            })
+                .Send("foo")
+                .AssertReply((reply) =>
+                {
+                    var activity = (Activity)reply;
+                    var rootElement = XElement.Parse(activity.Speak);
+                    Assert.AreEqual(rootElement.Name.LocalName, "speak");
+                    Assert.AreEqual(rootElement.Attribute(XNamespace.Xml + "lang").Value, "zh-CN");
+                    var voiceElement = rootElement.Element("voice");
+                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (zh-CN, HuihuiRUS)");
+                    Assert.AreEqual(voiceElement.Value, response);
+                })
+                .StartTestAsync();
+        }
+    }
+}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Close #2984

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

* Change voiceName to dictionary for SetSpeakMiddleware
    - Use non Neural for broader supported region
* Add SetSpeakMiddlewareTests
* Need update https://microsoft.github.io/botframework-solutions/clients-and-channels/tutorials/enable-speech/5-changing-the-voice/

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
