### PR TITLE
Pavolum/telephony changes

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Bots/DefaultActivityHandler.cs
@@ -7,7 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions;
 using Microsoft.Bot.Solutions.Responses;
@@ -66,6 +68,13 @@ namespace VirtualAssistantSample.Bots
 
         protected override Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
+            // directline speech occasionally sends empty message activities that should be ignored
+            var activity = turnContext.Activity;
+            if (activity.ChannelId == Channels.DirectlineSpeech && activity.Type == ActivityTypes.Message && string.IsNullOrEmpty(activity.Text))
+            {
+                return Task.CompletedTask;
+            }
+
             return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
         }
 

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Responses/MainResponses.lg
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Responses/MainResponses.lg
@@ -58,8 +58,12 @@
 
 # EscalateMessage
 [HeroCard
-  subtitle=Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.
+  subtitle= ${EscalatedText()}
+  speak = ${EscalatedText()}
 ]
+
+# EscalatedText
+- Our agents are available 24/7 at 1(800)555-1234. Or connect with us through Microsoft Teams.
 
 # NewUserIntroCard
 [Activity
@@ -206,8 +210,12 @@
 # HelpCard
 [HeroCard 
     title=Help for Virtual Assistant
-    subtitle=This card can be used to display information to help your user interact with your bot.
+    subtitle=${HelpText()}
+    speak = ${HelpText()}
 ]
+
+# HelpText
+- This can be used to display information to help your user interact with your bot.
 
 # RandomName 
 - IF: ${Name && rand(0, 1000) > 500}

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Responses/MainResponses.lg
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Responses/MainResponses.lg
@@ -215,7 +215,7 @@
 ]
 
 # HelpText
-- This can be used to display information to help your user interact with your bot.
+- This can be used to display information to help your user interact with your Virtual Assistant.
 
 # RandomName 
 - IF: ${Name && rand(0, 1000) > 500}

--- a/samples/csharp/skill/SkillSample/Bots/DefaultActivityHandler.cs
+++ b/samples/csharp/skill/SkillSample/Bots/DefaultActivityHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,6 +50,13 @@ namespace SkillSample.Bots
 
         protected override Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
+            // directline speech occasionally sends empty message activities that should be ignored
+            var activity = turnContext.Activity;
+            if (activity.ChannelId == Channels.DirectlineSpeech && activity.Type == ActivityTypes.Message && string.IsNullOrEmpty(activity.Text))
+            {
+                return Task.CompletedTask;
+            }
+
             return _dialog.RunAsync(turnContext, _dialogStateAccessor, cancellationToken);
         }
 

--- a/samples/csharp/skill/SkillSample/Responses/MainResponses.lg
+++ b/samples/csharp/skill/SkillSample/Responses/MainResponses.lg
@@ -62,6 +62,7 @@
 [HeroCard 
     title= ${HelpTitle()}
     subtitle= ${HelpSubtitle()}
+    speak = ${HelpSubtitle()}
 ]
 
 

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Solutions.Middleware
         /// Initializes a new instance of the <see cref="SetSpeakMiddleware"/> class.
         /// </summary>
         /// <param name="locale">If null, use en-US.</param>
-        /// <param name="voiceFonts">Map voice font for locale like en-US to "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)".</param>
+        /// <param name="voiceFonts">Map voice font for locale like en-US to "Microsoft Server Speech Text to Speech Voice (en-US, Jessa24kRUS)".</param>
         /// <param name="channels">Set SSML for these channels. If null, use <see cref="Connector.Channels.DirectlineSpeech"/> and <see cref="Connector.Channels.Emulator"/>.</param>
         public SetSpeakMiddleware(string locale = null, IDictionary<string, string> voiceFonts = null, ISet<string> channels = null)
         {
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Solutions.Middleware
                 var attachmentContent = activity.Attachments[0].Content;
                 if (attachmentContent != null && attachmentContent.GetType() == typeof(JObject))
                 {
-                    var contentObj = (JObject)attachmentContent;
+                    var contentObj = attachmentContent as JObject;
                     return contentObj["speak"]?.ToString();
                 }
             }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Bot.Solutions.Middleware
             if (activity.Attachments.Count > 0)
             {
                 var attachmentContent = activity.Attachments[0].Content;
-                if (attachmentContent != null && attachmentContent.GetType() == typeof(JObject))
+                if (attachmentContent != null)
                 {
                     var contentObj = attachmentContent as JObject;
-                    return contentObj["speak"]?.ToString();
+                    return contentObj?["speak"]?.ToString();
                 }
             }
 

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Middleware/SetSpeakMiddlewareTests.cs
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Middleware/SetSpeakMiddlewareTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Solutions.Tests.Middleware
                     Assert.AreEqual(rootElement.Name.LocalName, "speak");
                     Assert.AreEqual(rootElement.Attribute(XNamespace.Xml + "lang").Value, "en-US");
                     var voiceElement = rootElement.Element("voice");
-                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)");
+                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (en-US, Jessa24kRUS)");
                     Assert.AreEqual(voiceElement.Value, response);
                 })
                 .StartTestAsync();
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Solutions.Tests.Middleware
                     Assert.AreEqual(rootElement.Name.LocalName, "speak");
                     Assert.AreEqual(rootElement.Attribute(XNamespace.Xml + "lang").Value, "en-US");
                     var voiceElement = rootElement.Element("voice");
-                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (en-US, ZiraRUS)");
+                    Assert.AreEqual(voiceElement.Attribute("name").Value, "Microsoft Server Speech Text to Speech Voice (en-US, Jessa24kRUS)");
                     Assert.AreEqual(voiceElement.Value, response);
                 })
                 .StartTestAsync();


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Adding the following components needed to support telephony channel out of the box
- Added code to ignore blank message activities from DirectLineSpeech channel within activityHandler for both speech and VA
- Added code to grab speak values from attachments if the activity does not have a text or speak value and the attachment has a speak value
- Changes voice for speech scenarios to more human like neural voice
- Added speak values to HeroCard attachment types