### PR TITLE
[TypeScript][Virtual Assistant & Skill] Fix duplicated messages when communicating through DirectLine

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/test/localization.test.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/test/localization.test.js
@@ -20,8 +20,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "es-es"
                 })
                 .assertReply(function (activity, description) {
@@ -57,8 +65,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "de-de"
                 })
                 .assertReply(function (activity, description) {
@@ -94,8 +110,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "fr-fr"
                 })
                 .assertReply(function (activity, description) {
@@ -131,8 +155,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "it-it"
                 })
                 .assertReply(function (activity, description) {
@@ -168,8 +200,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "en-us"
                 })
                 .assertReply(function (activity, description) {
@@ -205,8 +245,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "zh-cn"
                 })
                 .assertReply(function (activity, description) {
@@ -241,15 +289,23 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "en-uk"
                 })
                 .assertReply(function (activity, description) {
                     assert.strictEqual(1, activity.attachments.length);
                 });
 
-                 return testNock.resolveWithMocks('localization_response_en-uk', done, flow);
+                return testNock.resolveWithMocks('localization_response_en-uk', done, flow);
             });
         });
     });

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/test/mainDialog.test.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/test/mainDialog.test.js
@@ -18,8 +18,17 @@ describe("Main Dialog", function () {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
+                    locale: "en-us"
                 })
 				.assertReply(function (activity, description) {
 					assert.strictEqual(1, activity.attachments.length);

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/bots/defaultActivityHandler.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/bots/defaultActivityHandler.ts
@@ -8,6 +8,7 @@ import {
     ActivityHandler,
     ActivityTypes,
     BotState,
+    ChannelAccount,
     Channels,
     StatePropertyAccessor, 
     TurnContext } from 'botbuilder';
@@ -42,8 +43,15 @@ export class DefaultActivityHandler<T extends Dialog> extends ActivityHandler {
     }
 
     protected async membersAdded(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {
-        await turnContext.sendActivity(this.templateManager.generateActivityForLocale('IntroMessage'));
-        await DialogEx.run(this.dialog, turnContext, this.dialogStateAccessor);
+        const membersAdded: ChannelAccount[] = turnContext.activity.membersAdded;
+        for (const member of membersAdded) {
+            if (member.id !== turnContext.activity.recipient.id) {
+                await turnContext.sendActivity(this.templateManager.generateActivityForLocale('IntroMessage'));
+                await DialogEx.run(this.dialog, turnContext, this.dialogStateAccessor);
+            }
+        }
+        // By calling next() you ensure that the next BotHandler is run.
+        await next();
     }
 
     protected onMessageActivity(turnContext: TurnContext): Promise<void> {

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/localization.test.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/localization.test.js
@@ -21,6 +21,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -45,6 +49,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -69,6 +77,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -93,6 +105,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -117,6 +133,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -141,6 +161,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -165,6 +189,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mainDialog.test.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mainDialog.test.js
@@ -22,6 +22,10 @@ describe("main dialog", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",

--- a/templates/typescript/samples/sample-assistant/test/localization.test.js
+++ b/templates/typescript/samples/sample-assistant/test/localization.test.js
@@ -20,8 +20,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "es-es"
                 })
                 .assertReply(function (activity, description) {
@@ -57,8 +65,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "de-de"
                 })
                 .assertReply(function (activity, description) {
@@ -94,8 +110,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "fr-fr"
                 })
                 .assertReply(function (activity, description) {
@@ -131,8 +155,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "it-it"
                 })
                 .assertReply(function (activity, description) {
@@ -168,8 +200,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "en-us"
                 })
                 .assertReply(function (activity, description) {
@@ -205,8 +245,16 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "zh-cn"
                 })
                 .assertReply(function (activity, description) {
@@ -241,15 +289,23 @@ describe("Localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
                     locale: "en-uk"
                 })
                 .assertReply(function (activity, description) {
                     assert.strictEqual(1, activity.attachments.length);
                 });
 
-                 return testNock.resolveWithMocks('localization_response_en-uk', done, flow);
+                return testNock.resolveWithMocks('localization_response_en-uk', done, flow);
             });
         });
     });

