### PR TITLE
[C#][Bot-Solutions] Fix MultiProviderAuthDialog not being localized

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Solutions.Authentication
     /// </summary>
     public class MultiProviderAuthDialog : ComponentDialog
     {
-        private static readonly string[] acceptedLocales = new string[] { "en", "de", "es", "fr", "it", "zh" };
+        private static readonly string[] AcceptedLocales = new string[] { "en", "de", "es", "fr", "it", "zh" };
         private string _selectedAuthType = string.Empty;
         private List<OAuthConnection> _authenticationConnections;
         private ResponseManager _responseManager;
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Solutions.Authentication
             _authenticationConnections = authenticationConnections ?? throw new ArgumentNullException(nameof(authenticationConnections));
             _oauthCredentials = oauthCredentials;
             _responseManager = new ResponseManager(
-                acceptedLocales,
+                AcceptedLocales,
                 new AuthenticationResponses());
 
             var firstStep = new WaterfallStep[]
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Solutions.Authentication
                 {
                     var connection = _authenticationConnections[i];
 
-                    foreach (var locale in acceptedLocales)
+                    foreach (var locale in AcceptedLocales)
                     {
                         // We ignore placeholder connections in config that don't have a Name
                         if (!string.IsNullOrWhiteSpace(connection.Name))

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Responses/ResponseManager.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Responses/ResponseManager.cs
@@ -69,6 +69,24 @@ namespace Microsoft.Bot.Solutions.Responses
         }
 
         /// <summary>
+        /// Gets a simple response from template with Text, Speak, InputHint, and SuggestedActions set.
+        /// </summary>
+        /// <param name="templateId">The name of the response template.</param>
+        /// <param name="locale">The locale for the response template.</param>
+        /// <param name="tokens">StringDictionary of tokens to replace in the response.</param>
+        /// <returns>An Activity.</returns>
+        public Activity GetResponse(
+            string templateId,
+            string locale,
+            StringDictionary tokens = null)
+        {
+            var template = GetResponseTemplate(templateId, locale);
+
+            // create the response the data items
+            return ParseResponse(template, tokens);
+        }
+
+        /// <summary>
         /// Get a response with an Adaptive Card attachment.
         /// </summary>
         /// <param name="card">The card to add to the response.</param>


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
Fix #3560 
### Purpose
*What is the context of this pull request? Why is it being done?*
MultiProviderAuthDialog login dialog only works with the fallback language. It should be able to localize it using the user's locale.

The dialog is [added in the constructor](https://github.com/microsoft/botframework-solutions/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs#L78-L81) of MultiProviderAuthDialog, before the activity from the user is received, therefore the locale of the user is unknown at this moment.

This fix revolves around the idea of adding dialogs of known language beforehand, and then using the user locale to retrieve their specific locale's dialog.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Overloads ResponseManager's [GetResponse](https://github.com/microsoft/botframework-solutions/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Responses/ResponseManager.cs#L60) to receive a specific locale instead of using the `CurrentUICulture`.
- Adds a new method on MultiProviderAuthDialog to add a new login dialog for each configured locale

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

The MultiProviderAuthDialog localization working using a skill connected to a virtual assistant
![localization working](https://user-images.githubusercontent.com/39467613/106291876-ee3c2680-622a-11eb-837c-79bc49fc28b1.gif)


### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [x] I have updated related documentation
