### PR TITLE
Fix deploy scripts with PowerShell Core 7.1

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -210,7 +210,7 @@ if (-not $armLuisAuthoringRegion) {
 }
 
 # Get timestamp
-$timestamp = Get-Date -f MMddyyyyHHmmss
+$timestamp = Get-Date -Format MMddyyyyHHmmss
 
 # Create resource group
 Write-Host "> Creating resource group ..." -NoNewline

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
@@ -210,7 +210,7 @@ if (-not $armLuisAuthoringRegion) {
 }
 
 # Get timestamp
-$timestamp = Get-Date -f MMddyyyyHHmmss
+$timestamp = Get-Date -Format MMddyyyyHHmmss
 
 # Create resource group
 Write-Host "> Creating resource group ..." -NoNewline

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/publish.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/publish.ps1
@@ -50,14 +50,13 @@ if (-not $resourceGroup) {
     $resourceGroup = Read-Host "? Bot Resource Group"
 }
 
+# Get path to csproj file
+$projFile = Get-ChildItem $projFolder `
+    | Where-Object {$_.extension -eq ".csproj" } `
+    | Select-Object -First 1
+
 # Check for existing deployment files
 if (-not (Test-Path (Join-Path $projFolder '.deployment'))) {
-
-	# Get path to csproj file
-	$projFile = Get-ChildItem $projFolder `
-		| Where-Object {$_.extension -eq ".csproj" } `
-		| Select-Object -First 1
-
 	# Add needed deployment files for az
 	az bot prepare-deploy --lang Csharp --code-dir $projFolder --proj-file-path $projFile.name --output json | Out-Null
 }
@@ -70,7 +69,7 @@ if (Test-Path $zipPath) {
 
 # Perform dotnet publish step ahead of zipping up
 $publishFolder = $(Join-Path $projFolder 'bin\release\netcoreapp3.0')
-dotnet publish -c release -o $publishFolder -v q > $logFile
+dotnet publish $projFile -c release -o $publishFolder -v q > $logFile
 
 if($?) {
     # Compress source code


### PR DESCRIPTION
Close #3387 

- Powershell Core 7.1 changes behaviour of `Get-Date` deprecating the `-f` shortcut that we were using, updating deploy.ps1 accordingly.
- Replicating earlier publish change from community to Skill template.