### PR TITLE
VirtualAssistantSample updates

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/VirtualAssistantSample.FunctionalTests.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/VirtualAssistantSample.FunctionalTests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/VirtualAssistantSample.FunctionalTests.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/VirtualAssistantSample.FunctionalTests.csproj
@@ -11,21 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.8.1-rc0" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\VirtualAssistantSample.Tests\VirtualAssistantSample.Tests.csproj" />
     <ProjectReference Include="..\VirtualAssistantSample\VirtualAssistantSample.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 </Project>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/VirtualAssistantSample.Tests.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/VirtualAssistantSample.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/VirtualAssistantSample.Tests.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/VirtualAssistantSample.Tests.csproj
@@ -16,13 +16,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.8.1-rc0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -57,10 +56,6 @@
     <None Update="Resources\chitchat_greeting.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 
 </Project>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Adapters/DefaultAdapter.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Adapters/DefaultAdapter.cs
@@ -1,37 +1,61 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Feedback;
 using Microsoft.Bot.Solutions.Middleware;
 using Microsoft.Bot.Solutions.Responses;
+using Microsoft.Bot.Solutions.Skills;
+using Microsoft.Extensions.Logging;
+using VirtualAssistantSample.Dialogs;
 using VirtualAssistantSample.Services;
 
 namespace VirtualAssistantSample.Adapters
 {
     public class DefaultAdapter : BotFrameworkHttpAdapter
     {
+        private readonly ConversationState _conversationState;
+        private readonly ILogger _logger;
+        private readonly IBotTelemetryClient _telemetryClient;
+        private readonly LocaleTemplateManager _templateEngine;
+        private readonly SkillHttpClient _skillClient;
+        private readonly SkillsConfiguration _skillsConfig;
+        private readonly BotSettings _settings;
+
         public DefaultAdapter(
             BotSettings settings,
             ICredentialProvider credentialProvider,
             IChannelProvider channelProvider,
-            LocaleTemplateManager templateFile,
+            AuthenticationConfiguration authConfig,
+            LocaleTemplateManager templateEngine,
             ConversationState conversationState,
             TelemetryInitializerMiddleware telemetryMiddleware,
-            IBotTelemetryClient telemetryClient)
-            : base(credentialProvider, channelProvider)
+            IBotTelemetryClient telemetryClient,
+            ILogger<BotFrameworkHttpAdapter> logger,
+            SkillsConfiguration skillsConfig = null,
+            SkillHttpClient skillClient = null)
+            : base(credentialProvider, authConfig, channelProvider, logger: logger)
         {
-            OnTurnError = async (turnContext, exception) =>
-            {
-                await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"Exception Message: {exception.Message}, Stack: {exception.StackTrace}"));
-                await turnContext.SendActivityAsync(templateFile.GenerateActivityForLocale("ErrorMessage", settings.DefaultLocale));
-                telemetryClient.TrackException(exception);
-            };
+            _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _templateEngine = templateEngine ?? throw new ArgumentNullException(nameof(templateEngine));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            _skillClient = skillClient;
+            _skillsConfig = skillsConfig;
+            _settings = settings;
+
+            OnTurnError = HandleTurnErrorAsync;
 
             Use(telemetryMiddleware);
 
@@ -43,6 +67,80 @@ namespace VirtualAssistantSample.Adapters
             Use(new EventDebuggerMiddleware());
             Use(new FeedbackMiddleware(conversationState, telemetryClient, new FeedbackOptions()));
             Use(new SetSpeakMiddleware());
