### PR TITLE
Actually fix deploy_cognitive_models.ps1

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -344,7 +344,7 @@ foreach ($language in $languageArr)
 					--resourceGroup $resourceGroup `
 					--armToken $azAccessToken.accessToken `
 					--azureSubscriptionId $azAccount.id `
-					--appId $dispatchApp.id `
+					--appId $dispatchApp.appId `
 					--endpoint $luisEndpoint `
 					--subscriptionKey $luisAuthoringKey 2>> $logFile
 

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -343,7 +343,7 @@ foreach ($language in $languageArr)
 					--resourceGroup $resourceGroup `
 					--armToken $azAccessToken.accessToken `
 					--azureSubscriptionId $azAccount.id `
-					--appId $dispatchApp.id `
+					--appId $dispatchApp.appId `
 					--endpoint $luisEndpoint `
 					--subscriptionKey $luisAuthoringKey 2>> $logFile
 

--- a/templates/csharp/Skill/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -343,7 +343,7 @@ foreach ($language in $languageArr)
 					--resourceGroup $resourceGroup `
 					--armToken $azAccessToken.accessToken `
 					--azureSubscriptionId $azAccount.id `
-					--appId $dispatchApp.id `
+					--appId $dispatchApp.appId `
 					--endpoint $luisEndpoint `
 					--subscriptionKey $luisAuthoringKey 2>> $logFile
 

--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy_cognitive_models.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy_cognitive_models.ps1
@@ -343,7 +343,7 @@ foreach ($language in $languageArr)
 					--resourceGroup $resourceGroup `
 					--armToken $azAccessToken.accessToken `
 					--azureSubscriptionId $azAccount.id `
-					--appId $dispatchApp.id `
+					--appId $dispatchApp.appId `
 					--endpoint $luisEndpoint `
 					--subscriptionKey $luisAuthoringKey 2>> $logFile
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
I fat-fingered my previous change from my manual attempts to address. So actually fixing the script to use the Dispatch app ID.

### Changes
Change deploy_cognitive_models.ps1 to use the Dispatch app ID when assigning the LUIS runtime resource to ensure it is properly authorized.

### Tests
N/A

### Feature Plan
N/A

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
