### PR TITLE
[Botskills] Add --force argument for bf luis convert method

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -208,6 +208,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
                 const argumentValue: string = executionModelByCulture.get(argument) as string;
                 luisConvertCommand.push(...[argument, argumentValue]);
             });
+            luisConvertCommand.push('--force');
             await this.runCommand(luisConvertCommand, `Parsing ${ culture } ${ luisApp } LU file`);
             if (!existsSync(luisFilePath)) {
                 throw new Error(`Path to ${ luisFile } (${ luisFilePath }) leads to a nonexistent file.`);


### PR DESCRIPTION
Close #3435 and close #3480.

### Purpose
*What is the context of this pull request? Why is it being done?*
[botskills@1.0.15](https://www.npmjs.com/package/botskills/v/1.0.15) was generating multiple luis files and was not updating the dispatch file after executing update command.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We added the flag `--force` when converting the `lu` file to a `luis` file in order to replace a existing `luis` file with the same name.
We took into account this [document](https://github.com/microsoft/botframework-cli/tree/master/packages/luis#bf-luisconvert).

![image](https://user-images.githubusercontent.com/37625424/85029699-f12e4f00-b152-11ea-86da-c53f653fb3e5.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