+        }
+
+        private async Task HandleTurnErrorAsync(ITurnContext turnContext, Exception exception)
+        {
+            // Log any leaked exception from the application.
+            _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+            await SendErrorMessageAsync(turnContext, exception);
+            await EndSkillConversationAsync(turnContext);
+            await ClearConversationStateAsync(turnContext);
+        }
+
+        private async Task SendErrorMessageAsync(ITurnContext turnContext, Exception exception)
+        {
+            try
+            {
+                _telemetryClient.TrackException(exception);
+
+                // Send a message to the user.
+                await turnContext.SendActivityAsync(_templateEngine.GenerateActivityForLocale("ErrorMessage"));
+
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator.
+                // Note: we return the entire exception in the value property to help the developer;
+                // this should not be done in production.
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught in SendErrorMessageAsync : {ex}");
+            }
+        }
+
+        private async Task EndSkillConversationAsync(ITurnContext turnContext)
+        {
+            if (_skillClient == null || _skillsConfig == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // Inform the active skill that the conversation is ended so that it has a chance to clean up.
+                // Note: the root bot manages the ActiveSkillPropertyName, which has a value while the root bot
+                // has an active conversation with a skill.
+                var activeSkill = await _conversationState.CreateProperty<BotFrameworkSkill>(MainDialog.ActiveSkillPropertyName).GetAsync(turnContext, () => null);
+                if (activeSkill != null)
+                {
+                    var endOfConversation = Activity.CreateEndOfConversationActivity();
+                    endOfConversation.Code = "RootSkillError";
+                    endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
+
+                    await _conversationState.SaveChangesAsync(turnContext, true);
+                    await _skillClient.PostActivityAsync(_settings.MicrosoftAppId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught on attempting to send EndOfConversation : {ex}");
+            }
+        }
+
+        private async Task ClearConversationStateAsync(ITurnContext turnContext)
+        {
+            try
+            {
+                // Delete the conversationState for the current conversation to prevent the
+                // bot from getting stuck in a error-loop caused by being in a bad state.
+                // ConversationState should be thought of as similar to "cookie-state" for a Web page.
+                await _conversationState.DeleteAsync(turnContext);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+            }
         }
     }
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Controllers/SkillController.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Controllers/SkillController.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Skills;
 
 namespace VirtualAssistantSample.Controllers
 {

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -53,6 +53,9 @@ namespace VirtualAssistantSample.Dialogs
             var conversationState = serviceProvider.GetService<ConversationState>();
             _previousResponseAccessor = conversationState.CreateProperty<List<Activity>>(StateProperties.PreviousBotResponse);
 
+            // Create state property to track the active skill.
+            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);
+
             var steps = new WaterfallStep[]
             {
                 OnboardingStepAsync,
@@ -77,9 +80,6 @@ namespace VirtualAssistantSample.Dialogs
             {
                 AddDialog(dialog);
             }
-
-            // Create state property to track the active skill.
-            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);
         }
 
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default)

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -11,13 +11,13 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Extensions;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Skills.Dialogs;
-using Microsoft.Bot.Solutions.Skills.Models;
 using Microsoft.Extensions.DependencyInjection;
 using VirtualAssistantSample.Models;
 using VirtualAssistantSample.Services;
@@ -27,25 +27,25 @@ namespace VirtualAssistantSample.Dialogs
     // Dialog providing activity routing and message/event processing.
     public class MainDialog : ComponentDialog
     {
-        private BotServices _services;
-        private BotSettings _settings;
-        private OnboardingDialog _onboardingDialog;
-        private SwitchSkillDialog _switchSkillDialog;
-        private SkillsConfiguration _skillsConfig;
-        private LocaleTemplateManager _templateManager;
-        private IStatePropertyAccessor<UserProfileState> _userProfileState;
-        private IStatePropertyAccessor<List<Activity>> _previousResponseAccessor;
+        // Conversation state property with the active skill (if any).
+        public static readonly string ActiveSkillPropertyName = $"{typeof(MainDialog).FullName}.ActiveSkillProperty";
+
+        private readonly BotServices _services;
+        private readonly OnboardingDialog _onboardingDialog;
+        private readonly SwitchSkillDialog _switchSkillDialog;
+        private readonly SkillsConfiguration _skillsConfig;
+        private readonly LocaleTemplateManager _templateManager;
+        private readonly IStatePropertyAccessor<UserProfileState> _userProfileState;
+        private readonly IStatePropertyAccessor<List<Activity>> _previousResponseAccessor;
+        private readonly IStatePropertyAccessor<BotFrameworkSkill> _activeSkillProperty;
 
         public MainDialog(
-            IServiceProvider serviceProvider,
-            IBotTelemetryClient telemetryClient)
+            IServiceProvider serviceProvider)
             : base(nameof(MainDialog))
         {
             _services = serviceProvider.GetService<BotServices>();
-            _settings = serviceProvider.GetService<BotSettings>();
             _templateManager = serviceProvider.GetService<LocaleTemplateManager>();
             _skillsConfig = serviceProvider.GetService<SkillsConfiguration>();
-            TelemetryClient = telemetryClient;
 
             var userState = serviceProvider.GetService<UserState>();
             _userProfileState = userState.CreateProperty<UserProfileState>(nameof(UserProfileState));
@@ -77,6 +77,9 @@ namespace VirtualAssistantSample.Dialogs
             {
                 AddDialog(dialog);
             }
+
+            // Create state property to track the active skill.
+            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);
         }
 
         protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default)
