### PR TITLE
[C# & TypeScript][VA & Skill] Clarify luis section after deploying bots

### DIFF
--- a/docs/_docs/virtual-assistant/handbook/deployment-scripts.md
+++ b/docs/_docs/virtual-assistant/handbook/deployment-scripts.md
@@ -156,13 +156,13 @@ Any of the following parameters in the ARM template can be overridden with your 
 | contentModeratorName | [name]-cm-[suffix] |
 | contentModeratorSku | S0 |
 | contentModeratorLocation | Resource group location |
-| luisRuntimeName | [name]-luisruntime-[suffix] |
-| luisRuntimeSku | S0 |
-| luisServiceLocation | Resource group location |
+| luisPredictionName | [name]-luisprediction-[suffix] |
+| luisPredictionSku | S0 |
+| luisPredictionLocation | Resource group location |
 | useLuisAuthoring | True |
 | luisAuthoringName | [name]-luisauthoring-[suffix] |
-| luisAuthroingSku | F0 |
-| luisAuthroingLocation | N/A |
+| luisAuthoringSku | F0 |
+| luisAuthoringLocation | N/A |
 | qnaMakerServiceName | [name]-qna-[suffix] |
 | qnaMakerServiceSku | S0 |
 | qnaMakerServiceLocation | Resource group location |

--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Resources/template.json
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -328,15 +328,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -358,7 +358,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -488,12 +488,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -353,7 +353,7 @@ if ($outputs)
 
     if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
@@ -362,10 +362,10 @@ if ($outputs)
 
     # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 
     # Publish bot

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Resources/template.json
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -328,15 +328,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -358,7 +358,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -488,12 +488,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -251,19 +251,19 @@ if ($outputs)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
     
     Write-Host "Done." -ForegroundColor Green
 
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
-	# Deploy cognitive models
+    # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($outputs.luis.value.endpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($outputs.luis.value.endpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 	
     # Publish bot

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/template.json
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -328,15 +328,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -358,7 +358,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -488,12 +488,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/deploy.ps1
@@ -353,7 +353,7 @@ if ($outputs)
 
     if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
@@ -362,10 +362,10 @@ if ($outputs)
 
     # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 
     # Publish bot

--- a/samples/csharp/skill/SkillSample/Deployment/Resources/parameters.template.json
+++ b/samples/csharp/skill/SkillSample/Deployment/Resources/parameters.template.json
@@ -17,7 +17,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     }
   }

--- a/samples/csharp/skill/SkillSample/Deployment/Resources/template.json
+++ b/samples/csharp/skill/SkillSample/Deployment/Resources/template.json
@@ -75,15 +75,15 @@
       "type": "string",
       "defaultValue": "S1"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -263,15 +263,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -293,7 +293,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     }
@@ -332,12 +332,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     }
   }

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/deploy.ps1
@@ -353,7 +353,7 @@ if ($outputs)
 
     if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
@@ -362,10 +362,10 @@ if ($outputs)
 
     # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 
     # Publish bot

--- a/templates/csharp/Skill/Skill/Deployment/Resources/parameters.template.json
+++ b/templates/csharp/Skill/Skill/Deployment/Resources/parameters.template.json
@@ -17,7 +17,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     }
   }

--- a/templates/csharp/Skill/Skill/Deployment/Resources/template.json
+++ b/templates/csharp/Skill/Skill/Deployment/Resources/template.json
@@ -75,15 +75,15 @@
       "type": "string",
       "defaultValue": "S1"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -263,15 +263,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -293,7 +293,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     }
@@ -332,12 +332,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     }
   }

--- a/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/deploy.ps1
@@ -353,7 +353,7 @@ if ($outputs)
 
     if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
@@ -362,10 +362,10 @@ if ($outputs)
 
     # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 
     # Publish bot

--- a/templates/csharp/VA/VA/Deployment/Resources/parameters.template.json
+++ b/templates/csharp/VA/VA/Deployment/Resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/templates/csharp/VA/VA/Deployment/Resources/template.json
+++ b/templates/csharp/VA/VA/Deployment/Resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -328,15 +328,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -358,7 +358,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -488,12 +488,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/deploy.ps1
@@ -353,7 +353,7 @@ if ($outputs)
 
     if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
