### PR TITLE
remove checking on activity.from.role

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleware.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Proactive/ProactiveStateMiddleware.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Solutions.Proactive
         {
             var activity = turnContext.Activity;
 
-            if (!string.IsNullOrEmpty(activity.From.Role) && activity.From.Role.Equals("user", StringComparison.InvariantCultureIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(activity.From?.Id))
             {
                 var proactiveState = await _proactiveStateAccessor.GetAsync(turnContext, () => new ProactiveModel()).ConfigureAwait(false);
                 ProactiveModel.ProactiveData data;

--- a/sdk/csharp/tests/microsoft.bot.solutions.tests/Microsoft.Bot.Solutions.Tests.csproj
+++ b/sdk/csharp/tests/microsoft.bot.solutions.tests/Microsoft.Bot.Solutions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

For ProactiveMiddleware, we do not need to check if an activity is from user per the latest botbuilder SDK.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Remove checking on activity.from.role and only check activity.from.id

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
