### PR TITLE
Restore QnAMakerService to keep cognitive models working

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Bot.Solutions
 #pragma warning disable CS0618 // Type or member is obsolete
             // TODO: #3139 Add required cognitive model class in Solutions SDK.
             public List<QnAMakerService> Knowledgebases { get; set; }
+
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Bot.Solutions
             /// The collection of QnA Maker knowledgebases.
             /// </value>
 #pragma warning disable CS0618 // Type or member is obsolete
+            // TODO: Add required cognitive model class in Solutions SDK.
             public List<QnAMakerService> Knowledgebases { get; set; }
 #pragma warning restore CS0618 // Type or member is obsolete
         }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -167,9 +167,9 @@ namespace Microsoft.Bot.Solutions
             /// The collection of QnA Maker knowledgebases.
             /// </value>
 #pragma warning disable CS0618 // Type or member is obsolete
-            // TODO: #3139 Add required cognitive model class in Solutions SDK.
-            public List<QnAMakerService> Knowledgebases { get; set; }
 
+            // TODO #3139: Add required cognitive model class in Solutions SDK.
+            public List<QnAMakerService> Knowledgebases { get; set; }
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Bot.Solutions
             /// The collection of QnA Maker knowledgebases.
             /// </value>
 #pragma warning disable CS0618 // Type or member is obsolete
-            // TODO: Add required cognitive model class in Solutions SDK.
+            // TODO: #3139 Add required cognitive model class in Solutions SDK.
             public List<QnAMakerService> Knowledgebases { get; set; }
 #pragma warning restore CS0618 // Type or member is obsolete
         }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -166,7 +166,9 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The collection of QnA Maker knowledgebases.
             /// </value>
-            public List<QnAMakerEndpoint> Knowledgebases { get; set; }
+#pragma warning disable CS0618 // Type or member is obsolete
+            public List<QnAMakerService> Knowledgebases { get; set; }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
#3139 highlights that some ConnectedService classes are marked as obsolete. The `QnAMakerEndpoint` class does not have all the properties required for the VA to work as expected. I am proposing we revert this change back to the obsolete class with a comment. 

I have a related issue in the SDK repo on if `LuisService` should be obsolete as well. If so our library will need to provide a solution for all, so this is a mitigation of using the previous approach until we have all the details.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