@@ -110,7 +113,7 @@ namespace VirtualAssistantSample.Dialogs
             }
 
             // Set up response caching for "repeat" functionality.
-            innerDc.Context.OnSendActivities(StoreOutgoingActivities);
+            innerDc.Context.OnSendActivities(StoreOutgoingActivitiesAsync);
             return await base.OnBeginDialogAsync(innerDc, options, cancellationToken);
         }
 
@@ -145,7 +148,7 @@ namespace VirtualAssistantSample.Dialogs
             }
 
             // Set up response caching for "repeat" functionality.
-            innerDc.Context.OnSendActivities(StoreOutgoingActivities);
+            innerDc.Context.OnSendActivities(StoreOutgoingActivitiesAsync);
             return await base.OnContinueDialogAsync(innerDc, cancellationToken);
         }
 
@@ -153,7 +156,7 @@ namespace VirtualAssistantSample.Dialogs
         {
             var interrupted = false;
             var activity = innerDc.Context.Activity;
-            var userProfile = await _userProfileState.GetAsync(innerDc.Context, () => new UserProfileState());
+            var userProfile = await _userProfileState.GetAsync(innerDc.Context, () => new UserProfileState(), cancellationToken);
             var dialog = innerDc.ActiveDialog?.Id != null ? innerDc.FindDialog(innerDc.ActiveDialog?.Id) : null;
 
             if (activity.Type == ActivityTypes.Message && !string.IsNullOrEmpty(activity.Text))
@@ -168,11 +171,10 @@ namespace VirtualAssistantSample.Dialogs
                 // Check if we need to switch skills.
                 if (isSkill && IsSkillIntent(dispatchIntent) && dispatchIntent.ToString() != dialog.Id && dispatchScore > 0.9)
                 {
-                    EnhancedBotFrameworkSkill identifiedSkill;
-                    if (_skillsConfig.Skills.TryGetValue(dispatchIntent.ToString(), out identifiedSkill))
+                    if (_skillsConfig.Skills.TryGetValue(dispatchIntent.ToString(), out var identifiedSkill))
                     {
                         var prompt = _templateManager.GenerateActivityForLocale("SkillSwitchPrompt", new { Skill = identifiedSkill.Name });
-                        await innerDc.BeginDialogAsync(_switchSkillDialog.Id, new SwitchSkillDialogOptions(prompt, identifiedSkill));
+                        await innerDc.BeginDialogAsync(_switchSkillDialog.Id, new SwitchSkillDialogOptions(prompt, identifiedSkill), cancellationToken);
                         interrupted = true;
                     }
                     else
@@ -193,17 +195,17 @@ namespace VirtualAssistantSample.Dialogs
                         {
                             case GeneralLuis.Intent.Cancel:
                                 {
-                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("CancelledMessage", userProfile));
-                                    await innerDc.CancelAllDialogsAsync();
-                                    await innerDc.BeginDialogAsync(InitialDialogId);
+                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("CancelledMessage", userProfile), cancellationToken);
+                                    await innerDc.CancelAllDialogsAsync(cancellationToken);
+                                    await innerDc.BeginDialogAsync(InitialDialogId, cancellationToken: cancellationToken);
                                     interrupted = true;
                                     break;
                                 }
 
                             case GeneralLuis.Intent.Escalate:
                                 {
-                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("EscalateMessage", userProfile));
-                                    await innerDc.RepromptDialogAsync();
+                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("EscalateMessage", userProfile), cancellationToken);
+                                    await innerDc.RepromptDialogAsync(cancellationToken);
                                     interrupted = true;
                                     break;
                                 }
