### PR TITLE
Handle Unsuccessful Speech Connection  + Speech SDK Update

### DIFF
--- a/samples/android/clients/VirtualAssistantClient/app/src/main/aidl/com/microsoft/bot/builder/solutions/virtualassistant/ISpeechService.aidl
+++ b/samples/android/clients/VirtualAssistantClient/app/src/main/aidl/com/microsoft/bot/builder/solutions/virtualassistant/ISpeechService.aidl
@@ -6,6 +6,7 @@ interface ISpeechService {
     void sendTextMessage(String msg);
     void initializeSpeechSdk(boolean haveRecordAudioPermission);
     void connectAsync();
+    void disconnectAsync();
     String getConfiguration();// the String is "Configuration" as JSON
     void setConfiguration(String json);// the String is "Configuration" as JSON
     void requestWelcomeCard();

--- a/samples/android/clients/VirtualAssistantClient/app/src/main/java/com/microsoft/bot/builder/solutions/virtualassistant/service/SpeechService.java
+++ b/samples/android/clients/VirtualAssistantClient/app/src/main/java/com/microsoft/bot/builder/solutions/virtualassistant/service/SpeechService.java
@@ -119,6 +119,11 @@ public class SpeechService extends Service {
             }
 
             @Override
+            public void disconnectAsync() {
+                if (speechSdk != null) speechSdk.disconnectAsync();
+            }
+
+            @Override
             public void startLocationUpdates() {
                 SpeechService.this.startLocationUpdates();
             }
@@ -376,7 +381,7 @@ public class SpeechService extends Service {
             Log.d(TAG_FOREGROUND_SERVICE, "resetting SpeechSDK");
             shouldListenAgain = false;
             previousRequestWasTyped = false;
-            speechSdk.reset();
+            speechSdk.disconnectAsync();
         }
         speechSdk = new SpeechSdk();
         File directory = getExternalFilesDir(null);

--- a/samples/android/clients/VirtualAssistantClient/app/src/main/res/values/strings.xml
+++ b/samples/android/clients/VirtualAssistantClient/app/src/main/res/values/strings.xml
@@ -12,12 +12,15 @@
     <string name="msg_listening" translatable="false">I am listening…</string>
     <string name="msg_listening_not" translatable="false">I am no longer listening…</string>
     <string name="msg_disconnected" translatable="false">Reconnecting to Service</string>
+    <string name="msg_canceled" translatable="false">Session Canceled</string>
+    <string name="msg_check_key_region" translatable="false">Check Speech Key/Region!</string>
 
     <!-- GENERAL STRINGS -->
     <string name="bot_input_hint" translatable="false">Type a message to the bot</string>
     <string name="ok">OK</string>
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
+    <string name="settings">Settings</string>
 
     <!-- NAVIGATION DRAWER MENU -->
     <string name="navigation_drawer_open">Open navigation drawer</string>

--- a/samples/android/clients/VirtualAssistantClient/directlinespeech/build.gradle
+++ b/samples/android/clients/VirtualAssistantClient/directlinespeech/build.gradle
@@ -56,5 +56,5 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.9'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.15.0'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.17.0'
 }

--- a/samples/android/clients/VirtualAssistantClient/directlinespeech/src/main/java/com/microsoft/bot/builder/solutions/directlinespeech/SpeechSdk.java
+++ b/samples/android/clients/VirtualAssistantClient/directlinespeech/src/main/java/com/microsoft/bot/builder/solutions/directlinespeech/SpeechSdk.java
@@ -205,7 +205,7 @@ public class SpeechSdk {
                 case 5:// this is Connection was closed by the remote host. Error code: 1011. Error details: Unable to read data from the transport connection: Connection reset by peer
                 case 1:// this is the authentication error (401) when using wrong certificate
                     isConnected = false;
-                    EventBus.getDefault().post(new Disconnected(canceledEventArgs.getErrorDetails(), errCode));
+                    EventBus.getDefault().post(new Disconnected(canceledEventArgs.getReason().getValue(), canceledEventArgs.getErrorDetails(), errCode));
                     break;
             }
 
@@ -334,16 +334,6 @@ public class SpeechSdk {
         });
     }
 
-    public void disconnectAsync(){
-        isConnected = false;
-        LogInfo("disconnectAsync");
-        final Future<Void> task = botConnector.disconnectAsync();
-        setOnTaskCompletedListener(task, result -> {
-            // your code here
-            LogInfo("disconnected done");
-        });
-    }
-
     private void startResponseTimeoutTimer(){
         LogInfo("startResponseTimeoutTimer");
         if (timeoutResponseRunnable == null) {
@@ -411,7 +401,7 @@ public class SpeechSdk {
         });
     }
 
-    public void reset() {
+    public void disconnectAsync() {
         cancelResponseTimeoutTimer();
         isConnected = false;
         stopKeywordListening();

--- a/samples/android/clients/VirtualAssistantClient/directlinespeech/src/main/java/events/Disconnected.java
+++ b/samples/android/clients/VirtualAssistantClient/directlinespeech/src/main/java/events/Disconnected.java
@@ -2,10 +2,12 @@ package events;
 
 public class Disconnected {
 
+    public int cancellationReason;
     public String errorDetails;
     public int errorCode;
 
-    public Disconnected(String errorDetails, int errorCode) {
+    public Disconnected(int cancellationReason, String errorDetails, int errorCode) {
+        this.cancellationReason = cancellationReason;
         this.errorDetails = errorDetails;
         this.errorCode = errorCode;
     }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Addressing [this bug](https://github.com/microsoft/botframework-solutions/issues/3804). The app now displays an alert dialog when a malformed or incorrect speech key or region is provided. User is given the option in the dialog to navigate to the settings.

Renamed SpeechSDK.reset() to SpeechSDK.disconnectAsync() to be more accurate.

For added robustness, the app was updated to use Speech SDK v1.17.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
New UI element - alert dialog when speech connection fails due to bad speech key/region combo.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
No, UI element change.
### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
