### PR TITLE
Declare $appName in UpdateLUIS (again)

### DIFF
--- a/templates/csharp/Skill/Skill/Deployment/Scripts/luis_functions.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `

--- a/templates/csharp/VA/VA/Deployment/Scripts/luis_functions.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/luis_functions.ps1
@@ -57,7 +57,7 @@ function UpdateLUIS ($luFile, $appId, $endpoint, $subscriptionKey, $culture, $ve
 {
    $id = $luFile.BaseName
     $outFile = Join-Path $luFile.DirectoryName "$($id).json"
-
+    $appName = "$($name)$($culture)_$($id)"
 
     Write-Host "> Getting hosted $($culture) $($id) LUIS model settings..." -NoNewline
     $luisApp = bf luis:application:show `


### PR DESCRIPTION
* update_cognitive_models.ps1 errors due to this. Fix by declaring $appName in luis_functions.ps1.
* Fix issue #3439

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose

Fixes issue #3439.

### Changes

No significant changes.

### Tests

No tests required for deployment scripts. IMO this repo should create deployment pipelines that utilize these PowerShell scripts to update bots. Then you'd see when this stuff breaks.

### Feature Plan

Not necessary.

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
