### PR TITLE
Add PII telemetry instructions

### DIFF
--- a/docs/_docs/solution-accelerators/tutorials/view-analytics/3-open-template.md
+++ b/docs/_docs/solution-accelerators/tutorials/view-analytics/3-open-template.md
@@ -25,3 +25,19 @@ order: 3
 6. Paste your Application Insights AppId
 7. Click Load
 8. *Important*: Select Organizational Account > Sign In > Connect
+
+## Additional Telemetry
+
+By default, a Virtual Assistant or Skill template based project doesn't collect personally identifiable information (e.g. Conversation drill-down and transcripts) which will lead to the respective sections in the PowerBI dashboard to not show information. If you wish to collect this information make the following change to `Startup.cs`
+
+Change this entry:
+
+```csharp
+    services.AddSingleton<TelemetryLoggerMiddleware>();
+```
+
+To the following:
+
+```csharp
+    services.AddSingleton<TelemetryLoggerMiddleware>(s=>new TelemetryLoggerMiddleware(s.GetService<IBotTelemetryClient>(), true));
+```


### PR DESCRIPTION
By default VA/Skills do not collect PII data by default requiring an opt-in. This generates PowerBI data errors if not enabled so highlighting the change if people wish this data to be populated.

Close #3126 