### PR TITLE
[Botskills] Get the LU filename using basename

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { isAbsolute, join, resolve } from 'path';
+import { isAbsolute, join, resolve, basename } from 'path';
 import { get } from 'request-promise-native';
 import { ConsoleLogger, ILogger } from '../logger';
 import {
@@ -106,9 +106,8 @@ export class ConnectSkill {
                 if(!existsSync(luFilePath)) {
                     throw new Error(`Path to the LU file (${luFilePath}) leads to a nonexistent file.`);
                 }
-
-                if (luFile.trim.length === 0) {
-                    luFile = luFilePath.split('\\').reverse()[0];
+                if (luFile.trim().length === 0) {
+                    luFile = basename(luFilePath);
                     luisFile = `${luFile.toLowerCase()}is`;
                 }
                 luisFilePath = join(luisFolderPath, luisFile);


### PR DESCRIPTION
Fix #3148 

### Purpose
*What is the context of this pull request? Why is it being done?*
The use of `split('\\')` is incompatible between OS, [basename](https://nodejs.org/api/path.html#path_path_basename_path_ext) method returns the last portion of a path, similar to the Unix basename command ignoring the trailing directory separators.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Change the `split('\\')` to `basename` in order to get the last portion of path

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
