### PR TITLE
[TypeScript][Virtual Assistant & Skill] Improve request capacity updating @types/restify@^8.4.2

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_package.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_package.json
@@ -36,7 +36,7 @@
     },
     "devDependencies": {
         "@types/i18next-node-fs-backend": "^0.0.30",
-        "@types/restify": "^7.2.4",
+        "@types/restify": "^8.4.2",
         "@typescript-eslint/eslint-plugin": "^2.0.0",
         "@typescript-eslint/parser": "^2.0.0",
         "copyfiles": "^2.1.0",

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
@@ -210,7 +210,7 @@ try {
 }
 
 // Create server
-const server: restify.Server = restify.createServer();
+const server: restify.Server = restify.createServer({ maxParamLength: 1000 });
 
 // Enable the Application Insights middleware, which helps correlate all activity
 // based on the incoming request.

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/_package.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/_package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/i18next-node-fs-backend": "^0.0.30",
         "@types/node": "^10.10.1",
-        "@types/restify": "^7.2.4",
+        "@types/restify": "^8.4.2",
         "@typescript-eslint/eslint-plugin": "^2.0.0",
         "@typescript-eslint/parser": "^2.0.0",
         "copyfiles": "^2.1.0",

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/index.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/index.ts
@@ -164,7 +164,7 @@ try {
 }
 
 // Create server
-const server: restify.Server = restify.createServer();
+const server: restify.Server = restify.createServer({ maxParamLength: 1000 });
 
 // Enable the Application Insights middleware, which helps correlate all activity
 // based on the incoming request.

--- a/templates/typescript/samples/sample-assistant/package.json
+++ b/templates/typescript/samples/sample-assistant/package.json
@@ -36,7 +36,7 @@
     },
     "devDependencies": {
         "@types/i18next-node-fs-backend": "^0.0.30",
-        "@types/restify": "^7.2.4",
+        "@types/restify": "^8.4.2",
         "@typescript-eslint/eslint-plugin": "^2.0.0",
         "@typescript-eslint/parser": "^2.0.0",
         "copyfiles": "^2.1.0",

--- a/templates/typescript/samples/sample-assistant/src/index.ts
+++ b/templates/typescript/samples/sample-assistant/src/index.ts
@@ -210,7 +210,7 @@ try {
 }
 
 // Create server
-const server: restify.Server = restify.createServer();
+const server: restify.Server = restify.createServer({ maxParamLength: 1000 });
 
 // Enable the Application Insights middleware, which helps correlate all activity
 // based on the incoming request.

--- a/templates/typescript/samples/sample-skill/package.json
+++ b/templates/typescript/samples/sample-skill/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@types/i18next-node-fs-backend": "^0.0.30",
         "@types/node": "^10.10.1",
-        "@types/restify": "^7.2.4",
+        "@types/restify": "^8.4.2",
         "@typescript-eslint/eslint-plugin": "^2.0.0",
         "@typescript-eslint/parser": "^2.0.0",
         "copyfiles": "^2.1.0",

--- a/templates/typescript/samples/sample-skill/src/index.ts
+++ b/templates/typescript/samples/sample-skill/src/index.ts
@@ -164,7 +164,7 @@ try {
 }
 
 // Create server
-const server: restify.Server = restify.createServer();
+const server: restify.Server = restify.createServer({ maxParamLength: 1000 });
 
 // Enable the Application Insights middleware, which helps correlate all activity
 // based on the incoming request.


### PR DESCRIPTION
Related to #2489

### Purpose
*What is the context of this pull request? Why is it being done?*
The `conversationId` received from Microsoft Teams was too long to be managed by the capacity assigned in the Virtual Assistant and Skill

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update `@types/restify@^8.4.2`
- Improved the capacity of the request using `maxParameLength` of restify to `1000`
- Replicate changes to templates

![image](https://user-images.githubusercontent.com/11904023/81873883-095aef00-9553-11ea-8466-7ffc0f8947bd.png)

![image](https://user-images.githubusercontent.com/11904023/81873887-0bbd4900-9553-11ea-84f8-668b85e0967b.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
