### PR TITLE
Fix to ARM Template to respect useComosDb on database

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/template.json
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/template.json
@@ -216,7 +216,8 @@
         "options": {
           "throughput": "[parameters('cosmosDbDatabaseThroughput')]"
         }
-      }
+      },
+      "condition": "[parameters('useCosmosDb')]"
     },
     {
       "comments": "storage account",

--- a/samples/csharp/skill/SkillSample/Deployment/Resources/template.json
+++ b/samples/csharp/skill/SkillSample/Deployment/Resources/template.json
@@ -166,7 +166,8 @@
         "options": {
           "throughput": "[parameters('cosmosDbDatabaseThroughput')]"
         }
-      }
+      },
+      "condition": "[parameters('useCosmosDb')]"
     },
     {
       "comments": "storage account",


### PR DESCRIPTION
Close #3401 

### Purpose
A recent change to the SDK CosmosDBProvider meant we had to add a new database creation step. This step did not have the conditional variable of useComosDB meaning if you deployed without cosmosdb it would error as this new step was looking for the resource. 

### Changes
Change is to ensure the condition is applied to both CosmosDB steps.