### PR TITLE
[BotSkills] Sanitize appsettings skills properties to be case insensitive for list command

### DIFF
--- a/tools/botskills/src/functionality/listSkill.ts
+++ b/tools/botskills/src/functionality/listSkill.ts
@@ -6,6 +6,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { ConsoleLogger, ILogger} from '../logger';
 import { IListConfiguration, IAppSetting, ISkill } from '../models';
+import { sanitizeAppSettingsProperties } from '../utils';
 
 export class ListSkill {
     public logger: ILogger;
@@ -21,9 +22,8 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
 
                 return false;
             }
-            // Take VA Skills configurations
-            const text = readFileSync(configuration.appSettingsFile, 'UTF8').replace('BotFrameworkSkills', 'botFrameworkSkills').replace('Id', 'id');
-            const assistantAppSettingsFile: IAppSetting = JSON.parse(text);
+            // Take VA Skills configurations            
+            const assistantAppSettingsFile: IAppSetting = JSON.parse(sanitizeAppSettingsProperties(configuration.appSettingsFile));
 
             if (assistantAppSettingsFile.botFrameworkSkills === undefined) {
                 this.logger.message('There are no Skills connected to the assistant.');

--- a/tools/botskills/src/functionality/listSkill.ts
+++ b/tools/botskills/src/functionality/listSkill.ts
@@ -22,7 +22,9 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
                 return false;
             }
             // Take VA Skills configurations
-            const assistantAppSettingsFile: IAppSetting = JSON.parse(readFileSync(configuration.appSettingsFile, 'UTF8'));
+            const text = readFileSync(configuration.appSettingsFile, 'UTF8').replace('BotFrameworkSkills', 'botFrameworkSkills').replace('Id', 'id');
+            const assistantAppSettingsFile: IAppSetting = JSON.parse(text);
+
             if (assistantAppSettingsFile.botFrameworkSkills === undefined) {
                 this.logger.message('There are no Skills connected to the assistant.');
 

--- a/tools/botskills/src/utils/index.ts
+++ b/tools/botskills/src/utils/index.ts
@@ -7,6 +7,6 @@ export { AuthenticationUtils } from './authenticationUtils';
 export { isAzPreviewMessage, isCloudGovernment, isValidAzVersion } from './azUtils';
 export { ChildProcessUtils } from './childProcessUtils';
 export { getDispatchNames } from './dispatchUtils';
-export { sanitizePath, wrapPathWithQuotes } from './sanitizationUtils';
+export { sanitizePath, sanitizeAppSettingsProperties, wrapPathWithQuotes } from './sanitizationUtils';
 export { isValidCultures, validatePairOfArgs, manifestV1Validation, manifestV2Validation, libraries, validateLibrary } from './validationUtils';
 export { ManifestUtils } from './manifestUtils';

--- a/tools/botskills/src/utils/sanitizationUtils.ts
+++ b/tools/botskills/src/utils/sanitizationUtils.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { readFileSync } from 'fs';
+
 const regexTrailingBackslash = /.*?(\\)+$/;
 
 /**
@@ -18,10 +20,24 @@ export function sanitizePath(path: string): string {
 }
 
 /**
+ * @param appsettings Path to the appsettings file.
+ * @returns Returns an appsettings which is sanitized
+ */
+export function sanitizeAppSettingsProperties(appsettings: string): string {
+    return readFileSync(appsettings, 'UTF8')
+        .replace(new RegExp("\\bBotFrameworkSkills\\b", "gi"), 'botFrameworkSkills')
+        .replace(new RegExp("\\bAppId\\b", "gi"), 'appId')
+        .replace(new RegExp("\\bId\\b", "gi"), 'id')
+        .replace(new RegExp("\\bSkillEndpoint\\b", "gi"), 'skillEndpoint')
+        .replace(new RegExp("\\bName\\b", "gi"), 'name')
+        .replace(new RegExp("\\bDescription\\b", "gi"), 'description')
+        .replace(new RegExp("\\bSkillHostEndpoint\\b", "gi"), 'skillHostEndpoint');    
+}
+
+/**
  * @param path Path to add quotes around in case it has spaces.
  * @returns Returns a path with quotes
  */
 export function wrapPathWithQuotes(path: string): string {
     return `"${ path }"`;
 }
-

--- a/tools/botskills/src/utils/sanitizationUtils.ts
+++ b/tools/botskills/src/utils/sanitizationUtils.ts
@@ -25,13 +25,13 @@ export function sanitizePath(path: string): string {
  */
 export function sanitizeAppSettingsProperties(appsettings: string): string {
     return readFileSync(appsettings, 'UTF8')
-        .replace(new RegExp("\\bBotFrameworkSkills\\b", "gi"), 'botFrameworkSkills')
-        .replace(new RegExp("\\bAppId\\b", "gi"), 'appId')
-        .replace(new RegExp("\\bId\\b", "gi"), 'id')
-        .replace(new RegExp("\\bSkillEndpoint\\b", "gi"), 'skillEndpoint')
-        .replace(new RegExp("\\bName\\b", "gi"), 'name')
-        .replace(new RegExp("\\bDescription\\b", "gi"), 'description')
-        .replace(new RegExp("\\bSkillHostEndpoint\\b", "gi"), 'skillHostEndpoint');    
+        .replace(new RegExp('\\bBotFrameworkSkills\\b', 'gi'), 'botFrameworkSkills')
+        .replace(new RegExp('\\bAppId\\b', 'gi'), 'appId')
+        .replace(new RegExp('\\bId\\b', 'gi'), 'id')
+        .replace(new RegExp('\\bSkillEndpoint\\b', 'gi'), 'skillEndpoint')
+        .replace(new RegExp('\\bName\\b', 'gi'), 'name')
+        .replace(new RegExp('\\bDescription\\b', 'gi'), 'description')
+        .replace(new RegExp('\\bSkillHostEndpoint\\b', 'gi'), 'skillHostEndpoint');    
 }
 
 /**


### PR DESCRIPTION
Fix #3588

### Purpose
*What is the context of this pull request? Why is it being done?*
BotSkills _list_ command would erroneously list no connected bots when applied to bots connected with BotSkills versions prior to 1.0.16, due to a casing change in properties name.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Functionality of the _list_ command was modified to accept properties in both upper and lower camel case format as not to break compatibility with older versions.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