@@ -213,8 +215,8 @@ namespace VirtualAssistantSample.Dialogs
                                     if (!isSkill)
                                     {
                                         // If current dialog is a skill, allow it to handle its own help intent.
-                                        await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("HelpCard", userProfile));
-                                        await innerDc.RepromptDialogAsync();
+                                        await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("HelpCard", userProfile), cancellationToken);
+                                        await innerDc.RepromptDialogAsync(cancellationToken);
                                         interrupted = true;
                                     }
 
@@ -224,11 +226,11 @@ namespace VirtualAssistantSample.Dialogs
                             case GeneralLuis.Intent.Logout:
                                 {
                                     // Log user out of all accounts.
-                                    await LogUserOut(innerDc);
+                                    await LogUserOutAsync(innerDc, cancellationToken);
 
-                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("LogoutMessage", userProfile));
-                                    await innerDc.CancelAllDialogsAsync();
-                                    await innerDc.BeginDialogAsync(InitialDialogId);
+                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("LogoutMessage", userProfile), cancellationToken);
+                                    await innerDc.CancelAllDialogsAsync(cancellationToken);
+                                    await innerDc.BeginDialogAsync(InitialDialogId, cancellationToken: cancellationToken);
                                     interrupted = true;
                                     break;
                                 }
@@ -236,13 +238,13 @@ namespace VirtualAssistantSample.Dialogs
                             case GeneralLuis.Intent.Repeat:
                                 {
                                     // Sends the activities since the last user message again.
-                                    var previousResponse = await _previousResponseAccessor.GetAsync(innerDc.Context, () => new List<Activity>());
+                                    var previousResponse = await _previousResponseAccessor.GetAsync(innerDc.Context, () => new List<Activity>(), cancellationToken);
 
                                     foreach (var response in previousResponse)
                                     {
                                         // Reset id of original activity so it can be processed by the channel.
                                         response.Id = string.Empty;
-                                        await innerDc.Context.SendActivityAsync(response);
+                                        await innerDc.Context.SendActivityAsync(response, cancellationToken);
                                     }
 
                                     interrupted = true;
@@ -251,11 +253,11 @@ namespace VirtualAssistantSample.Dialogs
 
                             case GeneralLuis.Intent.StartOver:
                                 {
-                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("StartOverMessage", userProfile));
+                                    await innerDc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("StartOverMessage", userProfile), cancellationToken);
 
                                     // Cancel all dialogs on the stack.
-                                    await innerDc.CancelAllDialogsAsync();
-                                    await innerDc.BeginDialogAsync(InitialDialogId);
+                                    await innerDc.CancelAllDialogsAsync(cancellationToken);
+                                    await innerDc.BeginDialogAsync(InitialDialogId, cancellationToken: cancellationToken);
                                     interrupted = true;
                                     break;
                                 }
@@ -275,13 +277,13 @@ namespace VirtualAssistantSample.Dialogs
 
         private async Task<DialogTurnResult> OnboardingStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var userProfile = await _userProfileState.GetAsync(stepContext.Context, () => new UserProfileState());
+            var userProfile = await _userProfileState.GetAsync(stepContext.Context, () => new UserProfileState(), cancellationToken);
             if (string.IsNullOrEmpty(userProfile.Name))
             {
-                return await stepContext.BeginDialogAsync(_onboardingDialog.Id);
+                return await stepContext.BeginDialogAsync(_onboardingDialog.Id, cancellationToken: cancellationToken);
             }
 