@@ -362,10 +362,10 @@ if ($outputs)
 
     # Deploy cognitive models
     if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($projDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 
     # Publish bot

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/parameters.template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -340,15 +340,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -370,7 +370,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -500,12 +500,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/scripts/deploy.ps1
@@ -254,20 +254,20 @@ if ($outputs)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
     
     Write-Host "Done." -ForegroundColor Green
 
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
-	# Deploy cognitive models
-	if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+    # Deploy cognitive models
+    if ($useGov) {
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
-	}
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+    }
 	
     # Publish bot
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/parameters.template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/parameters.template.json
@@ -17,7 +17,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     }
   }

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/template.json
@@ -75,15 +75,15 @@
       "type": "string",
       "defaultValue": "S1"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -275,15 +275,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -305,7 +305,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     }
@@ -344,12 +344,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     }
   }

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/scripts/deploy.ps1
@@ -254,19 +254,19 @@ if ($outputs)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
-	# Deploy cognitive models
+    # Deploy cognitive models
     if ($useGov) {
-		Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 	
     # Publish bot

--- a/templates/typescript/samples/sample-assistant/deployment/resources/parameters.template.json
+++ b/templates/typescript/samples/sample-assistant/deployment/resources/parameters.template.json
@@ -20,7 +20,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     },
     "qnaMakerServiceLocation": {

--- a/templates/typescript/samples/sample-assistant/deployment/resources/template.json
+++ b/templates/typescript/samples/sample-assistant/deployment/resources/template.json
@@ -91,15 +91,15 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -340,15 +340,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -370,7 +370,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     },
@@ -500,12 +500,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     },
     "qnaMaker": {

--- a/templates/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
+++ b/templates/typescript/samples/sample-assistant/deployment/scripts/deploy.ps1
@@ -254,20 +254,20 @@ if ($outputs)
 
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
     
     Write-Host "Done." -ForegroundColor Green
 
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
-	# Deploy cognitive models
-	if ($useGov) {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+    # Deploy cognitive models
+    if ($useGov) {
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
-	}
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+    }
 	
     # Publish bot
 	Invoke-Expression "& '$(Join-Path $PSScriptRoot 'publish.ps1')' -name $($outputs.botWebAppName.value) -resourceGroup $($resourceGroup) -projFolder '$($projDir)'"

--- a/templates/typescript/samples/sample-skill/deployment/resources/parameters.template.json
+++ b/templates/typescript/samples/sample-skill/deployment/resources/parameters.template.json
@@ -17,7 +17,7 @@
     "botServiceSku": {
       "value": "F0"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "value": "F0"
     }
   }

--- a/templates/typescript/samples/sample-skill/deployment/resources/template.json
+++ b/templates/typescript/samples/sample-skill/deployment/resources/template.json
@@ -75,15 +75,15 @@
       "type": "string",
       "defaultValue": "S1"
     },
-    "luisRuntimeName": {
+    "luisPredictionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('name'), '-luisruntime-', parameters('suffix'))]"
+      "defaultValue": "[concat(parameters('name'), '-luisprediction-', parameters('suffix'))]"
     },
