### PR TITLE
Update VA/Skill Sample to SDK RC0 and fix LG tests

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/InterruptionTests.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/InterruptionTests.cs
@@ -19,7 +19,7 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow()
                 .Send(string.Empty)
-                .AssertReplyOneOf(allFirstPromptVariations.ToArray())
+                .AssertReplyOneOf(allFirstPromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Help)
                 .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
                 .StartTestAsync();
@@ -32,10 +32,10 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow(includeUserProfile: false)
                 .Send(string.Empty)
-                .AssertReplyOneOf(allNamePromptVariations.ToArray())
+                .AssertReplyOneOf(allNamePromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Help)
                 .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
-                .AssertReplyOneOf(allNamePromptVariations.ToArray())
+                .AssertReplyOneOf(allNamePromptVariations.Cast<string>().ToArray())
                 .StartTestAsync();
         }
 
@@ -48,9 +48,9 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow()
                 .Send(string.Empty)
-                .AssertReplyOneOf(allFirstPromptVariations.ToArray())
+                .AssertReplyOneOf(allFirstPromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Cancel)
-                .AssertReplyOneOf(allResponseVariations.ToArray())
+                .AssertReplyOneOf(allResponseVariations.Cast<string>().ToArray())
                 .StartTestAsync();
         }
 
@@ -61,9 +61,9 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow(includeUserProfile: false)
                 .Send(string.Empty)
-                .AssertReplyOneOf(allNamePromptVariations.ToArray())
+                .AssertReplyOneOf(allNamePromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Repeat)
-                .AssertReplyOneOf(allNamePromptVariations.ToArray())
+                .AssertReplyOneOf(allNamePromptVariations.Cast<string>().ToArray())
                 .StartTestAsync();
         }
     }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/MainDialogTests.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/MainDialogTests.cs
@@ -34,7 +34,7 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow()
                 .Send(string.Empty)
-                .AssertReplyOneOf(allFirstPromptVariations.ToArray())
+                .AssertReplyOneOf(allFirstPromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Help)
                 .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
                 .StartTestAsync();
@@ -47,14 +47,13 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow()
                 .Send(string.Empty)
-                .AssertReplyOneOf(allFirstPromptVariations.ToArray())
+                .AssertReplyOneOf(allFirstPromptVariations.Cast<string>().ToArray())
                 .Send(GeneralUtterances.Escalate)
                 .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
                 .StartTestAsync();
         }
 
         [TestMethod]
-        [Ignore("the LG template 'UnsupportedMessage' has randomly generated response which makes this test unreliable")]
         public async Task Test_Unhandled_Message()
         {
             var allFirstPromptVariations = AllResponsesTemplates.ExpandTemplate("FirstPromptMessage");
@@ -62,9 +61,9 @@ namespace VirtualAssistantSample.Tests
 
             await GetTestFlow()
                 .Send(string.Empty)
-                .AssertReplyOneOf(allFirstPromptVariations.ToArray())
+                .AssertReplyOneOf(allFirstPromptVariations.Cast<string>().ToArray())
                 .Send("Unhandled message")
-                .AssertReplyOneOf(allResponseVariations.ToArray())
+                .AssertReplyOneOf(allResponseVariations.Cast<string>().ToArray())
                 .StartTestAsync();
         }
     }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/OnboardingDialogTests.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests/OnboardingDialogTests.cs
@@ -36,9 +36,9 @@ namespace VirtualAssistantSample.Tests
                     MembersAdded = new List<ChannelAccount>() { new ChannelAccount("user") }
                 })
                 .AssertReply(activity => Assert.AreEqual(1, activity.AsMessageActivity().Attachments.Count))
-                .AssertReplyOneOf(allNamePromptVariations.ToArray())
+                .AssertReplyOneOf(allNamePromptVariations.Cast<string>().ToArray())
                 .Send(testName)
-                .AssertReplyOneOf(allHaveMessageVariations.ToArray())
+                .AssertReplyOneOf(allHaveMessageVariations.Cast<string>().ToArray())
                 .StartTestAsync();
         }
     }

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/VirtualAssistantSample.csproj
@@ -14,13 +14,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.8.1-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.9.0-rc0-preview" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.0" />
   </ItemGroup>
 

--- a/samples/csharp/skill/SkillSample/SkillSample.csproj
+++ b/samples/csharp/skill/SkillSample/SkillSample.csproj
@@ -9,12 +9,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.8.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.9.0-rc0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.9.0-rc0" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update VA and Skill Sample projects to SDK RC0
- Fix broken LG tests which break nightly scratch build after RC0 update

Validated locally to fix issues.