### PR TITLE
[Botskills] Update disconnect command description

### DIFF
--- a/tools/botskills/src/botskills-disconnect.ts
+++ b/tools/botskills/src/botskills-disconnect.ts
@@ -28,7 +28,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 
 program
     .name('botskills disconnect')
-    .description('Disconnect a specific skill from your assitant bot. The id of the Skill is needed.')
+    .description('Disconnect a specific skill from your assistant bot. The id of the Skill is needed.')
     .option('-i, --skillId <id>', 'Id of the skill to remove from your assistant (case sensitive)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')

--- a/tools/botskills/src/botskills-disconnect.ts
+++ b/tools/botskills/src/botskills-disconnect.ts
@@ -28,7 +28,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 
 program
     .name('botskills disconnect')
-    .description('Disconnect a specific skill from your assitant bot.  Only one of both id or name of the Skill is needed.')
+    .description('Disconnect a specific skill from your assitant bot. The id of the Skill is needed.')
     .option('-i, --skillId <id>', 'Id of the skill to remove from your assistant (case sensitive)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')


### PR DESCRIPTION
Related to #3489

### Purpose
*What is the context of this pull request? Why is it being done?*
The disconnect command of botskills only checks for the id, not the name.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We changed the description to show what Botskills actually need to remove a Skill, that is the `id` of the Skill.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
