### PR TITLE
Update DI scope for DefaultAdapter from Transient to Singleton

### DIFF
--- a/samples/csharp/skill/SkillSample/Startup.cs
+++ b/samples/csharp/skill/SkillSample/Startup.cs
@@ -131,7 +131,7 @@ namespace SkillSample
             services.AddTransient<MainDialog>();
 
             // Configure adapters
-            services.AddTransient<IBotFrameworkHttpAdapter, DefaultAdapter>();
+            services.AddSingleton<IBotFrameworkHttpAdapter, DefaultAdapter>();
 
             // Configure bot
             services.AddTransient<IBot, DefaultActivityHandler<MainDialog>>();

--- a/templates/csharp/Skill/Skill/Startup.cs
+++ b/templates/csharp/Skill/Skill/Startup.cs
@@ -122,7 +122,7 @@ namespace $safeprojectname$
             services.AddTransient<MainDialog>();
 
             // Configure adapters
-            services.AddTransient<IBotFrameworkHttpAdapter, DefaultAdapter>();
+            services.AddSingleton<IBotFrameworkHttpAdapter, DefaultAdapter>();
 
             // Configure bot
             services.AddTransient<IBot, DefaultActivityHandler<MainDialog>>();


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Fixes #3627.

The underlying implementation for DefaultAdapter (BotFrameworkAdapter) contains a credential cache which is used to refresh credentials approximately every 30 minutes. However, DefaultAdapter is added to DI services using the Transient scope, which means that the adapter is instantiated on each request, which forces acquisition of the credentials and defeats the point of the cache. This change modifies the scope of DefaultAdapter to Singleton so it is appropriately reused across all requests.

### Changes
- Update templates/csharp/Skill/Skill/Startup.cs to change DI scope of DefaultAdapter from Transient to Singleton.
- Update samples/csharp/skill/SkillSample/Startup.cs to change DI scope of DefaultAdapter from Transient to Singleton.

### Tests
N/A

### Feature Plan
N/A

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
