### PR TITLE
./Deployment/Scripts/deploy.ps1: Replacing -f with -Format

### DIFF
--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
@@ -210,7 +210,7 @@ if (-not $armLuisAuthoringRegion) {
 }
 
 # Get timestamp
-$timestamp = Get-Date -f MMddyyyyHHmmss
+$timestamp = Get-Date -Format MMddyyyyHHmmss
 
 # Create resource group
 Write-Host "> Creating resource group ..." -NoNewline


### PR DESCRIPTION
To fix:
[deploy.ps1 is failing because the parameter name 'f' is ambiguous #3445](https://github.com/microsoft/botframework-solutions/issues/3445)