### PR TITLE
Adding 'Mail.Send' scope to To Do Skill sample documentation

### DIFF
--- a/docs/_docs/skills/samples/to-do.md
+++ b/docs/_docs/skills/samples/to-do.md
@@ -94,6 +94,7 @@ This skill uses the following authentication scopes:
 - **User.Read**
 - **User.ReadBasic.All**
 - **Tasks.ReadWrite**
+- **Mail.Send**
 
 You must use [these steps]({{site.baseurl}}/{{site.data.urls.SkillManualAuth}}) to manually configure Authentication for the ToDo Skill. Due to a change in the Skill architecture this is not currently automated.
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
The To Do Skill can prompt sending an email with a link to a newly created Tasks folder in Outlook if it is created. This requires the 'Mail.Send' scope to be granted, otherwise the operation is not authorized. The documentation missed this scope.

### Changes
Adding 'Mail.Send' to the list of scopes that are required on the To Do Skill sample documentation.

### Tests
Documentation change - only proof-reading required.

### Feature Plan
N/A

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
