### PR TITLE
[Botskills] Default to DispatchLuis className

### DIFF
--- a/tools/botskills/src/functionality/refreshSkill.ts
+++ b/tools/botskills/src/functionality/refreshSkill.ts
@@ -64,7 +64,8 @@ export class RefreshSkill {
             this.logger.message(`Running Luis Generate for ${ dispatchName }...`);
             const luisGenerateCommandArguments: string [] = [
                 '--in',
-                '--out'
+                '--out',
+                '--className'
             ];
             luisGenerateCommandArguments.forEach((argument: string): void => {
                 const argumentValue: string = executionModelByCulture.get(argument) as string;
@@ -99,7 +100,8 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
         executionModelMap.set('--dataFolder', dataFolder);
         executionModelMap.set('--in', wrapPathWithQuotes(dispatchJsonFilePath));
         executionModelMap.set('--out', wrapPathWithQuotes(this.configuration.lgOutFolder));
-
+        executionModelMap.set('--className', 'DispatchLuis');
+        
         return executionModelMap;
     }
 


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Botskills is generating the `DispatchLuis` file with a different name of the class.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Default to `DispatchLuis` as class name

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
