### PR TITLE
declaring $appName in UpdateLUIS

### DIFF
--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/luis_functions.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `


### PR DESCRIPTION
update_cognitive_models.ps1 errors out.
Fix to luis_functions.ps1 to declare missing $appName under function UpdateLUIS 

Also reported at https://github.com/microsoft/botframework-solutions/issues/3412

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->

Close #3412

### Purpose
*What is the context of this pull request? Why is it being done?*
To resolve issue at 
Also reported at https://github.com/microsoft/botframework-solutions/issues/3412

### Changes
Updated luis_functions.ps1 to add a missing field, which errors the script when run from update_cognitive_models.ps1

### Tests
These are PS scripts, not sure if there are testscripts built for

### Feature Plan
No dependency

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
