### PR TITLE
change from > to Out-File w/ encoding

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -140,7 +140,7 @@ foreach ($langCode in $languageMap.Keys) {
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --cloud $cloud `
-                --authoringKey $luisApp.authoringKey > $(Join-Path $luisFolder $langCode "$($luisApp.id).json")
+                --authoringKey $luisApp.authoringKey | Out-File -Encoding oem $(Join-Path $luisFolder $langCode "$($luisApp.id).json")
 
             bf luis:convert `
                 --in $(Join-Path $luisFolder $langCode "$($luisApp.id).json") `
@@ -196,7 +196,7 @@ foreach ($langCode in $languageMap.Keys) {
                 --endpoint $qnaEndpoint `
                 --environment Prod `
                 --kbId $kb.kbId `
-                --subscriptionKey $kb.subscriptionKey > $(Join-Path $qnaFolder $langCode "$($kb.id).json")
+                --subscriptionKey $kb.subscriptionKey | Out-File -Encoding oem $(Join-Path $qnaFolder $langCode "$($kb.id).json")
                 
             bf qnamaker:convert `
                 --in $(Join-Path $qnaFolder $langCode "$($kb.id).json") `

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -140,7 +140,7 @@ foreach ($langCode in $languageMap.Keys) {
                 --versionId $luisApp.version `
                 --region $luisApp.authoringRegion `
                 --cloud $cloud `
-                --authoringKey $luisApp.authoringKey > $(Join-Path $luisFolder $langCode "$($luisApp.id).json")
+                --authoringKey $luisApp.authoringKey | Out-File -Encoding oem $(Join-Path $luisFolder $langCode "$($luisApp.id).json")
 
             bf luis:convert `
                 --in $(Join-Path $luisFolder $langCode "$($luisApp.id).json") `
@@ -196,7 +196,7 @@ foreach ($langCode in $languageMap.Keys) {
                 --endpoint $qnaEndpoint `
                 --environment Prod `
                 --kbId $kb.kbId `
-                --subscriptionKey $kb.subscriptionKey > $(Join-Path $qnaFolder $langCode "$($kb.id).json")
+                --subscriptionKey $kb.subscriptionKey | Out-File -Encoding oem $(Join-Path $qnaFolder $langCode "$($kb.id).json")
                 
             bf qnamaker:convert `
                 --in $(Join-Path $qnaFolder $langCode "$($kb.id).json") `


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botframework-cli/issues/591

### Purpose

Using `<bf cli command> > <output files>` to output the stdout of a BF CLI command causes some encoding issues, particularly for Spanish and the `¿` character.

### Changes

From 

`<bf cli command> > <output files>`

To

`<bf cli command> | Out-File -Encoding oem <output files>`

...so that we can specify encoding as "OEM" instead of the default, "Unicode" which for some reason, causes this to break in PowerShell v5 and v6 (probably others, too).

Per @lauren-mills, these were the only two locations to update the scripts. I didn't notice any other scripts that would need this change.

### Tests

Manual test confirmed expected output.

I don't believe any tests need to be updates as I don't *think* this is covered by any, but let me know if that's not the case. If you have more extensive tests other than my manual run of `./Deployment/Scripts/update_cognitive_models.ps1 -RemoteToLocal`, I'd recommend running it before merging.

### Checklist

N/A
