### PR TITLE
SkillSample updates

### DIFF
--- a/samples/csharp/skill/SkillSample.Tests/SkillSample.Tests.csproj
+++ b/samples/csharp/skill/SkillSample.Tests/SkillSample.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -15,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample/Adapters/DefaultAdapter.cs
+++ b/samples/csharp/skill/SkillSample/Adapters/DefaultAdapter.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Middleware;
 using Microsoft.Bot.Solutions.Responses;
+using Microsoft.Extensions.Logging;
 using SkillSample.Extensions;
 using SkillSample.Services;
 
@@ -16,31 +20,29 @@ namespace SkillSample.Adapters
 {
     public class DefaultAdapter : BotFrameworkHttpAdapter
     {
+        private readonly ConversationState _conversationState;
+        private readonly ILogger _logger;
+        private readonly IBotTelemetryClient _telemetryClient;
+        private readonly LocaleTemplateManager _templateEngine;
+
         public DefaultAdapter(
             BotSettings settings,
             IChannelProvider channelProvider,
             ICredentialProvider credentialProvider,
+            AuthenticationConfiguration authConfig,
             LocaleTemplateManager templateEngine,
+            ConversationState conversationState,
             TelemetryInitializerMiddleware telemetryMiddleware,
-            IBotTelemetryClient telemetryClient)
-            : base(credentialProvider, channelProvider)
+            IBotTelemetryClient telemetryClient,
+            ILogger<BotFrameworkHttpAdapter> logger)
+            : base(credentialProvider, authConfig, channelProvider, logger: logger)
         {
-            OnTurnError = async (turnContext, exception) =>
-            {
-                await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Exception Message: {exception.Message}, Stack: {exception.StackTrace}"));
-                await turnContext.SendActivityAsync(templateEngine.GenerateActivityForLocale("ErrorMessage"));
-                telemetryClient.TrackException(exception);
+            _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _templateEngine = templateEngine ?? throw new ArgumentNullException(nameof(templateEngine));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
-                if (turnContext.IsSkill())
-                {
-                    // Send and EndOfConversation activity to the skill caller with the error to end the conversation
-                    // and let the caller decide what to do.
-                    var endOfConversation = Activity.CreateEndOfConversationActivity();
-                    endOfConversation.Code = "SkillError";
-                    endOfConversation.Text = exception.Message;
-                    await turnContext.SendActivityAsync(endOfConversation);
-                }
-            };
+            OnTurnError = HandleTurnError;
 
             Use(telemetryMiddleware);
 
@@ -52,6 +54,71 @@ namespace SkillSample.Adapters
             Use(new SetLocaleMiddleware(settings.DefaultLocale ?? "en-us"));
             Use(new EventDebuggerMiddleware());
             Use(new SetSpeakMiddleware());
+        }
+
+        private async Task HandleTurnError(ITurnContext turnContext, Exception exception)
+        {
+            // Log any leaked exception from the application.
+            _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+            await SendErrorMessageAsync(turnContext, exception);
+            await SendEoCToParentAsync(turnContext, exception);
+            await ClearConversationStateAsync(turnContext);
+        }
+
+        private async Task SendErrorMessageAsync(ITurnContext turnContext, Exception exception)
+        {
+            try
+            {
+                _telemetryClient.TrackException(exception);
+
+                // Send a message to the user.
+                await turnContext.SendActivityAsync(_templateEngine.GenerateActivityForLocale("ErrorMessage"));
+
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator.
+                // Note: we return the entire exception in the value property to help the developer;
+                // this should not be done in production.
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught in SendErrorMessageAsync : {ex}");
+            }
+        }
+
+        private async Task SendEoCToParentAsync(ITurnContext turnContext, Exception exception)
+        {
+            try
+            {
+                if (turnContext.IsSkill())
+                {
+                    // Send and EndOfConversation activity to the skill caller with the error to end the conversation
+                    // and let the caller decide what to do.
+                    var endOfConversation = Activity.CreateEndOfConversationActivity();
+                    endOfConversation.Code = "SkillError";
+                    endOfConversation.Text = exception.Message;
+                    await turnContext.SendActivityAsync(endOfConversation);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught in SendEoCToParentAsync : {ex}");
+            }
+        }
+
+        private async Task ClearConversationStateAsync(ITurnContext turnContext)
+        {
+            try
+            {
+                // Delete the conversationState for the current conversation to prevent the
+                // bot from getting stuck in a error-loop caused by being in a bad state.
+                // ConversationState should be thought of as similar to "cookie-state" for a Web page.
+                await _conversationState.DeleteAsync(turnContext);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+            }
         }
     }
 }

