### PR TITLE
[TypeScript][Virtual Assistant] Handle versionChanged event adding onDialogEvent method

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
@@ -22,7 +22,9 @@ import {
     SkillDialog,
     PromptOptions, 
     WaterfallDialog, 
-    BeginSkillDialogOptions} from 'botbuilder-dialogs';
+    BeginSkillDialogOptions,
+    DialogEvent,
+    DialogEvents } from 'botbuilder-dialogs';
 import {
     DialogContextEx,
     ICognitiveModelSet,
@@ -98,6 +100,14 @@ export class MainDialog extends ComponentDialog {
         skillDialogs.forEach((skillDialog: SkillDialog): void => {
             this.addDialog(skillDialog);
         });
+    }
+
+    public async onDialogEvent(dialogContext: DialogContext, event: DialogEvent): Promise<boolean> {
+        if(event.name === DialogEvents.versionChanged) {
+            return true;
+        }
+
+        return await super.onDialogEvent(dialogContext, event);
     }
 
     protected async onBeginDialog(innerDc: DialogContext, options: Object): Promise<DialogTurnResult> {

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
@@ -103,6 +103,8 @@ export class MainDialog extends ComponentDialog {
     }
 
     public async onDialogEvent(dialogContext: DialogContext, event: DialogEvent): Promise<boolean> {
+        // BF SDK now detects state changes in dialogs and surfaces them for confirmation.
+        // Returning true as this is an expected situation due to dynamic dialog construction for QnA multi-locale scenarios.
         if(event.name === DialogEvents.versionChanged) {
             return true;
         }

--- a/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
@@ -22,7 +22,9 @@ import {
     SkillDialog,
     PromptOptions, 
     WaterfallDialog, 
-    BeginSkillDialogOptions} from 'botbuilder-dialogs';
+    BeginSkillDialogOptions,
+    DialogEvent,
+    DialogEvents } from 'botbuilder-dialogs';
 import {
     DialogContextEx,
     ICognitiveModelSet,
@@ -98,6 +100,14 @@ export class MainDialog extends ComponentDialog {
         skillDialogs.forEach((skillDialog: SkillDialog): void => {
             this.addDialog(skillDialog);
         });
+    }
+
+    public async onDialogEvent(dialogContext: DialogContext, event: DialogEvent): Promise<boolean> {
+        if(event.name === DialogEvents.versionChanged) {
+            return true;
+        }
+
+        return await super.onDialogEvent(dialogContext, event);
     }
 
     protected async onBeginDialog(innerDc: DialogContext, options: Object): Promise<DialogTurnResult> {

--- a/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
@@ -103,6 +103,8 @@ export class MainDialog extends ComponentDialog {
     }
 
     public async onDialogEvent(dialogContext: DialogContext, event: DialogEvent): Promise<boolean> {
+        // BF SDK now detects state changes in dialogs and surfaces them for confirmation.
+        // Returning true as this is an expected situation due to dynamic dialog construction for QnA multi-locale scenarios.
         if(event.name === DialogEvents.versionChanged) {
             return true;
         }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
There is an issue of `Version change detected MainDialog dialog` which is raised when there are multiple QnA requests in the TypeScript Virtual Assistant, the issue is related to the `Version Change` error's message.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Handle the `versionChanged` event in the `onDialogEvent` method avoiding the issue of `Version change detected MainDialog dialog`
- Replicate changes to template

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