-    "luisRuntimeSku": {
+    "luisPredictionSku": {
       "type": "string",
       "defaultValue": "S0"
     },
-    "luisRuntimeLocation": {
+    "luisPredictionLocation": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
@@ -275,15 +275,15 @@
     },
     {
       "apiVersion": "2016-02-01-preview",
-      "name": "[parameters('luisRuntimeName')]",
-      "location": "[parameters('luisRuntimeLocation')]",
+      "name": "[parameters('luisPredictionName')]",
+      "location": "[parameters('luisPredictionLocation')]",
       "type": "Microsoft.CognitiveServices/accounts",
       "kind": "LUIS",
       "sku": {
-        "name": "[parameters('luisRuntimeSku')]"
+        "name": "[parameters('luisPredictionSku')]"
       },
       "properties": {
-        "customSubDomainName": "[parameters('luisRuntimeName')]"
+        "customSubDomainName": "[parameters('luisPredictionName')]"
       },
       "tags": {
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
@@ -305,7 +305,7 @@
         "[parameters('resourceTagName')]": "[parameters('resourceTagValue')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
+        "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
     }
@@ -344,12 +344,12 @@
     "luis": {
       "type": "object",
       "value": {
-        "accountName": "[parameters('luisRuntimeName')]",
-        "region": "[parameters('luisRuntimeLocation')]",
-        "key": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName')),'2016-02-01-preview').key1]",
+        "predictionAccountName": "[parameters('luisPredictionName')]",
+        "predictionRegion": "[parameters('luisPredictionLocation')]",
+        "predictionKey": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisPredictionName')),'2016-02-01-preview').key1]",
         "authoringRegion": "[parameters('luisAuthoringLocation')]",
         "authoringKey": "[if(parameters('useLuisAuthoring'), listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').key1, '')]",
-        "endpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
+        "authoringEndpoint": "[if(parameters('useLuisAuthoring'), reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('luisAuthoringName')),'2016-02-01-preview').endpoint, '')]"
       }
     }
   }

--- a/templates/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
+++ b/templates/typescript/samples/sample-skill/deployment/scripts/deploy.ps1
@@ -254,19 +254,19 @@ if ($outputs)
 	
 	if ($outputs.qnaMaker.value.key) { $qnaSubscriptionKey = $outputs.qnaMaker.value.key }
     if (-not $luisAuthoringKey) { $luisAuthoringKey = $outputs.luis.value.authoringKey }
-    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.endpoint }
+    if (-not $luisEndpoint) { $luisEndpoint = $outputs.luis.value.authoringEndpoint }
 
     Write-Host "Done." -ForegroundColor Green
 
 	# Delay to let QnA Maker finish setting up
 	Start-Sleep -s 30
 
-	# Deploy cognitive models
+    # Deploy cognitive models
     if ($useGov) {
-		Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)' -useGov"
     }
     else {
-        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.accountName)' -luisAccountRegion '$($outputs.luis.value.region)' -luisSubscriptionKey '$($outputs.luis.value.key)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
+        Invoke-Expression "& '$(Join-Path $PSScriptRoot 'deploy_cognitive_models.ps1')' -name $($name) -resourceGroup $($resourceGroup) -outFolder '$($srcDir)' -languages '$($languages)' -luisAuthoringRegion '$($luisAuthoringRegion)' -luisAuthoringKey '$($luisAuthoringKey)' -luisAccountName '$($outputs.luis.value.predictionAccountName)' -luisAccountRegion '$($outputs.luis.value.predictionRegion)' -luisSubscriptionKey '$($outputs.luis.value.predictionKey)' -luisEndpoint '$($luisEndpoint)' -qnaSubscriptionKey '$($qnaSubscriptionKey)' -qnaEndpoint '$($qnaEndpoint)'"
     }
 	
     # Publish bot


### PR DESCRIPTION
Fix #3659

### Purpose
*What is the context of this pull request? Why is it being done?*
The `luis` section of the `appsettings.json` is not clear and generates confusion as we have two LUIS resources deployed (`authoring` and `prediction`).

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Update `luis` section after deployment adding a prefix with `prediction` or `authoring`
- Rename internal `luisRuntime` variables to `luisPrediction`
- Update the documentation with these changes
- Replicate the changes to all the bots

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
We confirmed the test execution of each updated bot. Also, we tested the deployment manually and confirmed the results with the communication of each bot.

_LUIS Prediction resource deployed after applying the changes_
![image](https://user-images.githubusercontent.com/11904023/95909024-374b9600-0d74-11eb-9ed5-9e2e5c82859b.png)

_LUIS section of the appsetting.json populated after applying the changes_
![image](https://user-images.githubusercontent.com/11904023/95909041-3a468680-0d74-11eb-9ba9-d36dc339db70.png)

_Communication of a C# Virtual Assistant after applying the changes_
![image](https://user-images.githubusercontent.com/11904023/95909017-34e93c00-0d74-11eb-9ada-16a903945ad3.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [X] I have updated related documentation
