### PR TITLE
[TypeScript][Skill] Fix cognitivemodel mocks values

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/src/copier.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/src/copier.js
@@ -88,10 +88,6 @@ class Copier {
       join(`src`, `manifest`, `_manifest-1.1.json`),
       join(`src`, `manifest`, `manifest-1.1.json`)
     );
-    templateFiles.set(
-      join(`test`, `mocks`, `resources`, `_cognitiveModels.json`),
-      join(`test`, `mocks`, `resources`, `cognitiveModels.json`)
-    );
     selectedLanguages.forEach(language => {
       templateFiles.set(
         join(`deployment`, `resources`, `LU`, language, `_skill.lu`),

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mocks/resources/cognitiveModels.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mocks/resources/cognitiveModels.json
@@ -22,13 +22,13 @@
           "name": "general"
         },
         {
-          "id": "<%=skillNameCamelCase%>",
+          "id": "sampleSkill",
           "authoringRegion": "westus",
           "appId": "00000002-0000-0000-0000-000000000001",
           "authoringKey": "<--MOCK-VALUE-->",
           "version": "0.1",
           "subscriptionKey": "<--MOCK-VALUE-->",
-          "name": "<%=skillNameCamelCase%>",
+          "name": "sampleSkill",
           "region": "westus"
         }
       ]

--- a/templates/typescript/generator-bot-virtualassistant/test/generator-bot-virtualassistant.skill.test.suite.js
+++ b/templates/typescript/generator-bot-virtualassistant/test/generator-bot-virtualassistant.skill.test.suite.js
@@ -27,7 +27,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
     var manifest1_1;
     const manifestPath1_0 = join(`src`, `manifest`, `manifest-1.0.json`);
     const manifestPath1_1 = join(`src`, `manifest`, `manifest-1.1.json`);
-    const testCognitiveModelsPath = join(`test`, `mocks`, `resources`, `cognitiveModels.json`);
 
     const templatesFiles = [
         `package.json`,
@@ -36,7 +35,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
         `.nycrc`,
         manifestPath1_0,
         manifestPath1_1,
-        testCognitiveModelsPath
     ];
 
     const commonDirectories = [
@@ -196,24 +194,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
 
             it(`a description property with given description`, function(done) {
                 assert.strictEqual(packageJSON.description, skillDesc);
-                done();
-            });
-        });
-        
-        describe(`and have in the cognitiveModels file`, function() {
-            it(`an id property with the given name`, function(done) {
-                assert.fileContent(
-                  join(skillGenerationPath, skillName, testCognitiveModelsPath),
-                  `"id": "${skillNameCamelCase}",`
-                );
-                done();
-            });
-
-            it(`a name property with the given name`, function(done) {
-                assert.fileContent(
-                  join(skillGenerationPath, skillName, testCognitiveModelsPath),
-                  `"name": "${skillNameCamelCase}",`
-                );
                 done();
             });
         });


### PR DESCRIPTION
Fix #3529

### Purpose
*What is the context of this pull request? Why is it being done?*
The generator was creating skills with failing tests when the name of the skill was different to `sample-skill`.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Remove the placeholder in the cognitivemodels.json test file for the generation of the typescript skill
- Remove cognitivemodels test file validation in the generator 

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Those tests were removed as there is no placeholder to validate.

_Generator's tests_
![image](https://user-images.githubusercontent.com/11904023/91449419-74ee7100-e851-11ea-9b28-f508462ee3c0.png)

_TypeScript Skill tests_
![image](https://user-images.githubusercontent.com/11904023/91449424-7750cb00-e851-11ea-8008-2fe8e817bc5a.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist
\-

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
