### PR TITLE
[C#][Virtual Assistant] Add Unhandled Message Functional Test

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.FunctionalTests/DirectLineClientTests.cs
@@ -50,6 +50,14 @@ namespace VirtualAssistantSample.FunctionalTests
             await Assert_QnA_ChitChat_Responses(fromUser);
         }
 
+        [TestMethod]
+        public async Task Test_Unhandled_Message()
+        {
+            string fromUser = Guid.NewGuid().ToString();
+
+            await Assert_Unsupported_Message(fromUser);
+        }
+
         /// <summary>
         /// Assert that a new user is greeted with the onboarding prompt.
         /// </summary>
@@ -119,6 +127,27 @@ namespace VirtualAssistantSample.FunctionalTests
 
             responses = await SendActivityAsync(conversation, CreateMessageActivity(fromUser, testFaqMessage));
             Assert.AreEqual(responses[3].Text, "Raise an issue on the [GitHub repo](https://aka.ms/virtualassistant)");
+        }
+
+        /// <summary>
+        /// Assert that a message was not understood.
+        /// </summary>
+        /// <param name="fromUser">User identifier used for the conversation and activities.</param>
+        /// <returns>Task.</returns>
+        private async Task Assert_Unsupported_Message(string fromUser)
+        {
+            var conversation = await StartBotConversationAsync();
+
+            await SendActivityAsync(conversation, CreateStartConversationEvent(fromUser));
+            await SendActivityAsync(conversation, CreateMessageActivity(fromUser, TestName));
+
+            var allUnsupportedPromptVariations = AllResponsesTemplates.ExpandTemplate("UnsupportedMessage");
+            var responses = await SendActivityAsync(conversation, CreateMessageActivity(fromUser, "foo"));
+
+            Assert.AreEqual(5, responses.Count);
+            Assert.AreEqual(ActivityTypes.Message, responses[0].GetActivityType());
+            Assert.AreEqual(1, responses[0].Attachments.Count);
+            CollectionAssert.Contains(allUnsupportedPromptVariations as ICollection, responses[4].Text);
         }
 
         /// <summary>


### PR DESCRIPTION
Related to #3290

### Purpose
*What is the context of this pull request? Why is it being done?*
The functional tests need to cover the entire functionality of the Virtual Assistant. We implemented a new test to validate the handling of unrecognized messages for the C# Virtual Assistant Sample.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Add a single test called `Test_Unhandled_Message` that sends the message `foo` after the greeting with the user

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
It adds the test `Test_Unhandled_Message`.
![image](https://user-images.githubusercontent.com/39467613/91353919-4ecdc000-e7c2-11ea-881f-2f299b5e3c27.png)



### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
