### PR TITLE
Create CODEOWNERS for Android clients

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+samples/android/clients/ @dargilco @olmidy


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Adding users @dargilo and @olmidy as codeowners to the Virtual Assistant Android clients. Their PR approvals will count towards the 2 user minimum requirement.