-            return await stepContext.NextAsync();
+            return await stepContext.NextAsync(cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> IntroStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -303,7 +305,7 @@ namespace VirtualAssistantSample.Dialogs
         private async Task<DialogTurnResult> RouteStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var activity = stepContext.Context.Activity.AsMessageActivity();
-            var userProfile = await _userProfileState.GetAsync(stepContext.Context, () => new UserProfileState());
+            var userProfile = await _userProfileState.GetAsync(stepContext.Context, () => new UserProfileState(), cancellationToken);
 
             if (!string.IsNullOrEmpty(activity.Text))
             {
@@ -319,62 +321,66 @@ namespace VirtualAssistantSample.Dialogs
                     var dispatchIntentSkill = dispatchIntent.ToString();
                     var skillDialogArgs = new BeginSkillDialogOptions { Activity = (Activity)activity };
 
+                    // Save active skill in state.
+                    var selectedSkill = _skillsConfig.Skills[dispatchIntentSkill];
+                    await _activeSkillProperty.SetAsync(stepContext.Context, selectedSkill, cancellationToken);
+
                     // Start the skill dialog.
-                    return await stepContext.BeginDialogAsync(dispatchIntentSkill, skillDialogArgs);
+                    return await stepContext.BeginDialogAsync(dispatchIntentSkill, skillDialogArgs, cancellationToken);
                 }
-                else if (dispatchIntent == DispatchLuis.Intent.q_Faq)
+
+                if (dispatchIntent == DispatchLuis.Intent.q_Faq)
                 {
                     stepContext.SuppressCompletionMessage(true);
 
                     var knowledgebaseId = "Faq";
                     RegisterQnADialog(knowledgebaseId, localizedServices);
-                    return await stepContext.BeginDialogAsync(knowledgebaseId);
+                    return await stepContext.BeginDialogAsync(knowledgebaseId, cancellationToken: cancellationToken);
                 }
-                else if (dispatchIntent == DispatchLuis.Intent.q_Chitchat)
+
+                if (dispatchIntent == DispatchLuis.Intent.q_Chitchat)
                 {
                     stepContext.SuppressCompletionMessage(true);
 
                     var knowledgebaseId = "Chitchat";
                     RegisterQnADialog(knowledgebaseId, localizedServices);
-                    return await stepContext.BeginDialogAsync(knowledgebaseId);
+                    return await stepContext.BeginDialogAsync(knowledgebaseId, cancellationToken: cancellationToken);
                 }
-                else
-                {
-                    stepContext.SuppressCompletionMessage(true);
 
-                    await stepContext.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("UnsupportedMessage", userProfile));
-                    return await stepContext.NextAsync();
-                }
+                stepContext.SuppressCompletionMessage(true);
+
+                await stepContext.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("UnsupportedMessage", userProfile), cancellationToken);
+                return await stepContext.NextAsync(cancellationToken: cancellationToken);
             }
-            else
-            {
-                return await stepContext.NextAsync();
-            }
+
+            return await stepContext.NextAsync(cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> FinalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
+            // Clear active skill in state.
+            await _activeSkillProperty.DeleteAsync(stepContext.Context, cancellationToken);
+
             // Restart the main dialog with a different message the second time around
             return await stepContext.ReplaceDialogAsync(InitialDialogId, _templateManager.GenerateActivityForLocale("CompletedMessage"), cancellationToken);
         }
 
-        private async Task LogUserOut(DialogContext dc)
+        private async Task LogUserOutAsync(DialogContext dc, CancellationToken cancellationToken)
         {
-            IUserTokenProvider tokenProvider;
             var supported = dc.Context.Adapter is IUserTokenProvider;
             if (supported)
             {
-                tokenProvider = (IUserTokenProvider)dc.Context.Adapter;
+                var tokenProvider = (IUserTokenProvider)dc.Context.Adapter;
 
                 // Sign out user
-                var tokens = await tokenProvider.GetTokenStatusAsync(dc.Context, dc.Context.Activity.From.Id);
+                var tokens = await tokenProvider.GetTokenStatusAsync(dc.Context, dc.Context.Activity.From.Id, cancellationToken: cancellationToken);
                 foreach (var token in tokens)
                 {
-                    await tokenProvider.SignOutUserAsync(dc.Context, token.ConnectionName);
+                    await tokenProvider.SignOutUserAsync(dc.Context, token.ConnectionName, cancellationToken: cancellationToken);
                 }
 
                 // Cancel all active dialogs
-                await dc.CancelAllDialogsAsync();
+                await dc.CancelAllDialogsAsync(cancellationToken);
             }
             else
             {
@@ -382,7 +388,7 @@ namespace VirtualAssistantSample.Dialogs
             }
         }
 
