### PR TITLE
[Botskills] Fix RegExp for validating URLs

### DIFF
--- a/tools/botskills/src/utils/validationUtils.ts
+++ b/tools/botskills/src/utils/validationUtils.ts
@@ -55,7 +55,7 @@ export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: IL
     }
     if (!skillManifest.endpoint) {
         logger.error(`Missing property 'endpoint' of the manifest`);
-    } else if (skillManifest.endpoint.match(/^(https?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
+    } else if (skillManifest.endpoint.match(/^(https?:\/\/)?((([a-zA-Z\d]([a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
         logger.error(`The 'endpoint' property contains some characters not allowed.`);
     }
     if (skillManifest.authenticationConnections === undefined || !skillManifest.authenticationConnections) {
@@ -93,7 +93,7 @@ export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: IL
 
     if (!currentEndpoint.endpointUrl){
         logger.error(`Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
-    } else if (currentEndpoint.endpointUrl.match(/^(https?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
+    } else if (currentEndpoint.endpointUrl.match(/^(https?:\/\/)?((([a-zA-Z\d]([a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
         logger.error(`The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`);
     }
 

--- a/tools/botskills/src/utils/validationUtils.ts
+++ b/tools/botskills/src/utils/validationUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISkillManifestV1 } from '../models/manifestV1/skillManifestV1';
-import { ISkillManifestV2, IEndpoint } from '../models/manifestV2/skillManifestV2';
+import { ISkillManifestV2 } from '../models/manifestV2/skillManifestV2';
 import { ILogger } from '../logger';
 
 /**
@@ -55,7 +55,7 @@ export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: IL
     }
     if (!skillManifest.endpoint) {
         logger.error(`Missing property 'endpoint' of the manifest`);
-    } else if (skillManifest.endpoint.match(/^(https?:\/\/)?((([a-zA-F\d]([a-zA-F\d-]*[a-zA-F\d])*)\.)+[a-zA-F]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-zA-F\d%_.~+]*)*(\?[;&a-zA-F\d%_.~+=-]*)?(\#[-a-zA-F\d_]*)?$/g) === null) {
+    } else if (skillManifest.endpoint.match(/^(https?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
         logger.error(`The 'endpoint' property contains some characters not allowed.`);
     }
     if (skillManifest.authenticationConnections === undefined || !skillManifest.authenticationConnections) {
@@ -87,13 +87,13 @@ export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: IL
 
     if (!currentEndpoint.msAppId){
         logger.error(`Missing property 'msAppId' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
-    } else if (currentEndpoint.msAppId.match(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/g) === null) {
+    } else if (currentEndpoint.msAppId.match(/^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/g) === null) {
         logger.error(`The 'msAppId' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`);
     }
 
     if (!currentEndpoint.endpointUrl){
         logger.error(`Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
-    } else if (currentEndpoint.endpointUrl.match(/^(https?:\/\/)?((([a-zA-F\d]([a-zA-F\d-]*[a-zA-F\d])*)\.)+[a-zA-F]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-zA-F\d%_.~+]*)*(\?[;&a-zA-F\d%_.~+=-]*)?(\#[-a-zA-F\d_]*)?$/g) === null) {
+    } else if (currentEndpoint.endpointUrl.match(/^(https?:\/\/)?((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-z\d%_.~+]*)*(\?[;&a-z\d%_.~+=-]*)?(\#[-a-z\d_]*)?$/g) === null) {
         logger.error(`The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`);
     }
 

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -475,6 +475,130 @@ Error: Mocked function throws an Error`);
 Error: An error ocurred while updating the Dispatch model:
 Error: Mocked function throws an Error`);
         });
+
+        it("The localManifest V1 points to a nonexisting Endpoint URL", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpoint.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+        
+            const errorMessages = [
+                `Missing property 'endpoint' of the manifest`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+        
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+        
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+    
+        it("The localManifest V1 points to a Endpoint URL with uppercase scenario", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifest.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+        
+            const errorMessages = [
+                `The 'endpoint' property contains some characters not allowed.`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+        
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+        
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+    
+        it("The localManifest V2 points to a nonexisting Endpoint URL", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointV2.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+        
+            const errorMessages = [
+                `Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+        
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+        
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+    
+        it("The localManifest V2 points to a Endpoint URL with uppercase scenario", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifestV2.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+        
+            const errorMessages = [
+                `The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+        
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+        
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
     });
 
     describe("should show a warning", function () {
@@ -573,133 +697,5 @@ Error: Mocked function throws an Error`);
 
 			strictEqual(messageList[messageList.length - 1], `Configuring bot auth settings`);
 		});
-    });
-    
-    describe("Manifest validation V1", function() {
-        it("The localManifest points to a nonexisting Endpoint URL", async function() {
-            const configuration = {
-                botName: "",
-                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpoint.json")),
-                remoteManifest: "",
-                languages: "",
-                luisFolder: "",
-                dispatchFolder: "",
-                outFolder: "",
-                lgOutFolder: "",
-                resourceGroup: "",
-                appSettingsFile: "",
-                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
-                lgLanguage: "",
-                logger: this.logger
-            };
-
-            const errorMessages = [
-                `Missing property 'endpoint' of the manifest`,
-                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
-            ]
-
-            this.connector.configuration = configuration;
-            await this.connector.connectSkill();
-            const errorList = this.logger.getError();
-
-            errorList.forEach((errorMessage, index) => {
-                strictEqual(errorMessage, errorMessages[index]);
-            });
-        });
-
-        it("The localManifest points to a Endpoint URL with uppercase scenario", async function() {
-            const configuration = {
-                botName: "",
-                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifest.json")),
-                remoteManifest: "",
-                languages: "",
-                luisFolder: "",
-                dispatchFolder: "",
-                outFolder: "",
-                lgOutFolder: "",
-                resourceGroup: "",
-                appSettingsFile: "",
-                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
-                lgLanguage: "",
-                logger: this.logger
-            };
-
-            const errorMessages = [
-                `The 'endpoint' property contains some characters not allowed.`,
-                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
-            ]
-
-            this.connector.configuration = configuration;
-            await this.connector.connectSkill();
-            const errorList = this.logger.getError();
-
-            errorList.forEach((errorMessage, index) => {
-                strictEqual(errorMessage, errorMessages[index]);
-            });
-        });
-    });
- 
-    describe("Manifest validation V2", function() {
-        it("The localManifest points to a nonexisting Endpoint URL", async function() {
-            const configuration = {
-                botName: "",
-                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointV2.json")),
-                remoteManifest: "",
-                languages: "",
-                luisFolder: "",
-                dispatchFolder: "",
-                outFolder: "",
-                lgOutFolder: "",
-                resourceGroup: "",
-                appSettingsFile: "",
-                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
-                lgLanguage: "",
-                logger: this.logger
-            };
-
-            const errorMessages = [
-                `Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`,
-                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
-            ]
-
-            this.connector.configuration = configuration;
-            await this.connector.connectSkill();
-            const errorList = this.logger.getError();
-
-            errorList.forEach((errorMessage, index) => {
-                strictEqual(errorMessage, errorMessages[index]);
-            });
-        });
-
-        it("The localManifest points to a Endpoint URL with uppercase scenario", async function() {
-            const configuration = {
-                botName: "",
-                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifestV2.json")),
-                remoteManifest: "",
-                languages: "",
-                luisFolder: "",
-                dispatchFolder: "",
-                outFolder: "",
-                lgOutFolder: "",
-                resourceGroup: "",
-                appSettingsFile: "",
-                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
-                lgLanguage: "",
-                logger: this.logger
-            };
-
-            const errorMessages = [
-                `The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`,
-                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
-            ]
-
-            this.connector.configuration = configuration;
-            await this.connector.connectSkill();
-            const errorList = this.logger.getError();
-
-            errorList.forEach((errorMessage, index) => {
-                strictEqual(errorMessage, errorMessages[index]);
-            });
-        });
     });
 });

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -573,5 +573,133 @@ Error: Mocked function throws an Error`);
 
 			strictEqual(messageList[messageList.length - 1], `Configuring bot auth settings`);
 		});
-	});
+    });
+    
+    describe("Manifest validation V1", function() {
+        it("The localManifest points to a nonexisting Endpoint URL", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpoint.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+
+            const errorMessages = [
+                `Missing property 'endpoint' of the manifest`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+
+        it("The localManifest points to a Endpoint URL with uppercase scenario", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifest.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+
+            const errorMessages = [
+                `The 'endpoint' property contains some characters not allowed.`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+    });
+ 
+    describe("Manifest validation V2", function() {
+        it("The localManifest points to a nonexisting Endpoint URL", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointV2.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+
+            const errorMessages = [
+                `Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+
+        it("The localManifest points to a Endpoint URL with uppercase scenario", async function() {
+            const configuration = {
+                botName: "",
+                localManifest: resolve(__dirname, join("mocks", "skills", "invalidEndpointManifestV2.json")),
+                remoteManifest: "",
+                languages: "",
+                luisFolder: "",
+                dispatchFolder: "",
+                outFolder: "",
+                lgOutFolder: "",
+                resourceGroup: "",
+                appSettingsFile: "",
+                cognitiveModelsFile : resolve(__dirname, "mocks", "cognitivemodels", "cognitivemodelsWithTwoDispatch.json"),
+                lgLanguage: "",
+                logger: this.logger
+            };
+
+            const errorMessages = [
+                `The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`,
+                `There was an error while connecting the Skill to the Assistant:\nError: Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.`
+            ]
+
+            this.connector.configuration = configuration;
+            await this.connector.connectSkill();
+            const errorList = this.logger.getError();
+
+            errorList.forEach((errorMessage, index) => {
+                strictEqual(errorMessage, errorMessages[index]);
+            });
+        });
+    });
 });

--- a/tools/botskills/test/mocks/skills/invalidEndpoint.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpoint.json
@@ -14,7 +14,7 @@
                 "triggers": {
                     "utteranceSources": [
                         {
-                            "locale": "en",
+                            "locale": "en-us",
                             "source": [
                                 "test#Test"
                             ]

--- a/tools/botskills/test/mocks/skills/invalidEndpoint.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpoint.json
@@ -1,0 +1,27 @@
+{
+    "id": "testSkill",
+    "msaAppId": "00000000-0000-0000-0000-000000000000",
+    "name": "Test Skill",
+    "endpoint": "",
+    "description": "This is a test skill to use for testing purpose.",
+    "authenticationConnections": [],
+    "actions": [
+        {
+            "id": "testSkill_testAction",
+            "definition": {
+                "description": "Test Action",
+                "slots": [],
+                "triggers": {
+                    "utteranceSources": [
+                        {
+                            "locale": "en",
+                            "source": [
+                                "test#Test"
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tools/botskills/test/mocks/skills/invalidEndpointManifest.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointManifest.json
@@ -2,7 +2,7 @@
     "id": "testSkill",
     "msaAppId": "00000000-0000-0000-0000-000000000000",
     "name": "Test Skill",
-    "endpoint": "https://test-Stage.azurewebsites.net/manifest",
+    "endpoint": "https://Test-Stage.azurewebsites.net/manifest",
     "description": "This is a test skill to use for testing purpose.",
     "authenticationConnections": [],
     "actions": [
@@ -14,7 +14,7 @@
                 "triggers": {
                     "utteranceSources": [
                         {
-                            "locale": "en",
+                            "locale": "en-us",
                             "source": [
                                 "test#Test"
                             ]

--- a/tools/botskills/test/mocks/skills/invalidEndpointManifest.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointManifest.json
@@ -1,0 +1,27 @@
+{
+    "id": "testSkill",
+    "msaAppId": "00000000-0000-0000-0000-000000000000",
+    "name": "Test Skill",
+    "endpoint": "https://test-Stage.azurewebsites.net/manifest",
+    "description": "This is a test skill to use for testing purpose.",
+    "authenticationConnections": [],
+    "actions": [
+        {
+            "id": "testSkill_testAction",
+            "definition": {
+                "description": "Test Action",
+                "slots": [],
+                "triggers": {
+                    "utteranceSources": [
+                        {
+                            "locale": "en",
+                            "source": [
+                                "test#Test"
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tools/botskills/test/mocks/skills/invalidEndpointManifestV2.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointManifestV2.json
@@ -1,44 +1,44 @@
 {
-    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
-    "$id": "TestSkill",
-    "name": "Test Skill",
-    "description": "Test skill",
-    "publisherName": "Microsoft",
-    "version": "0.8",
-    "iconUrl": "https://{YOUR_SKILL_URL}/images/skill.png",
-    "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
-    "license": "",
-    "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
-    "tags": [
-      "skill"
-    ],
-    "endpoints": [
-      {
-        "name": "ManifestV2",
-        "protocol": "TEST",
-        "description": "Test Endpoint Skill",
-        "endpointUrl": "https://test-Stage.azurewebsites.net/manifest",
-        "msAppId": "00000000-0000-0000-0000-000000000000"
-      }
-    ],
-    "dispatchModels": {
-      "languages": {
-        "en-us": [
-          {
-            "id": "TestLuModel-en",
-            "name": "Test LU (English)",
-            "contentType": "application/lu",
-            "url": "file://Test-en.lu",
-            "description": "English language model for the skill"
-          }
-        ]
-      },
-      "intents": {}
-    },
-    "activities": {
-      "message": {
-        "type": "message",
-        "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
-      }
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "TestSkill",
+  "name": "Test Skill",
+  "description": "Test skill",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images/skill.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "ManifestV2",
+      "protocol": "TEST",
+      "description": "Test Endpoint Skill",
+      "endpointUrl": "https://Test-Stage.azurewebsites.net/manifest",
+      "msAppId": "00000000-0000-0000-0000-000000000000"
     }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "TestLuModel-en-us",
+          "name": "Test LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Test-en-us.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {}
+  },
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }

--- a/tools/botskills/test/mocks/skills/invalidEndpointManifestV2.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointManifestV2.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+    "$id": "TestSkill",
+    "name": "Test Skill",
+    "description": "Test skill",
+    "publisherName": "Microsoft",
+    "version": "0.8",
+    "iconUrl": "https://{YOUR_SKILL_URL}/images/skill.png",
+    "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+    "license": "",
+    "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+    "tags": [
+      "skill"
+    ],
+    "endpoints": [
+      {
+        "name": "ManifestV2",
+        "protocol": "TEST",
+        "description": "Test Endpoint Skill",
+        "endpointUrl": "https://test-Stage.azurewebsites.net/manifest",
+        "msAppId": "00000000-0000-0000-0000-000000000000"
+      }
+    ],
+    "dispatchModels": {
+      "languages": {
+        "en-us": [
+          {
+            "id": "TestLuModel-en",
+            "name": "Test LU (English)",
+            "contentType": "application/lu",
+            "url": "file://Test-en.lu",
+            "description": "English language model for the skill"
+          }
+        ]
+      },
+      "intents": {}
+    },
+    "activities": {
+      "message": {
+        "type": "message",
+        "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+      }
+    }
+}

--- a/tools/botskills/test/mocks/skills/invalidEndpointV2.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointV2.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+    "$id": "TestSkill",
+    "name": "Test Skill",
+    "description": "Test skill",
+    "publisherName": "Microsoft",
+    "version": "0.8",
+    "iconUrl": "https://{YOUR_SKILL_URL}/images.png",
+    "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+    "license": "",
+    "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+    "tags": [
+      "skill"
+    ],
+    "endpoints": [
+      {
+        "name": "ManifestV2",
+        "protocol": "TEST",
+        "description": "Test Endpoint Skill",
+        "endpointUrl": "",
+        "msAppId": "00000000-0000-0000-0000-000000000000"
+      }
+    ],
+    "dispatchModels": {
+      "languages": {
+        "en-us": [
+          {
+            "id": "TestLuModel-en",
+            "name": "Test LU (English)",
+            "contentType": "application/lu",
+            "url": "file://Test-en.lu",
+            "description": "English language model for the skill"
+          }
+        ]
+      },
+      "intents": {}
+    },
+    "activities": {
+      "message": {
+        "type": "message",
+        "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+      }
+    }
+}

--- a/tools/botskills/test/mocks/skills/invalidEndpointV2.json
+++ b/tools/botskills/test/mocks/skills/invalidEndpointV2.json
@@ -1,44 +1,44 @@
 {
-    "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
-    "$id": "TestSkill",
-    "name": "Test Skill",
-    "description": "Test skill",
-    "publisherName": "Microsoft",
-    "version": "0.8",
-    "iconUrl": "https://{YOUR_SKILL_URL}/images.png",
-    "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
-    "license": "",
-    "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
-    "tags": [
-      "skill"
-    ],
-    "endpoints": [
-      {
-        "name": "ManifestV2",
-        "protocol": "TEST",
-        "description": "Test Endpoint Skill",
-        "endpointUrl": "",
-        "msAppId": "00000000-0000-0000-0000-000000000000"
-      }
-    ],
-    "dispatchModels": {
-      "languages": {
-        "en-us": [
-          {
-            "id": "TestLuModel-en",
-            "name": "Test LU (English)",
-            "contentType": "application/lu",
-            "url": "file://Test-en.lu",
-            "description": "English language model for the skill"
-          }
-        ]
-      },
-      "intents": {}
-    },
-    "activities": {
-      "message": {
-        "type": "message",
-        "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
-      }
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "TestSkill",
+  "name": "Test Skill",
+  "description": "Test skill",
+  "publisherName": "Microsoft",
+  "version": "0.8",
+  "iconUrl": "https://{YOUR_SKILL_URL}/images.png",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "privacyUrl": "https://{YOUR_SKILL_URL}/privacy.html",
+  "tags": [
+    "skill"
+  ],
+  "endpoints": [
+    {
+      "name": "ManifestV2",
+      "protocol": "TEST",
+      "description": "Test Endpoint Skill",
+      "endpointUrl": "",
+      "msAppId": "00000000-0000-0000-0000-000000000000"
     }
+  ],
+  "dispatchModels": {
+    "languages": {
+      "en-us": [
+        {
+          "id": "TestLuModel-en-us",
+          "name": "Test LU (English)",
+          "contentType": "application/lu",
+          "url": "file://Test-en-us.lu",
+          "description": "English language model for the skill"
+        }
+      ]
+    },
+    "intents": {}
+  },
+  "activities": {
+    "message": {
+      "type": "message",
+      "description": "Receives the users utterance and attempts to resolve it using the skill's LU models"
+    }
+  }
 }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Update the RegExp in the Endpoint URL to allow characters between A-Z replacing the actual scenario that contemplates characters between A-F in uppercase.

Fixes #3188
 
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Update the regex validation inside the ManifestV1 and ManifestV2 functions when the user introduces data in the manifest properties `Endpoint URL` and `MsaAppId`.

Before update the manifest RegEx
![image](https://user-images.githubusercontent.com/42946572/76895158-431eba80-686e-11ea-97cc-babcaae41e95.png)

After update the manifest RegEx
![image](https://user-images.githubusercontent.com/42946572/76895171-4619ab00-686e-11ea-9313-6bc609a46158.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
We added tests cases to cover the validation of RegExp.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
*-*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects