### PR TITLE
Remove HRBenefits intent to fix build failure

### DIFF
--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -529,7 +529,6 @@ namespace VirtualAssistantSample.Dialogs
             if (dispatchIntent.ToString().Equals(DispatchLuis.Intent.l_General.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
                 dispatchIntent.ToString().Equals(DispatchLuis.Intent.q_Faq.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
                 dispatchIntent.ToString().Equals(DispatchLuis.Intent.q_Chitchat.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
-                dispatchIntent.ToString().Equals(DispatchLuis.Intent.q_HRBenefits.ToString(), StringComparison.InvariantCultureIgnoreCase) ||
                 dispatchIntent.ToString().Equals(DispatchLuis.Intent.None.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return false;

--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Services/DispatchLuis.cs
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Services/DispatchLuis.cs
@@ -21,8 +21,7 @@ namespace Luis
         public enum Intent {
             l_General, 
             q_Chitchat, 
-            q_Faq, 
-            q_HRBenefits, 
+            q_Faq,
             None
         };
         [JsonProperty("intents")]


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
Fix EnterpriseVA build failure by removing q_HRBenefit intent from Dispatch
### Purpose
*What is the context of this pull request? Why is it being done?*
q_HRBenefit Dispatch is disabled in build pipeline as a result is causing build failures 
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
