### PR TITLE
[TypeScript] Remove strict check in tsconfig files

### DIFF
--- a/sdk/typescript/libraries/bot-solutions/tsconfig.json
+++ b/sdk/typescript/libraries/bot-solutions/tsconfig.json
@@ -21,7 +21,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/tsconfig.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/tsconfig.json
@@ -21,7 +21,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/tsconfig.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/tsconfig.json
@@ -21,7 +21,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */

--- a/templates/typescript/samples/sample-assistant/tsconfig.json
+++ b/templates/typescript/samples/sample-assistant/tsconfig.json
@@ -21,7 +21,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */

--- a/templates/typescript/samples/sample-skill/tsconfig.json
+++ b/templates/typescript/samples/sample-skill/tsconfig.json
@@ -21,7 +21,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                        /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */


### PR DESCRIPTION
Fixes #3630 
Fixes #3635

### Purpose
*What is the context of this pull request? Why is it being done?*
With the last version of the SDK 4.10.0, the compilation of the TypeScript solutions raises an issue related to types missing for [@microsoft/recognizers-text-data-types-timex-expression](https://www.npmjs.com/package/@microsoft/recognizers-text-data-types-timex-expression) library

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Remove the `strict` check in `tsconfig` files for Virtual Assistant (Sample & Template), Skill (Sample & Template) and Bot-Solutions

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes, it was tested manually 

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
