### PR TITLE
Chitchat as fallback

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -15,7 +15,8 @@ Param(
 	[switch] $useDispatch = $true,
     [string] $languages = "en-us",
     [string] $outFolder = $(Get-Location),
-	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt")
+	[string] $logFile = $(Join-Path $PSScriptRoot .. "deploy_cognitive_models_log.txt"),
+	[string[]] $excludedKbFromDispatch = @("Chitchat")
 )
 
 . $PSScriptRoot\luis_functions.ps1
@@ -272,7 +273,7 @@ foreach ($language in $languageArr)
                     -log $logFile
        
 				if ($qnaKb) {
-					if ($useDispatch) {
+					if ($useDispatch -and -not $excludedKbFromDispatch.Contains($lu.BaseName)) {
 						Write-Host "> Adding $($langCode) $($lu.BaseName) kb to dispatch model ..." -NoNewline    
 						(dispatch add `
 							--type "qna" `

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/update_cognitive_models.ps1
@@ -10,7 +10,8 @@ Param(
 	[string] $qnaEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v4.0",
     [string] $qnaFolder = $(Join-Path $PSScriptRoot '..' 'Resources' 'QnA'),
     [string] $lgOutFolder = $(Join-Path (Get-Location) 'Services'),
-    [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt")
+    [string] $logFile = $(Join-Path $PSScriptRoot .. "update_cognitive_models_log.txt"),
+    [string[]] $excludedKbFromDispatch = @("Chitchat")
 )
 
 . $PSScriptRoot\luis_functions.ps1
@@ -109,7 +110,7 @@ foreach ($langCode in $languageMap.Keys) {
         {    
             # Add the knowledge base to the dispatch model. 
             # If the knowledge base id already exists within the model no action will be taken
-            if ($dispatch) {
+            if ($dispatch -and -not $excludedKbFromDispatch.Contains($kb.id))
                 Write-Host "> Adding $($langCode) $($kb.id) kb to dispatch file ..." -NoNewline
                 dispatch add `
                     --type "qna" `
@@ -208,7 +209,7 @@ foreach ($langCode in $languageMap.Keys) {
 		
             # Add the knowledge base to the dispatch model. 
             # If the knowledge base id already exists within the model no action will be taken
-            if ($dispatch) {
+            if ($dispatch -and -not $excludedKbFromDispatch.Contains($kb.id)) {
                 Write-Host "> Adding $($langCode) $($kb.id) kb to dispatch model ..." -NoNewline
                 (dispatch add `
                     --type "qna" `

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -451,16 +451,16 @@ namespace VirtualAssistantSample.Dialogs
         /// <summary>
         /// A simple set of heuristics to govern if we should invoke the personality <see cref="QnAMakerDialog"/>.
         /// </summary>
-        /// <param name="stepContext">Current dialog context</param>
-        /// <param name="dispatchIntent">Intent that Dispatch thinks should be invoked</param>
-        /// <param name="dispatchScore">Confidence score for intent</param>
-        /// <param name="threshold">User provided threshold, if above this threshold do NOT show chitchat</param>
-        /// <returns>A <see cref="bool"/> indicating if we should invoke the personality dialog</returns>
+        /// <param name="stepContext">Current dialog context.</param>
+        /// <param name="dispatchIntent">Intent that Dispatch thinks should be invoked.</param>
+        /// <param name="dispatchScore">Confidence score for intent.</param>
+        /// <param name="threshold">User provided threshold between 0.0 and 1.0, if above this threshold do NOT show chitchat.</param>
+        /// <returns>A <see cref="bool"/> indicating if we should invoke the personality dialog.</returns>
         private bool ShouldBeginChitChatDialog(WaterfallStepContext stepContext, DispatchLuis.Intent dispatchIntent, double dispatchScore, double threshold = 0.5)
         {
-            if (IsSkillIntent(dispatchIntent))
+            if (threshold < 0.0 || threshold > 1.0)
             {
-                return false;
+                throw new ArgumentOutOfRangeException(nameof(threshold));
             }
 
             if (dispatchIntent == DispatchLuis.Intent.None)

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs
@@ -462,11 +462,13 @@ namespace VirtualAssistantSample.Dialogs
             {
                 return false;
             }
-            else if (dispatchIntent == DispatchLuis.Intent.None)
+
+            if (dispatchIntent == DispatchLuis.Intent.None)
             {
                 return true;
             }
-            else if (dispatchIntent == DispatchLuis.Intent.l_General)
+
+            if (dispatchIntent == DispatchLuis.Intent.l_General)
             {
                 // If dispatch classifies user query as general, we should check against the cached general Luis score instead.
                 var generalResult = stepContext.Context.TurnState.Get<GeneralLuis>(StateProperties.GeneralResult);

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Services/DispatchLuis.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Services/DispatchLuis.cs
@@ -21,7 +21,6 @@ namespace Luis
         public enum Intent
         {
             l_General,
-            q_Chitchat,
             q_Faq,
             None
         };


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
Fixes [#3233](https://github.com/microsoft/botframework-solutions/issues/3233)
### Purpose
LUIS has a tendency to overfit on training data. Our personality datasets tend be very big, and once introduced at the dispatch level, tends to cause dispatch to be biased towards the chitchat intent. 

This PR moves chitchat out of dispatch, and calls the chitchat kb only after skills, faq and other intents are evaluated, and a user-adjustable threshold is met.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
The suggested threshold and conditionals are heuristics.  Might have to be adjusted after some testing.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
 \-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
 \-

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
