### PR TITLE
[Botskills] Fix paths with whitespaces

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -205,8 +205,8 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             // Parse LU file
             const luisConvertCommandArguments: string[] = ['--in', '--culture', '--out', '--name'];
             luisConvertCommandArguments.forEach((argument: string): void => {
-                const argumentValue: string = wrapPathWithQuotes(executionModelByCulture.get(argument) as string);
-                luisConvertCommand.push(...[argument, argumentValue]);
+                const argumentValue: string = executionModelByCulture.get(argument) as string;
+                luisConvertCommand.push(...[argument, wrapPathWithQuotes(argumentValue)]);
             });
             await this.runCommand(luisConvertCommand, `Parsing ${ culture } ${ luisApp } LU file`);
             if (!existsSync(luisFilePath)) {

--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -125,7 +125,7 @@ Make sure your Skill's .lu file's name matches your Skill's manifest id`);
         executionModelMap.set('luisApp', luisApp);
         executionModelMap.set('luisFile', luisFile);
         executionModelMap.set('luisFilePath', luisFilePath);
-        executionModelMap.set('--in', wrapPathWithQuotes(luFilePath));
+        executionModelMap.set('--in', luFilePath);
         executionModelMap.set('--culture', culture);
         executionModelMap.set('--out', luisFilePath);
         executionModelMap.set('--type', 'file');
@@ -205,7 +205,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             // Parse LU file
             const luisConvertCommandArguments: string[] = ['--in', '--culture', '--out', '--name'];
             luisConvertCommandArguments.forEach((argument: string): void => {
-                const argumentValue: string = executionModelByCulture.get(argument) as string;
+                const argumentValue: string = wrapPathWithQuotes(executionModelByCulture.get(argument) as string);
                 luisConvertCommand.push(...[argument, argumentValue]);
             });
             await this.runCommand(luisConvertCommand, `Parsing ${ culture } ${ luisApp } LU file`);

--- a/tools/botskills/src/functionality/refreshSkill.ts
+++ b/tools/botskills/src/functionality/refreshSkill.ts
@@ -69,7 +69,7 @@ export class RefreshSkill {
             ];
             luisGenerateCommandArguments.forEach((argument: string): void => {
                 const argumentValue: string = executionModelByCulture.get(argument) as string;
-                luisGenerateCommand.push(...[argument, argumentValue]);
+                luisGenerateCommand.push(...[argument, wrapPathWithQuotes(argumentValue)]);
             });
 
             // Force the bf luis:generate to overwrite the output file if it already exists
@@ -98,8 +98,8 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
         executionModelMap.set('dispatchJsonFilePath', dispatchJsonFilePath);
         executionModelMap.set('--dispatch', dispatchFilePath);
         executionModelMap.set('--dataFolder', dataFolder);
-        executionModelMap.set('--in', wrapPathWithQuotes(dispatchJsonFilePath));
-        executionModelMap.set('--out', wrapPathWithQuotes(this.configuration.lgOutFolder));
+        executionModelMap.set('--in', dispatchJsonFilePath);
+        executionModelMap.set('--out', this.configuration.lgOutFolder);
         executionModelMap.set('--className', 'DispatchLuis');
         
         return executionModelMap;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Fixes #3545 

Botskills was failing when a path had whitespaces on it.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
All the `bf convert` arguments are being wrapped in quotes.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
The error is produced by an external tool as it is related to a `bf convert` error with a wrong path. That method is mocked so always it's running successfully.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

