### PR TITLE
[TypeScript][Virtual Assistant] Add claim's validation if the VA is not connected to Skills

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
@@ -77,12 +77,16 @@ const credentialProvider: SimpleCredentialProvider = new SimpleCredentialProvide
 // Register the skills configuration class.
 const skillsConfig: SkillsConfiguration = new SkillsConfiguration(appsettings.botFrameworkSkills as IEnhancedBotFrameworkSkill[], appsettings.skillHostEndpoint);
 
+let authenticationConfiguration = new AuthenticationConfiguration();
+
 // Register AuthConfiguration to enable custom claim validation.
-const allowedCallers: string[] = [...skillsConfig.skills.values()].map(skill => skill.appId);
-const authenticationConfiguration = new AuthenticationConfiguration(
-    undefined,
-    allowedCallersClaimsValidator(allowedCallers)
-);
+if (skillsConfig.skills.size > 0) {
+    const allowedCallers: string[] = [...skillsConfig.skills.values()].map(skill => skill.appId);
+    authenticationConfiguration = new AuthenticationConfiguration(
+        undefined,
+        allowedCallersClaimsValidator(allowedCallers)
+    );
+}
 
 // Configure telemetry
 const telemetryClient: BotTelemetryClient = getTelemetryClient(settings);

--- a/templates/typescript/samples/sample-assistant/src/index.ts
+++ b/templates/typescript/samples/sample-assistant/src/index.ts
@@ -77,12 +77,16 @@ const credentialProvider: SimpleCredentialProvider = new SimpleCredentialProvide
 // Register the skills configuration class.
 const skillsConfig: SkillsConfiguration = new SkillsConfiguration(appsettings.botFrameworkSkills as IEnhancedBotFrameworkSkill[], appsettings.skillHostEndpoint);
 
+let authenticationConfiguration = new AuthenticationConfiguration();
+
 // Register AuthConfiguration to enable custom claim validation.
-const allowedCallers: string[] = [...skillsConfig.skills.values()].map(skill => skill.appId);
-const authenticationConfiguration = new AuthenticationConfiguration(
-    undefined,
-    allowedCallersClaimsValidator(allowedCallers)
-);
+if(skillsConfig.skills.size > 0){
+    const allowedCallers: string[] = [...skillsConfig.skills.values()].map(skill => skill.appId);
+    const authenticationConfiguration = new AuthenticationConfiguration(
+        undefined,
+        allowedCallersClaimsValidator(allowedCallers)
+    );
+}
 
 // Configure telemetry
 const telemetryClient: BotTelemetryClient = getTelemetryClient(settings);

--- a/templates/typescript/samples/sample-assistant/src/index.ts
+++ b/templates/typescript/samples/sample-assistant/src/index.ts
@@ -80,9 +80,9 @@ const skillsConfig: SkillsConfiguration = new SkillsConfiguration(appsettings.bo
 let authenticationConfiguration = new AuthenticationConfiguration();
 
 // Register AuthConfiguration to enable custom claim validation.
-if(skillsConfig.skills.size > 0){
+if (skillsConfig.skills.size > 0) {
     const allowedCallers: string[] = [...skillsConfig.skills.values()].map(skill => skill.appId);
-    const authenticationConfiguration = new AuthenticationConfiguration(
+    authenticationConfiguration = new AuthenticationConfiguration(
         undefined,
         allowedCallersClaimsValidator(allowedCallers)
     );


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
When trying to run the TypeScript Virtual Assistant without a Skill connected, an assertion error is raised, pointing that "The expression evaluated to a falsy value: assert_1.ok(allowedCallers.length)" because of the caller claims are [empty](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botframework-connector/src/auth/allowedCallersClaimsValidator.ts#L17).

![allowed error](https://user-images.githubusercontent.com/64086728/122460696-d3bfdb00-cf88-11eb-9508-c180e4759149.png)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- New validation to check if the Virtual Assistant has skills connected or not to complete the caller claims
- Replicate to template

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
_The TypeScript Virtual Assistant communication worked as expected_
![VA working](https://user-images.githubusercontent.com/64086728/122461056-3e711680-cf89-11eb-93d9-8f6729732a43.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
