### PR TITLE
[VA] remove duplicate GeneralResult

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/OnboardingDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/OnboardingDialog.cs
@@ -73,6 +73,7 @@ namespace VirtualAssistantSample.Dialogs
             {
                 var localizedServices = _services.GetCognitiveModels();
                 generalResult = await localizedServices.LuisServices["General"].RecognizeAsync<GeneralLuis>(sc.Context, cancellationToken);
+                sc.Context.TurnState.Add(StateProperties.GeneralResult, generalResult);
             }
 
             (var generalIntent, var generalScore) = generalResult.TopIntent();
@@ -101,11 +102,6 @@ namespace VirtualAssistantSample.Dialogs
         private class DialogIds
         {
             public const string NamePrompt = "namePrompt";
-        }
-
-        private class StateProperties
-        {
-            public const string GeneralResult = "generalResult";
         }
     }
 }

--- a/templates/csharp/VA/VA/Dialogs/OnboardingDialog.cs
+++ b/templates/csharp/VA/VA/Dialogs/OnboardingDialog.cs
@@ -73,6 +73,7 @@ namespace $safeprojectname$.Dialogs
             {
                 var localizedServices = _services.GetCognitiveModels();
                 generalResult = await localizedServices.LuisServices["General"].RecognizeAsync<GeneralLuis>(sc.Context, cancellationToken);
+                sc.Context.TurnState.Add(StateProperties.GeneralResult, generalResult);
             }
 
             (var generalIntent, var generalScore) = generalResult.TopIntent();
@@ -101,11 +102,6 @@ namespace $safeprojectname$.Dialogs
         private class DialogIds
         {
             public const string NamePrompt = "namePrompt";
-        }
-
-        private class StateProperties
-        {
-            public const string GeneralResult = "generalResult";
         }
     }
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Remove StateProperties which is already in Models.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

I also thought the the get-recognize-set part should be wrapped to a function:
```
            var generalResult = sc.Context.TurnState.Get<GeneralLuis>(StateProperties.GeneralResult);
            if (generalResult == null)
            {
                var localizedServices = _services.GetCognitiveModels();
                generalResult = await localizedServices.LuisServices["General"].RecognizeAsync<GeneralLuis>(sc.Context, cancellationToken);
                sc.Context.TurnState.Add(StateProperties.GeneralResult, generalResult);
            }
```

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
