### PR TITLE
[Botskills] Avoid warnings messages as errors

### DIFF
--- a/tools/botskills/src/utils/childProcessUtils.ts
+++ b/tools/botskills/src/utils/childProcessUtils.ts
@@ -32,7 +32,7 @@ export class ChildProcessUtils {
             childProcess.exec(
                 `${ command } ${ args.join(' ') }`,
                 (err: childProcess.ExecException | null, stdout: string, stderr: string): void => {
-                    if (stderr && !stderr.includes('Update available')) {
+                    if (stderr && !stderr.includes('Update available') && !stderr.toLowerCase().includes('warning')) {
                         pReject(stderr);
                     }
                     pResolve(stdout);


### PR DESCRIPTION
Similar to #2021

### Purpose
*What is the context of this pull request? Why is it being done?*
Botskills is treating the external warnings as errors.
`child_process` manages the `stdout` and `stderr` vars, in which `stderr` should contain the external's warning messages.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Validate if `stderr` contains a warning message or not

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