--- a/samples/csharp/skill/SkillSample/Authentication/AllowedCallersClaimsValidator.cs
+++ b/samples/csharp/skill/SkillSample/Authentication/AllowedCallersClaimsValidator.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+
+namespace SkillSample.Authentication
+{
+    /// <summary>
+    /// Sample claims validator that loads an allowed list from configuration
+    /// and checks that requests are coming from allowed parent bots.
+    /// </summary>
+    public class AllowedCallersClaimsValidator : ClaimsValidator
+    {
+        private const string _configKey = "allowedCallers";
+        private readonly List<string> _allowedCallers;
+
+        public AllowedCallersClaimsValidator(IConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            // AllowedCallers is the setting in the appsettings.json file
+            // that consists of the list of parent bot IDs that are allowed to access the skill.
+            // To add a new parent bot, simply edit the AllowedCallers and add
+            // the parent bot's Microsoft app ID to the list.
+            // In this sample, we allow all callers if AllowedCallers contains an "*".
+            var section = config.GetSection(_configKey);
+            var appsList = section.Get<string[]>();
+            if (appsList == null)
+            {
+                throw new ArgumentNullException($"\"{_configKey}\" not found in configuration.");
+            }
+
+            _allowedCallers = new List<string>(appsList);
+        }
+
+        public override Task ValidateClaimsAsync(IList<Claim> claims)
+        {
+            // If _allowedCallers contains an "*", we allow all callers.
+            if (SkillValidation.IsSkillClaim(claims) && !_allowedCallers.Contains("*"))
+            {
+                // Check that the appId claim in the skill request is in the list of callers configured for this bot.
+                var appId = JwtTokenValidation.GetAppIdFromClaims(claims);
+                if (!_allowedCallers.Contains(appId))
+                {
+                    throw new UnauthorizedAccessException($"Received a request from a bot with an app ID of \"{appId}\". To enable requests from this caller, add the app ID to your configuration file.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/samples/csharp/skill/SkillSample/Bots/DefaultActivityHandler.cs
+++ b/samples/csharp/skill/SkillSample/Bots/DefaultActivityHandler.cs
@@ -19,12 +19,13 @@ namespace SkillSample.Bots
         private readonly Dialog _dialog;
         private readonly BotState _conversationState;
         private readonly BotState _userState;
-        private IStatePropertyAccessor<DialogState> _dialogStateAccessor;
-        private LocaleTemplateManager _templateEngine;
+        private readonly IStatePropertyAccessor<DialogState> _dialogStateAccessor;
+        private readonly LocaleTemplateManager _templateEngine;
 
         public DefaultActivityHandler(IServiceProvider serviceProvider, T dialog)
         {
             _dialog = dialog;
+            _dialog.TelemetryClient = serviceProvider.GetService<IBotTelemetryClient>();
             _conversationState = serviceProvider.GetService<ConversationState>();
             _userState = serviceProvider.GetService<UserState>();
             _dialogStateAccessor = _conversationState.CreateProperty<DialogState>(nameof(DialogState));
@@ -42,7 +43,7 @@ namespace SkillSample.Bots
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync(_templateEngine.GenerateActivityForLocale("IntroMessage"));
+            await turnContext.SendActivityAsync(_templateEngine.GenerateActivityForLocale("IntroMessage"), cancellationToken);
             await _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
         }
 

--- a/samples/csharp/skill/SkillSample/Dialogs/SampleAction.cs
+++ b/samples/csharp/skill/SkillSample/Dialogs/SampleAction.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Newtonsoft.Json;
 
@@ -25,15 +24,14 @@ namespace SkillSample.Dialogs
     public class SampleAction : SkillDialogBase
     {
         public SampleAction(
-            IServiceProvider serviceProvider,
-            IBotTelemetryClient telemetryClient)
-            : base(nameof(SampleAction), serviceProvider, telemetryClient)
+            IServiceProvider serviceProvider)
+            : base(nameof(SampleAction), serviceProvider)
         {
             var sample = new WaterfallStep[]
             {
-                PromptForName,
-                GreetUser,
-                End,
+                PromptForNameAsync,
+                GreetUserAsync,
+                EndAsync,
             };
 
             AddDialog(new WaterfallDialog(nameof(SampleAction), sample));
@@ -42,42 +40,43 @@ namespace SkillSample.Dialogs
             InitialDialogId = nameof(SampleAction);
         }
 
-        private async Task<DialogTurnResult> PromptForName(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> PromptForNameAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // If we have been provided a input data structure we pull out provided data as appropriate
             // and make a decision on whether the dialog needs to prompt for anything.
-            var actionInput = stepContext.Options as SampleActionInput;
-            if (actionInput != null && !string.IsNullOrEmpty(actionInput.Name))
+            if (stepContext.Options is SampleActionInput actionInput && !string.IsNullOrEmpty(actionInput.Name))
             {
                 // We have Name provided by the caller so we skip the Name prompt.
-                return await stepContext.NextAsync(actionInput.Name);
+                return await stepContext.NextAsync(actionInput.Name, cancellationToken);
             }
 
             var prompt = TemplateEngine.GenerateActivityForLocale("NamePrompt");
-            return await stepContext.PromptAsync(DialogIds.NamePrompt, new PromptOptions { Prompt = prompt });
+            return await stepContext.PromptAsync(DialogIds.NamePrompt, new PromptOptions { Prompt = prompt }, cancellationToken);
         }
 
-        private async Task<DialogTurnResult> GreetUser(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> GreetUserAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             dynamic data = new { Name = stepContext.Result.ToString() };
             var response = TemplateEngine.GenerateActivityForLocale("HaveNameMessage", data);
             await stepContext.Context.SendActivityAsync(response);
 
             // Pass the response which we'll return to the user onto the next step
-            return await stepContext.NextAsync();
+            return await stepContext.NextAsync(cancellationToken: cancellationToken);
         }
 
-        private async Task<DialogTurnResult> End(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> EndAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // Simulate a response object payload
-            var actionResponse = new SampleActionOutput();
-            actionResponse.CustomerId = new Random().Next();
+            var actionResponse = new SampleActionOutput
+            {
+                CustomerId = new Random().Next()
+            };
 
             // We end the dialog (generating an EndOfConversation event) which will serialize the result object in the Value field of the Activity
-            return await stepContext.EndDialogAsync(actionResponse);
+            return await stepContext.EndDialogAsync(actionResponse, cancellationToken);
         }
 
-        private class DialogIds
+        private static class DialogIds
         {
             public const string NamePrompt = "namePrompt";
         }

--- a/samples/csharp/skill/SkillSample/Dialogs/SampleDialog.cs
+++ b/samples/csharp/skill/SkillSample/Dialogs/SampleDialog.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 
 namespace SkillSample.Dialogs
@@ -12,18 +11,17 @@ namespace SkillSample.Dialogs
     public class SampleDialog : SkillDialogBase
     {
         public SampleDialog(
-            IServiceProvider serviceProvider,
-            IBotTelemetryClient telemetryClient)
-            : base(nameof(SampleDialog), serviceProvider, telemetryClient)
+            IServiceProvider serviceProvider)
+            : base(nameof(SampleDialog), serviceProvider)
         {
             var sample = new WaterfallStep[]
             {
                 // NOTE: Uncomment these lines to include authentication steps to this dialog
-                // GetAuthToken,
-                // AfterGetAuthToken,
-                PromptForName,
-                GreetUser,
-                End,
+                // GetAuthTokenAsync,
+                // AfterGetAuthTokenAsync,
+                PromptForNameAsync,
+                GreetUserAsync,
+                EndAsync,
             };
 
             AddDialog(new WaterfallDialog(nameof(SampleDialog), sample));
@@ -32,29 +30,29 @@ namespace SkillSample.Dialogs
             InitialDialogId = nameof(SampleDialog);
         }
 
-        private async Task<DialogTurnResult> PromptForName(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> PromptForNameAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             // NOTE: Uncomment the following lines to access LUIS result for this turn.
             // var luisResult = stepContext.Context.TurnState.Get<LuisResult>(StateProperties.SkillLuisResult);
             var prompt = TemplateEngine.GenerateActivityForLocale("NamePrompt");
-            return await stepContext.PromptAsync(DialogIds.NamePrompt, new PromptOptions { Prompt = prompt });
+            return await stepContext.PromptAsync(DialogIds.NamePrompt, new PromptOptions { Prompt = prompt }, cancellationToken);
         }
 
-        private async Task<DialogTurnResult> GreetUser(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> GreetUserAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             dynamic data = new { Name = stepContext.Result.ToString() };
             var response = TemplateEngine.GenerateActivityForLocale("HaveNameMessage", data);
             await stepContext.Context.SendActivityAsync(response);
 
-            return await stepContext.NextAsync();
+            return await stepContext.NextAsync(cancellationToken: cancellationToken);
         }
 
-        private Task<DialogTurnResult> End(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        private Task<DialogTurnResult> EndAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            return stepContext.EndDialogAsync();
+            return stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
-        private class DialogIds
+        private static class DialogIds
         {
             public const string NamePrompt = "namePrompt";
         }

--- a/samples/csharp/skill/SkillSample/Extensions/ITurnContextEx.cs
+++ b/samples/csharp/skill/SkillSample/Extensions/ITurnContextEx.cs
@@ -11,7 +11,7 @@ namespace SkillSample.Extensions
     {
         public static bool IsSkill(this ITurnContext turnContext)
         {
-            return turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims) ? true : false;
+            return turnContext.TurnState.Get<ClaimsIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims) ? true : false;
         }
     }
 }

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -10,11 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -7,19 +7,16 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample/Startup.cs
+++ b/samples/csharp/skill/SkillSample/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SkillSample.Adapters;
+using SkillSample.Authentication;
 using SkillSample.Bots;
 using SkillSample.Dialogs;
 using SkillSample.Services;
@@ -48,7 +49,7 @@ namespace SkillSample
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers();
+            services.AddControllers().AddNewtonsoftJson();
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>
@@ -69,6 +70,9 @@ namespace SkillSample
 
             // Configure channel provider
             services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();
+
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(sp.GetService<IConfiguration>()) });
 
             // Configure configuration provider
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
@@ -137,6 +141,9 @@ namespace SkillSample
                 .UseWebSockets()
                 .UseRouting()
                 .UseEndpoints(endpoints => endpoints.MapControllers());
+
+            // Uncomment this to support HTTPS.
+            // app.UseHttpsRedirection();
         }
     }
 }

