### PR TITLE
Fix deprecaction message for ActivityHandlerDialog, small doc update …

### DIFF
--- a/docs/_docs/overview/whats-new/0.8-beta/maindialog-updates.md
+++ b/docs/_docs/overview/whats-new/0.8-beta/maindialog-updates.md
@@ -15,6 +15,7 @@ toc: true
 {{ page.description }}
 
 ### Steps
+1. Change MainDialog to derive from `ComponentDialog`
 1. Move introduction logic to DefaultActivityHandler OnMembersAddedAsync method.
 1. Copy routing logic from OnMessageActivityAsync method into RouteStepAsync method.
     - Change any switch statement cases that start new dialogs to return the result of BeginDialogAsync like below for proper dialog flow management:

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Dialogs/ActivityHandlerDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Dialogs/ActivityHandlerDialog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Solutions.Dialogs
     /// <summary>
     /// Provides interruption logic and methods for handling incoming activities based on type.
     /// </summary>
-    [Obsolete("ActivityHandlerDialog is being deprecated. For more information, refer to https://aka.ms/bfvarouting.", false)]
+    [Obsolete("ActivityHandlerDialog is being deprecated in favor of a waterfall dialog. For more information, refer to https://microsoft.github.io/botframework-solutions/overview/whats-new/0.8-beta/maindialog-updates/.", false)]
     public abstract class ActivityHandlerDialog : InterruptableDialog
     {
         public ActivityHandlerDialog(

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Dialogs/RouterDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Dialogs/RouterDialog.cs
@@ -11,7 +11,7 @@ using Microsoft.Bot.Solutions.Extensions;
 
 namespace Microsoft.Bot.Solutions.Dialogs
 {
-    [Obsolete("Please use ActivityHandlerDialog instead. For more information, refer to https://aka.ms/bfvarouting.", false)]
+    [Obsolete("Please use the waterfall dialog pattern implemnted in VA MaindDialog.cs instead. For more information, refer to https://microsoft.github.io/botframework-solutions/overview/whats-new/0.8-beta/maindialog-updates/.", false)]
     public abstract class RouterDialog : InterruptableDialog
     {
         public RouterDialog(string dialogId, IBotTelemetryClient telemetryClient)


### PR DESCRIPTION
…for .8 release doc outlining mainDialog changes

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Deprecated function method for routing dialog was telling users to use ActivityHandlerDialog. Depreciation message for ActivityHandlerDialog was pointing to documentation that said to use...ActivityHandler dialog.

Fixed links to route to proper deprecation and recommendation guidance.


### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
