### PR TITLE
Revert back to QnAMakerService references in VASample and scripts

### DIFF
--- a/build/build.cognitive-models.ps1
+++ b/build/build.cognitive-models.ps1
@@ -33,8 +33,8 @@ $languageModel = [pscustomobject]@{
 $knowledgeBase = [pscustomobject]@{
     endpointKey = ""
     id = ""
-    host = ""
-    knowledgeBaseId = ""
+    hostname = ""
+    kbId = ""
     name = ""
     subscriptionKey = ""
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Services/BotServices.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Services/BotServices.cs
@@ -54,12 +54,12 @@ namespace VirtualAssistantSample.Services
                 {
                     var qnaEndpoint = new QnAMakerEndpoint()
                     {
-                        KnowledgeBaseId = kb.KnowledgeBaseId,
+                        KnowledgeBaseId = kb.KbId,
                         EndpointKey = kb.EndpointKey,
-                        Host = kb.Host,
+                        Host = kb.Hostname,
                     };
 
-                    set.QnAConfiguration.Add(kb.KnowledgeBaseId, qnaEndpoint);
+                    set.QnAConfiguration.Add(kb.Id, qnaEndpoint);
                 }
 
                 CognitiveModelSets.Add(language, set);

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.0-preview-200213-105928" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.0-preview-200213-105928" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.0-preview-200213-105928" />
-    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily228" />
+    <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily239" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/cognitivemodels.json
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/cognitivemodels.json
@@ -25,9 +25,9 @@
       "knowledgebases": [
         {
           "endpointKey": "",
-          "host": "",
+          "hostname": "",
           "id": "",
-          "knowledgeBaseId": "",
+          "kbId": "",
           "name": "",
           "subscriptionKey": ""
         }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #3028 - revert back to QnAMakerService references to keep existing cognitive models set up working. This has been validated on both Core VA and Skills VA test environments.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