--- a/templates/typescript/samples/sample-assistant/test/mainDialog.test.js
+++ b/templates/typescript/samples/sample-assistant/test/mainDialog.test.js
@@ -18,8 +18,17 @@ describe("Main Dialog", function () {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
+                    channelId: "emulator",
+                    recipient: {
+                        id: "1"
+                    },
+                    locale: "en-us"
                 })
 				.assertReply(function (activity, description) {
 					assert.strictEqual(1, activity.attachments.length);

--- a/templates/typescript/samples/sample-skill/src/bots/defaultActivityHandler.ts
+++ b/templates/typescript/samples/sample-skill/src/bots/defaultActivityHandler.ts
@@ -8,6 +8,7 @@ import {
     ActivityHandler,
     ActivityTypes,
     BotState,
+    ChannelAccount,
     Channels,
     StatePropertyAccessor, 
     TurnContext } from 'botbuilder';
@@ -42,8 +43,15 @@ export class DefaultActivityHandler<T extends Dialog> extends ActivityHandler {
     }
 
     protected async membersAdded(turnContext: TurnContext, next: () => Promise<void>): Promise<void> {
-        await turnContext.sendActivity(this.templateManager.generateActivityForLocale('IntroMessage'));
-        await DialogEx.run(this.dialog, turnContext, this.dialogStateAccessor);
+        const membersAdded: ChannelAccount[] = turnContext.activity.membersAdded;
+        for (const member of membersAdded) {
+            if (member.id !== turnContext.activity.recipient.id) {
+                await turnContext.sendActivity(this.templateManager.generateActivityForLocale('IntroMessage'));
+                await DialogEx.run(this.dialog, turnContext, this.dialogStateAccessor);
+            }
+        }
+        // By calling next() you ensure that the next BotHandler is run.
+        await next();
     }
 
     protected onMessageActivity(turnContext: TurnContext): Promise<void> {

--- a/templates/typescript/samples/sample-skill/test/localization.test.js
+++ b/templates/typescript/samples/sample-skill/test/localization.test.js
@@ -21,6 +21,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -45,6 +49,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -69,6 +77,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -93,6 +105,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -117,6 +133,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -141,6 +161,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",
@@ -165,6 +189,10 @@ describe("localization", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",

--- a/templates/typescript/samples/sample-skill/test/mainDialog.test.js
+++ b/templates/typescript/samples/sample-skill/test/mainDialog.test.js
@@ -22,6 +22,10 @@ describe("main dialog", function() {
                         {
                             id: "1",
                             name: "user"
+                        },
+                        {
+                            id: "2",
+                            name: "bot"
                         }
                     ],
                     channelId: "emulator",


### PR DESCRIPTION
Fixes #3731 

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
An [issue](https://github.com/microsoft/botframework-solutions/issues/3731) was found where duplicated messages would arrive when contacting the TypeScript V.A. or Skill throught Direct Line. To fix this we implemented a validation taking as a reference the behavior in the [sample bots](https://github.com/microsoft/BotBuilder-Samples/blob/8e8fed1f4f09932ff63cbdea8de70306b41dc424/generators/generator-botbuilder/generators/app/templates/empty/bot.ts#L12).

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We added a validation to the membersAdded method in both the Virtual Assistant and Skill to only deliver the message when it's due to the user.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Tests have been adapted and are passing in both the V.A. and Skill
![image](https://user-images.githubusercontent.com/20074735/100930084-57bbe500-34c7-11eb-91d5-6d0cabc9facb.png)
![image](https://user-images.githubusercontent.com/20074735/100930137-6bffe200-34c7-11eb-922f-04ca47cab9fa.png)



### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation