### PR TITLE
Implement Sharded version of ProactiveState

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleWareTemplate.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleWareTemplate.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Solutions.Util;
+
+namespace Microsoft.Bot.Solutions.Proactive
+{
+    /// <summary>
+    /// A Middleware for saving the proactive model data
+    /// This middleware will refresh user's latest conversation reference and save it to state.
+    /// </summary>
+    /// <typeparam name="T">Type of ProacitveState.</typeparam>
+    public class ProactiveStateMiddleWareTemplate<T> : IMiddleware
+        where T : BotState
+    {
+        private readonly T _proactiveState;
+        private readonly IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
+
+        public ProactiveStateMiddleWareTemplate(T proactiveState)
+        {
+            _proactiveState = proactiveState;
+            _proactiveStateAccessor = _proactiveState.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
+        }
+
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        {
+            var activity = turnContext.Activity;
+
+            if (!string.IsNullOrEmpty(activity.From.Role) && activity.From.Role.Equals("user", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel()).ConfigureAwait(false);
+                ProactiveModel.ProactiveData data;
+                var hashedUserId = MD5Util.ComputeHash(turnContext.Activity.From.Id);
+                var conversationReference = turnContext.Activity.GetConversationReference();
+                var proactiveData = new ProactiveModel.ProactiveData { Conversation = conversationReference };
+
+                if (proactiveState.TryGetValue(hashedUserId, out data))
+                {
+                    data.Conversation = conversationReference;
+                }
+                else
+                {
+                    data = new ProactiveModel.ProactiveData { Conversation = conversationReference };
+                }
+
+                proactiveState[hashedUserId] = data;
+                await _proactiveStateAccessor.SetAsync(turnContext, proactiveState).ConfigureAwait(false);
+                await _proactiveState.SaveChangesAsync(turnContext).ConfigureAwait(false);
+            }
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleware.cs
@@ -13,44 +13,11 @@ namespace Microsoft.Bot.Solutions.Proactive
     /// A Middleware for saving the proactive model data
     /// This middleware will refresh user's latest conversation reference and save it to state.
     /// </summary>
-    public class ProactiveStateMiddleware : IMiddleware
+    public class ProactiveStateMiddleware : ProactiveStateMiddleWareTemplate<ProactiveState>
     {
-        private ProactiveState _proactiveState;
-        private IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
-
-        public ProactiveStateMiddleware(ProactiveState proactiveState)
+        public ProactiveStateMiddleware(ProactiveState proactiveStateSharded)
+            : base(proactiveStateSharded)
         {
-            _proactiveState = proactiveState;
-            _proactiveStateAccessor = _proactiveState.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
-        }
-
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var activity = turnContext.Activity;
-
-            if (!string.IsNullOrEmpty(activity.From.Role) && activity.From.Role.Equals("user", StringComparison.InvariantCultureIgnoreCase))
-            {
-                var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel()).ConfigureAwait(false);
-                ProactiveModel.ProactiveData data;
-                var hashedUserId = MD5Util.ComputeHash(turnContext.Activity.From.Id);
-                var conversationReference = turnContext.Activity.GetConversationReference();
-                var proactiveData = new ProactiveModel.ProactiveData { Conversation = conversationReference };
-
-                if (proactiveState.TryGetValue(hashedUserId, out data))
-                {
-                    data.Conversation = conversationReference;
-                }
-                else
-                {
-                    data = new ProactiveModel.ProactiveData { Conversation = conversationReference };
-                }
-
-                proactiveState[hashedUserId] = data;
-                await _proactiveStateAccessor.SetAsync(turnContext, proactiveState).ConfigureAwait(false);
-                await _proactiveState.SaveChangesAsync(turnContext).ConfigureAwait(false);
-            }
-
-            await next(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateMiddlewareSharded.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateMiddlewareSharded.cs
@@ -13,44 +13,11 @@ namespace Microsoft.Bot.Solutions.Proactive.Sharded
     /// A Middleware for saving the proactive model data
     /// This middleware will refresh user's latest conversation reference and save it to state.
     /// </summary>
-    public class ProactiveStateMiddlewareSharded : IMiddleware
+    public class ProactiveStateMiddlewareSharded : ProactiveStateMiddleWareTemplate<ProactiveStateSharded>
     {
-        private ProactiveStateSharded _proactiveState;
-        private IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
-
-        public ProactiveStateMiddlewareSharded(ProactiveStateSharded proactiveState)
+        public ProactiveStateMiddlewareSharded(ProactiveStateSharded proactiveStateSharded)
+            : base(proactiveStateSharded)
         {
-            _proactiveState = proactiveState;
-            _proactiveStateAccessor = _proactiveState.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
-        }
-
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var activity = turnContext.Activity;
-
-            if (!string.IsNullOrEmpty(activity.From.Role) && activity.From.Role.Equals("user", StringComparison.InvariantCultureIgnoreCase))
-            {
-                var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel()).ConfigureAwait(false);
-                ProactiveModel.ProactiveData data;
-                var hashedUserId = MD5Util.ComputeHash(turnContext.Activity.From.Id);
-                var conversationReference = turnContext.Activity.GetConversationReference();
-                var proactiveData = new ProactiveModel.ProactiveData { Conversation = conversationReference };
-
-                if (proactiveState.TryGetValue(hashedUserId, out data))
-                {
-                    data.Conversation = conversationReference;
-                }
-                else
-                {
-                    data = new ProactiveModel.ProactiveData { Conversation = conversationReference };
-                }
-
-                proactiveState[hashedUserId] = data;
-                await _proactiveStateAccessor.SetAsync(turnContext, proactiveState).ConfigureAwait(false);
-                await _proactiveState.SaveChangesAsync(turnContext).ConfigureAwait(false);
-            }
-
-            await next(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateMiddlewareSharded.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateMiddlewareSharded.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Solutions.Proactive.Sharded
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Solutions.Util;
+
+    /// <summary>
+    /// A Middleware for saving the proactive model data
+    /// This middleware will refresh user's latest conversation reference and save it to state.
+    /// </summary>
+    public class ProactiveStateMiddlewareSharded : IMiddleware
+    {
+        private ProactiveStateSharded _proactiveState;
+        private IStatePropertyAccessor<ProactiveModel> _proactiveStateAccessor;
+
+        public ProactiveStateMiddlewareSharded(ProactiveStateSharded proactiveState)
+        {
+            _proactiveState = proactiveState;
+            _proactiveStateAccessor = _proactiveState.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
+        }
+
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var activity = turnContext.Activity;
+
+            if (!string.IsNullOrEmpty(activity.From.Role) && activity.From.Role.Equals("user", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel()).ConfigureAwait(false);
+                ProactiveModel.ProactiveData data;
+                var hashedUserId = MD5Util.ComputeHash(turnContext.Activity.From.Id);
+                var conversationReference = turnContext.Activity.GetConversationReference();
+                var proactiveData = new ProactiveModel.ProactiveData { Conversation = conversationReference };
+
+                if (proactiveState.TryGetValue(hashedUserId, out data))
+                {
+                    data.Conversation = conversationReference;
+                }
+                else
+                {
+                    data = new ProactiveModel.ProactiveData { Conversation = conversationReference };
+                }
+
+                proactiveState[hashedUserId] = data;
+                await _proactiveStateAccessor.SetAsync(turnContext, proactiveState).ConfigureAwait(false);
+                await _proactiveState.SaveChangesAsync(turnContext).ConfigureAwait(false);
+            }
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateSharded.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/Sharded/ProactiveStateSharded.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Solutions.Proactive.Sharded
+{
+    using Microsoft.Bot.Builder;
+
+    public class ProactiveStateSharded : BotState
+    {
+        /// <summary>The key used to cache the state information in the turn context.</summary>
+        private const string ShardedStorageKey = "ProactiveState_";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProactiveStateSharded"/> class.</summary>
+        /// <param name="storage">The storage provider to use.</param>
+        /// <param name="turnContext">TurnContext to get conversationId.</param>
+        public ProactiveStateSharded(IStorage storage)
+            : base(storage, ShardedStorageKey)
+        {
+        }
+
+        /// <summary>Gets the storage key for caching state information.</summary>
+        /// <param name="turnContext">A <see cref="ITurnContext"/> containing all the data needed
+        /// for processing this conversation turn.</param>
+        /// <returns>The storage key.</returns>
+        protected override string GetStorageKey(ITurnContext turnContext) => ShardedStorageKey + turnContext.Activity.Conversation.Id;
+    }
+}

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveShardedTest.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveShardedTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Solutions.Proactive;
+using Microsoft.Bot.Solutions.Proactive.Sharded;
+using Microsoft.Bot.Solutions.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Solutions.Tests.Proactive
+{
+    [TestClass]
+    [TestCategory("UnitTests")]
+    public class ProactiveShardedTest
+    {
+        [TestMethod]
+        public async Task DefaultOptions()
+        {
+            var microsoftAppId = string.Empty;
+
+            var storage = new MemoryStorage();
+
+            var state = new ProactiveStateSharded(storage);
+            var proactiveStateAccessor = state.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
+
+            var conversation = TestAdapter.CreateConversation("Name");
+            conversation.User.Role = "user";
+
+            var adapter = new TestAdapter(conversation)
+                .Use(new ProactiveStateMiddlewareSharded(state));
+
+            var response = "Response";
+            var proactiveResponse = "ProactiveResponse";
+            var proactiveEvent = new Activity(type: ActivityTypes.Event, value: "user1", text: proactiveResponse);
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Type == ActivityTypes.Event)
+                {
+                    var proactiveModel = await proactiveStateAccessor.GetAsync(context, () => new ProactiveModel());
+
+                    var hashedUserId = MD5Util.ComputeHash(context.Activity.Value.ToString());
+
+                    var conversationReference = proactiveModel[hashedUserId].Conversation;
+
+                    await context.Adapter.ContinueConversationAsync(microsoftAppId, conversationReference, ContinueConversationCallback(context, context.Activity.Text), cancellationToken);
+                }
+                else
+                {
+                    await context.SendActivityAsync(context.Activity.CreateReply(response));
+                }
+            })
+                .Send("foo")
+                .AssertReply(response)
+                .Send(proactiveEvent)
+                .AssertReply(proactiveResponse)
+                .StartTestAsync();
+        }
+
+        private BotCallbackHandler ContinueConversationCallback(ITurnContext context, string message)
+        {
+            return async (turnContext, cancellationToken) =>
+            {
+                var activity = turnContext.Activity.CreateReply(message);
+                await turnContext.SendActivityAsync(activity);
+            };
+        }
+    }
+}

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveShardedTest.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveShardedTest.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Bot.Solutions.Tests.Proactive
             var state = new ProactiveStateSharded(storage);
             var proactiveStateAccessor = state.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
 
-            var conversation = TestAdapter.CreateConversation("Name");
-            conversation.User.Role = "user";
+            var conversation = TestAdapter.CreateConversation(ProactiveTestConstants.Name);
+            conversation.User.Role = ProactiveTestConstants.User;
 
             var adapter = new TestAdapter(conversation)
                 .Use(new ProactiveStateMiddlewareSharded(state));
 
-            var response = "Response";
-            var proactiveResponse = "ProactiveResponse";
-            var proactiveEvent = new Activity(type: ActivityTypes.Event, value: "user1", text: proactiveResponse);
+            var response = ProactiveTestConstants.Response;
+            var proactiveResponse = ProactiveTestConstants.ProactiveResponse;
+            var proactiveEvent = new Activity(type: ActivityTypes.Event, value: ProactiveTestConstants.User1, text: proactiveResponse);
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveTestConstants.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveTestConstants.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Solutions.Tests.Proactive
+{
+    public static class ProactiveTestConstants
+    {
+        public const string User1 = "user1";
+        public const string ProactiveResponse = "ProactiveResponse";
+        public const string Response = "Response";
+        public const string Name = "Name";
+        public const string User = "user";
+    }
+}

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Proactive/ProactiveTests.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Bot.Solutions.Tests.Proactive
             var state = new ProactiveState(storage);
             var proactiveStateAccessor = state.CreateProperty<ProactiveModel>(nameof(ProactiveModel));
 
-            var conversation = TestAdapter.CreateConversation("Name");
-            conversation.User.Role = "user";
+            var conversation = TestAdapter.CreateConversation(ProactiveTestConstants.Name);
+            conversation.User.Role = ProactiveTestConstants.User;
 
             var adapter = new TestAdapter(conversation)
                 .Use(new ProactiveStateMiddleware(state));
 
-            var response = "Response";
-            var proactiveResponse = "ProactiveResponse";
-            var proactiveEvent = new Activity(type: ActivityTypes.Event, value: "user1", text: proactiveResponse);
+            var response = ProactiveTestConstants.Response;
+            var proactiveResponse = ProactiveTestConstants.ProactiveResponse;
+            var proactiveEvent = new Activity(type: ActivityTypes.Event, value: ProactiveTestConstants.User1, text: proactiveResponse);
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
Cosmos dB has limit of 2MB on document size, storing all Proactivestate will quickly hit that limit, having a Sharded version of proactive state will help mitigate above limitation
### Purpose
*What is the context of this pull request? Why is it being done?*
Sharded version of Proactivestate will mitigate 2MB limit on Document size

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
a. add ProactiveStateSharded.cs
b. add ProactiveStateShardedMiddleware.cs

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