--- a/samples/csharp/skill/SkillSample/appsettings.json
+++ b/samples/csharp/skill/SkillSample/appsettings.json
@@ -1,6 +1,7 @@
 {
   "microsoftAppId": "",
   "microsoftAppPassword": "",
+  "allowedCallers": [ "*" ],
   "oauthConnections": [],
   "skillAuthenticationWhitelist": [],
   "ApplicationInsights": {


### PR DESCRIPTION
This PR contains several suggested changes to the SkillSample based on the SDK samples and other observations: 

- Refactored DefaultAdapter based on SDK Skill samples (broke down OnTurnError in several discrete methods with error handling and deleted conversation state at the end).
- Added AllowedCallersClaimsValidator sample.
- Moved assignment of MainDialog.TelemetryClient into DefaultActivityHandler to avoid calling a virtual property from the Dialog's constructor.
- Made private fields readonly where possible.
- Removed unused _stateAccessor from MainDialog
- Added missing cancellationToken parameters across the board.
- Added Async suffic to async methods.
- Simplified SDK references by removing redundant packages already included in top packages.
- Made private class DialogIds static
- Updated reference to StyleCop.Analyzers to released version and add the  PrivateAssets="all" property to avoid propagating it to child projects.
- Added a reference toMicrosoft.AspNetCore.Mvc.NewtonsoftJson to the project and updated startup.cs to .AddNewtonsoftJson() to ensure compatibility.
- Updated startup.cs to register the AllowedCallersClaimsValidator.