### PR TITLE
[Botskills] Update outdated validation methods in migrate command

### DIFF
--- a/tools/botskills/src/functionality/migrateSkill.ts
+++ b/tools/botskills/src/functionality/migrateSkill.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { ConsoleLogger, ILogger} from '../logger';
 import { IMigrateConfiguration, IAppSetting, ISkill, ISkillFileV1 } from '../models';
-import { isInstanceOfISkillManifestV1 } from '../utils/validationUtils';
+import { manifestV1Validation } from '../utils/validationUtils';
 
 export class MigrateSkill {
     public logger: ILogger;
@@ -44,7 +44,8 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             const destAssistantSkills: ISkill[] = destFile.BotFrameworkSkills || [];
 
             sourceAssistantSkills.skills.forEach((skill): void => {
-                if (isInstanceOfISkillManifestV1(skill)){
+                manifestV1Validation(skill, this.logger);
+                if (!this.logger.isError){
 
                     if (destAssistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.Id === skill.id)) {
                         this.logger.warning(`The skill '${ skill.name }' is already registered.`);
@@ -59,7 +60,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
                     });
                 }
                 else {
-                    throw new Error(`A skill has an incorrect format, please check that all the skills intended to be migrated has the V1 format`);
+                    throw new Error(`The skill '${ skill.name }' has an incorrect format, please check that all the skills intended to be migrated has the V1 format`);
                 }
             });
 


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
As in PR #3012 some methods were updated to be verbose when capturing an error, the `migrate` command contained outdated validation's methods.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Change the method `isInstanceOfISkillManifestV1` to `manifestV1Validation`.
- Update error message

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
