### PR TITLE
Fix Deployment Scripts

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -234,7 +234,7 @@ if ($parametersFile) {
         --parameters name=$name microsoftAppId=$appId microsoftAppPassword="`"$($appPassword)`"" luisAuthoringLocation=$armLuisAuthoringRegion useLuisAuthoring=$createLuisAuthoring `
         --output json `
         2>&1 `
-        | Tee-Object -FilePath $logFile -OutVariable validation
+        | Tee-Object -FilePath $logFile -OutVariable validation `
         | Out-Null
 
     # OutVariable always outputs the contents of the piped output stream as System.Collections.ArrayList, so now let's parse into
@@ -279,7 +279,7 @@ else {
         --parameters name=$name microsoftAppId=$appId microsoftAppPassword="`"$($appPassword)`"" luisAuthoringLocation=$armLuisAuthoringRegion useLuisAuthoring=$createLuisAuthoring `
         --output json `
         2>&1 `
-        | Tee-Object -FilePath $logFile -OutVariable validation
+        | Tee-Object -FilePath $logFile -OutVariable validation `
         | Out-Null
 
     # OutVariable always outputs the contents of the piped output stream as System.Collections.ArrayList, so now let's parse into

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
@@ -234,7 +234,7 @@ if ($parametersFile) {
         --parameters name=$name microsoftAppId=$appId microsoftAppPassword="`"$($appPassword)`"" luisAuthoringLocation=$armLuisAuthoringRegion useLuisAuthoring=$createLuisAuthoring `
         --output json `
         2>&1 `
-        | Tee-Object -FilePath $logFile -OutVariable validation
+        | Tee-Object -FilePath $logFile -OutVariable validation `
         | Out-Null
 
     # OutVariable always outputs the contents of the piped output stream as System.Collections.ArrayList, so now let's parse into
@@ -279,7 +279,7 @@ else {
         --parameters name=$name microsoftAppId=$appId microsoftAppPassword="`"$($appPassword)`"" luisAuthoringLocation=$armLuisAuthoringRegion useLuisAuthoring=$createLuisAuthoring `
         --output json `
         2>&1 `
-        | Tee-Object -FilePath $logFile -OutVariable validation
+        | Tee-Object -FilePath $logFile -OutVariable validation `
         | Out-Null
 
     # OutVariable always outputs the contents of the piped output stream as System.Collections.ArrayList, so now let's parse into


### PR DESCRIPTION

Fix deployment script problem whereby a ` is missing at the end of commands running over multiple lines.

![image](https://user-images.githubusercontent.com/33519520/81965348-d7f42900-960f-11ea-9992-647489516ec3.png)

Tested and validated locally.
