### PR TITLE
display correct message with current locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
@@ -399,7 +399,7 @@ export class MainDialog extends ComponentDialog {
     private async finalStep(stepContext: WaterfallStepContext): Promise<DialogTurnResult> {
         // Clear active skill in state.
         await this.activeSkillProperty.delete(stepContext.context);
-        
+
         // Restart the main dialog with a different message the second time around
         return await stepContext.replaceDialog(this.initialDialogId, this.templateManager.generateActivityForLocale('CompletedMessage'));
     }
@@ -417,11 +417,11 @@ export class MainDialog extends ComponentDialog {
                 // The following line is a workaround until the method getQnAClient of QnAMakerDialog is fixed
                 // as per issue https://github.com/microsoft/botbuilder-js/issues/1885
                 new URL(qnaEndpoint.host).hostname.split('.')[0],
-                this.templateManager.generateActivityForLocale('UnsupportedMessage') as Activity,
+                this.templateManager.generateActivityForLocale('UnsupportedMessage',undefined,locale) as Activity,
                 // Before, instead of 'undefined' a '0.3' value was used in the following line
                 undefined,
-                this.templateManager.generateActivityForLocale('QnaMakerAdaptiveLearningCardTitle').text,
-                this.templateManager.generateActivityForLocale('QnaMakerNoMatchText').text
+                this.templateManager.generateActivityForLocale('QnaMakerAdaptiveLearningCardTitle',undefined,locale).text,
+                this.templateManager.generateActivityForLocale('QnaMakerNoMatchText',undefined,locale).text
             );
 
             qnaDialog.id = knowledgebaseId;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
I found this issue with my project. I created two languages models, and I found if any intent was matched, there will always show english fallback message, not my current locale (for example zh-cn),
### Changes
 I checked the code, and added few changes, then it works fine for me.


### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