-        private async Task<ResourceResponse[]> StoreOutgoingActivities(ITurnContext turnContext, List<Activity> activities, Func<Task<ResourceResponse[]>> next)
+        private async Task<ResourceResponse[]> StoreOutgoingActivitiesAsync(ITurnContext turnContext, List<Activity> activities, Func<Task<ResourceResponse[]>> next)
         {
             var messageActivities = activities
                 .Where(a => a.Type == ActivityTypes.Message)

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/OnboardingDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/OnboardingDialog.cs
@@ -18,13 +18,12 @@ namespace VirtualAssistantSample.Dialogs
     // Example onboarding dialog to initial user profile information.
     public class OnboardingDialog : ComponentDialog
     {
-        private BotServices _services;
-        private LocaleTemplateManager _templateManager;
-        private IStatePropertyAccessor<UserProfileState> _accessor;
+        private readonly BotServices _services;
+        private readonly LocaleTemplateManager _templateManager;
+        private readonly IStatePropertyAccessor<UserProfileState> _accessor;
 
         public OnboardingDialog(
-            IServiceProvider serviceProvider,
-            IBotTelemetryClient telemetryClient)
+            IServiceProvider serviceProvider)
             : base(nameof(OnboardingDialog))
         {
             _templateManager = serviceProvider.GetService<LocaleTemplateManager>();
@@ -35,37 +34,32 @@ namespace VirtualAssistantSample.Dialogs
 
             var onboarding = new WaterfallStep[]
             {
-                AskForName,
-                FinishOnboardingDialog,
+                AskForNameAsync,
+                FinishOnboardingDialogAsync,
             };
 
-            // To capture built-in waterfall dialog telemetry, set the telemetry client
-            // to the new waterfall dialog and add it to the component dialog
-            TelemetryClient = telemetryClient;
-            AddDialog(new WaterfallDialog(nameof(onboarding), onboarding) { TelemetryClient = telemetryClient });
+            AddDialog(new WaterfallDialog(nameof(onboarding), onboarding));
             AddDialog(new TextPrompt(DialogIds.NamePrompt));
         }
 
-        public async Task<DialogTurnResult> AskForName(WaterfallStepContext sc, CancellationToken cancellationToken)
+        public async Task<DialogTurnResult> AskForNameAsync(WaterfallStepContext sc, CancellationToken cancellationToken)
         {
-            var state = await _accessor.GetAsync(sc.Context, () => new UserProfileState());
+            var state = await _accessor.GetAsync(sc.Context, () => new UserProfileState(), cancellationToken);
 
             if (!string.IsNullOrEmpty(state.Name))
             {
-                return await sc.NextAsync(state.Name);
+                return await sc.NextAsync(state.Name, cancellationToken);
             }
-            else
+
+            return await sc.PromptAsync(DialogIds.NamePrompt, new PromptOptions()
             {
-                return await sc.PromptAsync(DialogIds.NamePrompt, new PromptOptions()
-                {
-                    Prompt = _templateManager.GenerateActivityForLocale("NamePrompt"),
-                });
-            }
+                Prompt = _templateManager.GenerateActivityForLocale("NamePrompt"),
+            }, cancellationToken);
         }
 
-        public async Task<DialogTurnResult> FinishOnboardingDialog(WaterfallStepContext sc, CancellationToken cancellationToken)
+        public async Task<DialogTurnResult> FinishOnboardingDialogAsync(WaterfallStepContext sc, CancellationToken cancellationToken)
         {
-            var userProfile = await _accessor.GetAsync(sc.Context, () => new UserProfileState());
+            var userProfile = await _accessor.GetAsync(sc.Context, () => new UserProfileState(), cancellationToken);
             var name = (string)sc.Result;
 
             var generalResult = sc.Context.TurnState.Get<GeneralLuis>(StateProperties.GeneralResult);
@@ -89,17 +83,17 @@ namespace VirtualAssistantSample.Dialogs
                 }
             }
 
-            // Captialize name
+            // Capitalize name
             userProfile.Name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLower());
 
             await _accessor.SetAsync(sc.Context, userProfile, cancellationToken);
 
-            await sc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("HaveNameMessage", userProfile));
+            await sc.Context.SendActivityAsync(_templateManager.GenerateActivityForLocale("HaveNameMessage", userProfile), cancellationToken);
 
-            return await sc.EndDialogAsync();
+            return await sc.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
-        private class DialogIds
+        private static class DialogIds
         {
             public const string NamePrompt = "namePrompt";
         }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Program.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace VirtualAssistantSample
 {
@@ -10,12 +10,14 @@ namespace VirtualAssistantSample
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
-                .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Startup.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Startup.cs
@@ -20,11 +20,9 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Bot.Solutions.Skills;
 using Microsoft.Bot.Solutions.Skills.Dialogs;
-using Microsoft.Bot.Solutions.Skills.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using VirtualAssistantSample.Adapters;
 using VirtualAssistantSample.Authentication;
 using VirtualAssistantSample.Bots;
@@ -35,7 +33,7 @@ namespace VirtualAssistantSample
 {
     public class Startup
     {
-        public Startup(IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        public Startup(IWebHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
@@ -68,6 +66,13 @@ namespace VirtualAssistantSample
 
             // Configure configuration provider
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+
+            // Register the skills configuration class.
+            var skillsConfig = new SkillsConfiguration(Configuration);
+            services.AddSingleton(skillsConfig);
+
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(skillsConfig) });
 
             // Configure telemetry
             services.AddApplicationInsightsTelemetry();
@@ -104,68 +109,48 @@ namespace VirtualAssistantSample
 
             services.AddSingleton(new LocaleTemplateManager(localizedTemplates, settings.DefaultLocale ?? "en-us"));
 
-            // Register the skills configuration class
-            services.AddSingleton<SkillsConfiguration>();
-
-            // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(sp.GetService<SkillsConfiguration>()) });
-
-            // Register dialogs
-            services.AddTransient<MainDialog>();
-            services.AddTransient<SwitchSkillDialog>();
-            services.AddTransient<OnboardingDialog>();
-
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.
             services.AddSingleton<BotFrameworkHttpAdapter, DefaultAdapter>();
             services.AddSingleton<BotAdapter>(sp => sp.GetService<BotFrameworkHttpAdapter>());
-
-            // Configure bot
-            services.AddTransient<IBot, DefaultActivityHandler<MainDialog>>();
 
             // Register the skills conversation ID factory, the client and the request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
             services.AddHttpClient<SkillHttpClient>();
             services.AddSingleton<ChannelServiceHandler, SkillHandler>();
 
+            // Register dialogs
+            services.AddTransient<MainDialog>();
+            services.AddTransient<SwitchSkillDialog>();
+            services.AddTransient<OnboardingDialog>();
+
             // Register the SkillDialogs (remote skills).
-            var section = Configuration?.GetSection("BotFrameworkSkills");
-            var skills = section?.Get<EnhancedBotFrameworkSkill[]>();
-            if (skills != null)
+            var botId = Configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
+            if (string.IsNullOrWhiteSpace(botId))
             {
-                var hostEndpointSection = Configuration?.GetSection("SkillHostEndpoint");
-                if (hostEndpointSection == null)
-                {
-                    throw new ArgumentException($"{hostEndpointSection} is not in the configuration");
-                }
-                else
-                {
-                    var hostEndpoint = new Uri(hostEndpointSection.Value);
-                    var botId = Configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-                    if (string.IsNullOrWhiteSpace(botId))
-                    {
-                        throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
-                    }
-
-                    foreach (var skill in skills)
-                    {
-                        services.AddSingleton(sp =>
-                        {
-                            var skillDialogOptions = new SkillDialogOptions
-                            {
-                                BotId = botId,
-                                ConversationIdFactory = sp.GetService<SkillConversationIdFactoryBase>(),
-                                SkillClient = sp.GetService<SkillHttpClient>(),
-                                SkillHostEndpoint = hostEndpoint,
-                                Skill = skill,
-                                ConversationState = sp.GetService<ConversationState>()
-                            };
-
-                            return new SkillDialog(skillDialogOptions, skill.Id);
-                        });
-                    }
-                }
+                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
             }
+
+            foreach (var skill in skillsConfig.Skills.Values)
+            {
+                services.AddSingleton(sp =>
+                {
+                    var skillDialogOptions = new SkillDialogOptions
+                    {
+                        BotId = botId,
+                        ConversationIdFactory = sp.GetService<SkillConversationIdFactoryBase>(),
+                        SkillClient = sp.GetService<SkillHttpClient>(),
+                        SkillHostEndpoint = skillsConfig.SkillHostEndpoint,
+                        Skill = skill,
+                        ConversationState = sp.GetService<ConversationState>()
+                    };
+
+                    return new SkillDialog(skillDialogOptions, skill.Id);
+                });
+            }
+
+            // Configure bot
+            services.AddTransient<IBot, DefaultActivityHandler<MainDialog>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -180,7 +165,11 @@ namespace VirtualAssistantSample
                 .UseStaticFiles()
                 .UseWebSockets()
                 .UseRouting()
+                .UseAuthorization()
                 .UseEndpoints(endpoints => endpoints.MapControllers());
+
+            // Uncomment this to support HTTPS.
+            // app.UseHttpsRedirection();
         }
     }
 }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Startup.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Startup.cs
@@ -165,7 +165,6 @@ namespace VirtualAssistantSample
                 .UseStaticFiles()
                 .UseWebSockets()
                 .UseRouting()
-                .UseAuthorization()
                 .UseEndpoints(endpoints => endpoints.MapControllers());
 
             // Uncomment this to support HTTPS.

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.8.1-rc0" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -11,25 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="1.2.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.8.1-rc0" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample.Tests/SkillSample.Tests.csproj
+++ b/samples/csharp/skill/SkillSample.Tests/SkillSample.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample/Adapters/DefaultAdapter.cs
+++ b/samples/csharp/skill/SkillSample/Adapters/DefaultAdapter.cs
@@ -27,8 +27,8 @@ namespace SkillSample.Adapters
 
         public DefaultAdapter(
             BotSettings settings,
-            IChannelProvider channelProvider,
             ICredentialProvider credentialProvider,
+            IChannelProvider channelProvider,
             AuthenticationConfiguration authConfig,
             LocaleTemplateManager templateEngine,
             ConversationState conversationState,
@@ -42,7 +42,7 @@ namespace SkillSample.Adapters
             _templateEngine = templateEngine ?? throw new ArgumentNullException(nameof(templateEngine));
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
-            OnTurnError = HandleTurnError;
+            OnTurnError = HandleTurnErrorAsync;
 
             Use(telemetryMiddleware);
 
@@ -56,7 +56,7 @@ namespace SkillSample.Adapters
             Use(new SetSpeakMiddleware());
         }
 
-        private async Task HandleTurnError(ITurnContext turnContext, Exception exception)
+        private async Task HandleTurnErrorAsync(ITurnContext turnContext, Exception exception)
         {
             // Log any leaked exception from the application.
             _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");

--- a/samples/csharp/skill/SkillSample/Program.cs
+++ b/samples/csharp/skill/SkillSample/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace SkillSample
 {
@@ -10,12 +10,14 @@ namespace SkillSample
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>() // Note: Application Insights is added in Startup.  Disabling is also handled there.
-                .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -6,11 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="1.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="0.9.0-daily252" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
This PR contains several suggested changes to the VASkillSample based on the SDK samples and other observations:

- Refactored DefaultAdapter based on SDK Skill samples (broke down OnTurnError in several discrete methods with error handling and deleted conversation state at the end).
- Moved assignment of MainDialog.TelemetryClient into DefaultActivityHandler to avoid calling a virtual property from the Dialog's constructor.
- Updated MainDialog to store the active skill in convo state so we can send an EoC in OnTurnError if the VA crashes and is not handled.
- Reorganized startup.cs a bit and also refactored to use SkillsConfiguration for creating the skill dialog instances rather than rereading the appsettings and dublicating config keys that are already in SkillsConfiguration.
- Made private fields readonly where possible.
- Re-added some top level BF references to the SkillSample.csproj so devs can update SDK packages without having to update the Solutions package.
- Added missing cancellationToken parameters across the board.
- Added Async suffic to async methods.
- Updated program.cs based on OOTB 3.1 program.cs for asp.net core)