### PR TITLE
[TypeScript][Samples] Update package-lock to consume last version of bot-solutions 1.1.0

### DIFF
--- a/templates/typescript/samples/sample-assistant/package-lock.json
+++ b/templates/typescript/samples/sample-assistant/package-lock.json
@@ -4,6 +4,21 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@azure/abort-controller": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/abort-controller/-/@azure/abort-controller-1.0.4.tgz",
+            "integrity": "sha1-/TxNRsjtZ6rOQkmMjiJwlgJQ6v0=",
+            "requires": {
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
         "@azure/cognitiveservices-luis-authoring": {
             "version": "2.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cognitiveservices-luis-authoring/-/@azure/cognitiveservices-luis-authoring-2.1.0.tgz",
@@ -22,50 +37,228 @@
                 "tslib": "^1.9.3"
             }
         },
-        "@azure/cosmos": {
-            "version": "3.6.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.6.3.tgz",
-            "integrity": "sha1-u1O941+/M4FgaR0ramL0e0qaHLs=",
+        "@azure/core-asynciterator-polyfill": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-asynciterator-polyfill/-/@azure/core-asynciterator-polyfill-1.0.0.tgz",
+            "integrity": "sha1-3MzruIQG5cduDh1S6MxMQ6aLPuc="
+        },
+        "@azure/core-auth": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-auth/-/@azure/core-auth-1.3.0.tgz",
+            "integrity": "sha1-DVVRfPBlCu/nVWaayoovNyT89TY=",
             "requires": {
-                "@types/debug": "^4.1.4",
-                "debug": "^4.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "node-abort-controller": "^1.0.4",
-                "node-fetch": "^2.6.0",
-                "os-name": "^3.1.0",
-                "priorityqueuejs": "^1.0.0",
-                "semaphore": "^1.0.5",
-                "tslib": "^1.10.0",
-                "uuid": "^3.3.2"
+                "@azure/abort-controller": "^1.0.0",
+                "tslib": "^2.0.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/core-http": {
+            "version": "1.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-http/-/@azure/core-http-1.2.6.tgz",
+            "integrity": "sha1-nNUIQYVy0gYv0xdSdCGUOHcr22U=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-asynciterator-polyfill": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "@types/node-fetch": "^2.5.0",
+                "@types/tunnel": "^0.0.1",
+                "form-data": "^3.0.0",
+                "node-fetch": "^2.6.0",
+                "process": "^0.11.10",
+                "tough-cookie": "^4.0.0",
+                "tslib": "^2.2.0",
+                "tunnel": "^0.0.6",
+                "uuid": "^8.3.0",
+                "xml2js": "^0.4.19"
+            },
+            "dependencies": {
+                "@types/tunnel": {
+                    "version": "0.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tunnel/-/@types/tunnel-0.0.1.tgz",
+                    "integrity": "sha1-DXJ3R2i3PfJvJd+RhCc6QtpysZw=",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "@types/node": "*"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
                 },
                 "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+                },
+                "tough-cookie": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+                    "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+                    "requires": {
+                        "psl": "^1.1.33",
+                        "punycode": "^2.1.1",
+                        "universalify": "^0.1.2"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/core-lro": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-lro/-/@azure/core-lro-1.0.5.tgz",
+            "integrity": "sha1-hWostqm+xznunN4zonzCj4GsBSI=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-http": "^1.2.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "events": "^3.0.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/core-paging": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-paging/-/@azure/core-paging-1.1.3.tgz",
+            "integrity": "sha1-NYfJiYoFMMrLZLqyFtcxhGiqXvw=",
+            "requires": {
+                "@azure/core-asynciterator-polyfill": "^1.0.0"
+            }
+        },
+        "@azure/core-rest-pipeline": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-rest-pipeline/-/@azure/core-rest-pipeline-1.0.4.tgz",
+            "integrity": "sha1-+bVb+ljg2dLkupCSvth0kG04Cig=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "form-data": "^3.0.0",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "tslib": "^2.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/core-tracing": {
+            "version": "1.0.0-preview.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-tracing/-/@azure/core-tracing-1.0.0-preview.11.tgz",
+            "integrity": "sha1-vfsrpzzWw5t9bCB7lSLrmOCLTd0=",
+            "requires": {
+                "@opencensus/web-types": "0.0.7",
+                "@opentelemetry/api": "1.0.0-rc.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/cosmos": {
+            "version": "3.11.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.11.5.tgz",
+            "integrity": "sha1-Kk4LWgjtcQ9jCZkWjIy5NJRJuGI=",
+            "requires": {
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-rest-pipeline": "^1.0.3",
+                "debug": "^4.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "jsbi": "^3.1.3",
+                "node-abort-controller": "^1.2.0",
+                "priorityqueuejs": "^1.0.0",
+                "semaphore": "^1.0.5",
+                "tslib": "^2.0.0",
+                "universal-user-agent": "^6.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/logger": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/logger/-/@azure/logger-1.0.2.tgz",
+            "integrity": "sha1-rS0GR47tp4NfU9735FZpgbR9l4c=",
+            "requires": {
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
                 }
             }
         },
         "@azure/ms-rest-js": {
-            "version": "1.8.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.15.tgz",
-            "integrity": "sha1-Qme2uMANhTAXkf4M80fgRVqAczg=",
+            "version": "1.11.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.11.2.tgz",
+            "integrity": "sha1-6D1RKxAsMCQl2l/wOm12rfKqSuY=",
             "requires": {
-                "@types/tunnel": "0.0.0",
-                "axios": "^0.19.0",
+                "@azure/core-auth": "^1.1.4",
+                "axios": "^0.21.1",
                 "form-data": "^2.3.2",
                 "tough-cookie": "^2.4.3",
                 "tslib": "^1.9.2",
@@ -74,140 +267,144 @@
                 "xml2js": "^0.4.19"
             }
         },
+        "@azure/storage-blob": {
+            "version": "12.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/storage-blob/-/@azure/storage-blob-12.6.0.tgz",
+            "integrity": "sha1-mQXYDl+Qilc8xl4cuDAqvDKBiEQ=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-http": "^1.2.0",
+                "@azure/core-lro": "^1.0.2",
+                "@azure/core-paging": "^1.1.1",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "events": "^3.0.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.10.1.tgz",
-            "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.14.5.tgz",
+            "integrity": "sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.14.5"
             }
         },
         "@babel/generator": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.10.2.tgz",
-            "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.14.5.tgz",
+            "integrity": "sha1-hI17nwMcrKnQzQrwGwY/Im9S14U=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.2",
+                "@babel/types": "^7.14.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.10.1.tgz",
-            "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.14.5.tgz",
+            "integrity": "sha1-ieLEdJcvFdjiM7Uu6MSA4s/NUMQ=",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-get-function-arity": "^7.14.5",
+                "@babel/template": "^7.14.5",
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.10.1.tgz",
-            "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.14.5.tgz",
+            "integrity": "sha1-Jfv6V5sJN+7h87gF7OTOOYxDGBU=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-hoist-variables/-/@babel/helper-hoist-variables-7.14.5.tgz",
+            "integrity": "sha1-4N0nwzp45XfXyIhJFqPn7x98f40=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.10.1.tgz",
-            "integrity": "sha1-xvS+HLwV46ho5MZKF9XTHXVNo18=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.14.5.tgz",
+            "integrity": "sha1-IrI6VO9RwrdgXYUZMMGXbdC8aTo=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.14.5.tgz",
+            "integrity": "sha1-0PDid8US4Mk4J3+qhaOWjJpEwOg=",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.10.1.tgz",
-            "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.14.5.tgz",
+            "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.10.2.tgz",
-            "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
+            "version": "7.14.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.14.7.tgz",
+            "integrity": "sha1-YJlyDIg5yoZaJjfmyFhS6tC9tZU=",
             "dev": true
         },
-        "@babel/runtime": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.10.2.tgz",
-            "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
         "@babel/template": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.10.1.tgz",
-            "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.14.5.tgz",
+            "integrity": "sha1-qbydizM1T/blWpxg0RCSAKaJdPQ=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/code-frame": "^7.14.5",
+                "@babel/parser": "^7.14.5",
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/traverse": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.10.1.tgz",
-            "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
+            "version": "7.14.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.14.7.tgz",
+            "integrity": "sha1-ZAB8l3TP3Dq9I7B4C8GKPONjF1M=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.1",
-                "@babel/helper-function-name": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.14.5",
+                "@babel/helper-function-name": "^7.14.5",
+                "@babel/helper-hoist-variables": "^7.14.5",
+                "@babel/helper-split-export-declaration": "^7.14.5",
+                "@babel/parser": "^7.14.7",
+                "@babel/types": "^7.14.5",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
-                }
+                "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.10.2.tgz",
-            "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.14.5.tgz",
+            "integrity": "sha1-O7mXuoKaIQTO2yBonEpbgSHTg/8=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -222,9 +419,9 @@
             }
         },
         "@microsoft/microsoft-graph-types": {
-            "version": "1.12.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.12.0.tgz",
-            "integrity": "sha1-rPPPz7ZrCXMTKYJdh3MO4GbYFIo="
+            "version": "1.41.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.41.0.tgz",
+            "integrity": "sha1-ZpETOR9O+wLoiKijNJ5OPW0lujU="
         },
         "@microsoft/recognizers-text": {
             "version": "1.3.0",
@@ -241,9 +438,9 @@
             }
         },
         "@microsoft/recognizers-text-data-types-timex-expression": {
-            "version": "1.1.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-data-types-timex-expression/-/@microsoft/recognizers-text-data-types-timex-expression-1.1.4.tgz",
-            "integrity": "sha1-YjRTrmXo3yEtgVb2oxRnXDBpbB0="
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-data-types-timex-expression/-/@microsoft/recognizers-text-data-types-timex-expression-1.3.0.tgz",
+            "integrity": "sha1-/F1YbIJuR46Ed7f8sh6eKDDoHGc="
         },
         "@microsoft/recognizers-text-date-time": {
             "version": "1.1.4",
@@ -364,6 +561,16 @@
                 }
             }
         },
+        "@opencensus/web-types": {
+            "version": "0.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@opencensus/web-types/-/@opencensus/web-types-0.0.7.tgz",
+            "integrity": "sha1-RCbeH+Wqj2JNs5XSFSuQKHTwVwo="
+        },
+        "@opentelemetry/api": {
+            "version": "1.0.0-rc.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@opentelemetry/api/-/@opentelemetry/api-1.0.0-rc.0.tgz",
+            "integrity": "sha1-DHw/XhKF+ZzttWPXStGtuYIrUUQ="
+        },
         "@sindresorhus/is": {
             "version": "0.14.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@sindresorhus/is/-/@sindresorhus/is-0.14.0.tgz",
@@ -379,10 +586,15 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
-        "@types/atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob/-/@types/atob-2.1.2.tgz",
-            "integrity": "sha1-FX6wzEYmSoxV8ic6g2x6GmRPuCA="
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@tootallnate/once/-/@tootallnate/once-1.1.2.tgz",
+            "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
+        },
+        "@types/atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob-lite/-/@types/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM="
         },
         "@types/body-parser": {
             "version": "1.19.0",
@@ -393,6 +605,11 @@
                 "@types/node": "*"
             }
         },
+        "@types/btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/btoa-lite/-/@types/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-4ZClpUjgs0itsN+ax/pfEVHHzKQ="
+        },
         "@types/bunyan": {
             "version": "1.8.6",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/bunyan/-/@types/bunyan-1.8.6.tgz",
@@ -402,29 +619,18 @@
                 "@types/node": "*"
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/color-name/-/@types/color-name-1.1.1.tgz",
-            "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
-            "dev": true
-        },
         "@types/connect": {
-            "version": "3.4.33",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.33.tgz",
-            "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
+            "version": "3.4.34",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.34.tgz",
+            "integrity": "sha1-FwpAIjptZmAG2TyhKK8r6x2bGQE=",
             "requires": {
                 "@types/node": "*"
             }
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/debug/-/@types/debug-4.1.5.tgz",
-            "integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0="
-        },
         "@types/documentdb": {
-            "version": "1.10.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.6.tgz",
-            "integrity": "sha1-FWwV1yDmhx3gY3HJbZPHtX7htic=",
+            "version": "1.10.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.8.tgz",
+            "integrity": "sha1-zyAI+KSUSrvZcfKsHbuBq/LZL5I=",
             "requires": {
                 "@types/node": "*"
             }
@@ -435,19 +641,13 @@
             "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0=",
             "dev": true
         },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/events/-/@types/events-3.0.0.tgz",
-            "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
-            "dev": true
-        },
         "@types/express": {
-            "version": "4.17.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.6.tgz",
-            "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
+            "version": "4.17.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.12.tgz",
+            "integrity": "sha1-S8G/PNDP5tP28oU2SLQNt9VN41A=",
             "requires": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "*",
+                "@types/express-serve-static-core": "^4.17.18",
                 "@types/qs": "*",
                 "@types/serve-static": "*"
             }
@@ -462,9 +662,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.7.tgz",
-            "integrity": "sha1-3+Yfhw61SdxtfhIFCQGEfH1+kVs=",
+            "version": "4.17.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.21.tgz",
+            "integrity": "sha1-pCcnjhBryne4OthSIernCaNBTUI=",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -480,34 +680,18 @@
             }
         },
         "@types/formidable": {
-            "version": "1.0.31",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/formidable/-/@types/formidable-1.0.31.tgz",
-            "integrity": "sha1-J0+dwtChqc4f7vSMJMoIWefslHs=",
+            "version": "1.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/formidable/-/@types/formidable-1.2.2.tgz",
+            "integrity": "sha1-5pDWBzLunT8KRBvFcsF0CXhbKDw=",
             "dev": true,
             "requires": {
-                "@types/events": "*",
                 "@types/node": "*"
             }
         },
-        "@types/i18next": {
-            "version": "2.3.41",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next/-/@types/i18next-2.3.41.tgz",
-            "integrity": "sha1-Wj69y0lCBSyi73HE9jQUOMV8sYw=",
-            "dev": true
-        },
-        "@types/i18next-node-fs-backend": {
-            "version": "0.0.30",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next-node-fs-backend/-/@types/i18next-node-fs-backend-0.0.30.tgz",
-            "integrity": "sha1-dFT46SN5ii6/FjCb78/f3jLpCnw=",
-            "dev": true,
-            "requires": {
-                "@types/i18next": "^2"
-            }
-        },
         "@types/json-schema": {
-            "version": "7.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.4.tgz",
-            "integrity": "sha1-OP1z3f2bVaux4bLtV4y1W9e30zk=",
+            "version": "7.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.7.tgz",
+            "integrity": "sha1-mKmTUWyFnrDVxMjwmDF6nqaNua0=",
             "dev": true
         },
         "@types/jsonwebtoken": {
@@ -524,27 +708,40 @@
             "integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM="
         },
         "@types/mime": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.2.tgz",
-            "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU="
-        },
-        "@types/moment-timezone": {
-            "version": "0.5.13",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/moment-timezone/-/@types/moment-timezone-0.5.13.tgz",
-            "integrity": "sha1-AxfMyR60x/SQFwQWYWY5XDknZSg=",
-            "requires": {
-                "moment": ">=2.14.0"
-            }
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-1.3.2.tgz",
+            "integrity": "sha1-k+Jb+e51/g/YC1lLxP6w6GIRG1o="
         },
         "@types/node": {
-            "version": "14.0.9",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-14.0.9.tgz",
-            "integrity": "sha1-Q4lquH/IK9od/WAM30SgyKZOEdI="
+            "version": "15.12.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-15.12.4.tgz",
+            "integrity": "sha1-4c+BfXCh4RjoGSLE/2aDzp1CLiY="
+        },
+        "@types/node-fetch": {
+            "version": "2.5.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node-fetch/-/@types/node-fetch-2.5.10.tgz",
+            "integrity": "sha1-m01KBCVWL5/OpwsSyz/N2UbKgTI=",
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
+            }
         },
         "@types/qs": {
-            "version": "6.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.3.tgz",
-            "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM="
+            "version": "6.9.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.6.tgz",
+            "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E="
         },
         "@types/range-parser": {
             "version": "1.2.3",
@@ -552,9 +749,9 @@
             "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
         },
         "@types/restify": {
-            "version": "8.4.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-8.4.2.tgz",
-            "integrity": "sha1-8HHZcdEK159gc9+77tdynWh2Dn8=",
+            "version": "8.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-8.5.1.tgz",
+            "integrity": "sha1-eQltaUhpVr6DpA+wZjIyVfIKQk8=",
             "dev": true,
             "requires": {
                 "@types/bunyan": "*",
@@ -564,12 +761,12 @@
             }
         },
         "@types/serve-static": {
-            "version": "1.13.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.4.tgz",
-            "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
+            "version": "1.13.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.9.tgz",
+            "integrity": "sha1-qs8oqFoF7imhH7fD6tk1rFbzPk4=",
             "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
+                "@types/mime": "^1",
+                "@types/node": "*"
             }
         },
         "@types/spdy": {
@@ -598,9 +795,9 @@
             }
         },
         "@types/xmldom": {
-            "version": "0.1.29",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/xmldom/-/@types/xmldom-0.1.29.tgz",
-            "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E="
+            "version": "0.1.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/xmldom/-/@types/xmldom-0.1.30.tgz",
+            "integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "2.34.0",
@@ -653,19 +850,10 @@
                 "tsutils": "^3.17.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -676,16 +864,28 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
                 },
                 "semver": {
-                    "version": "7.3.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-7.3.2.tgz",
-                    "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+                    "version": "7.3.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
                     "dev": true
                 }
             }
@@ -697,27 +897,27 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.4.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.4.1.tgz",
-            "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
+            "version": "6.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-            "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+            "version": "5.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
             "dev": true
         },
         "adal-node": {
-            "version": "0.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.2.1.tgz",
-            "integrity": "sha1-GeQBvVeZd0SMGnfODltMmszcM04=",
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.2.2.tgz",
+            "integrity": "sha1-lfbM4PtsUI8bvNZ3t2SyFyxOjDs=",
             "requires": {
                 "@types/node": "^8.0.47",
                 "async": "^2.6.3",
+                "axios": "^0.21.1",
                 "date-utils": "*",
                 "jws": "3.x.x",
-                "request": "^2.88.0",
                 "underscore": ">= 1.3.1",
                 "uuid": "^3.1.0",
                 "xmldom": ">= 0.1.x",
@@ -725,30 +925,52 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 }
             }
         },
         "adaptive-expressions": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.9.2.tgz",
-            "integrity": "sha1-Cj0ng3DTAQiHACEKAmZ33sY8WfY=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.13.6.tgz",
+            "integrity": "sha1-GbYjcO/SDZRfJ0ext0Ig142syPs=",
             "requires": {
-                "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-                "@types/atob": "^2.1.2",
+                "@microsoft/recognizers-text-data-types-timex-expression": "1.3.0",
+                "@types/atob-lite": "^2.0.0",
+                "@types/btoa-lite": "^1.0.0",
                 "@types/lru-cache": "^5.1.0",
-                "@types/moment-timezone": "^0.5.12",
-                "@types/xmldom": "^0.1.29",
-                "antlr4ts": "0.5.0-alpha.1",
-                "atob": "^2.1.2",
+                "@types/xmldom": "^0.1.30",
+                "antlr4ts": "0.5.0-alpha.3",
+                "atob-lite": "^2.0.0",
                 "big-integer": "^1.6.48",
+                "btoa-lite": "^1.0.0",
+                "d3-format": "^1.4.4",
+                "dayjs": "^1.10.3",
                 "jspath": "^0.4.0",
-                "lodash": "^4.17.15",
                 "lru-cache": "^5.1.1",
-                "moment": "^2.25.1",
-                "moment-timezone": "^0.5.28"
+                "uuid": "^8.3.2",
+                "x2js": "^3.4.0",
+                "xml2js": "^0.4.23",
+                "xmldom": "^0.5.0",
+                "xpath": "^0.0.32"
+            },
+            "dependencies": {
+                "dayjs": {
+                    "version": "1.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dayjs/-/dayjs-1.10.5.tgz",
+                    "integrity": "sha1-VgDfRUj8JFOz8WPrsqu+llzPuYY="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                },
+                "xmldom": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.5.0.tgz",
+                    "integrity": "sha1-GTy5a4SqNIYSfqYnLEWWNUy0li4="
+                }
             }
         },
         "adaptivecards": {
@@ -756,10 +978,27 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptivecards/-/adaptivecards-1.2.6.tgz",
             "integrity": "sha1-K+H3FFaT29Y+nxthKNUsMn//a4Q="
         },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+            "requires": {
+                "debug": "4"
+            }
+        },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
         "ajv": {
-            "version": "6.12.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.2.tgz",
-            "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
+            "version": "6.12.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -835,25 +1074,23 @@
             "dev": true
         },
         "ansi-styles": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-            "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
             "dev": true,
             "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
             }
         },
         "antlr4ts": {
-            "version": "0.5.0-alpha.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.1.tgz",
-            "integrity": "sha1-xCHYJpUjNWxCxVM2A67AQQtCOAY="
+            "version": "0.5.0-alpha.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+            "integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y="
         },
         "anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
-            "dev": true,
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -869,14 +1106,14 @@
             }
         },
         "applicationinsights": {
-            "version": "1.7.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.7.5.tgz",
-            "integrity": "sha1-Qj2bWM0gEX1yS4aBGTXendq4uFI=",
+            "version": "1.8.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.8.10.tgz",
+            "integrity": "sha1-//pILNFRmID7iIU2qHCBrAUTBmc=",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.4"
+                "diagnostic-channel": "0.3.1",
+                "diagnostic-channel-publishers": "0.4.4"
             }
         },
         "archy": {
@@ -889,6 +1126,7 @@
             "version": "1.0.10",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -957,10 +1195,10 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+        "atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob-lite/-/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -968,16 +1206,16 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI="
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+            "version": "0.21.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha1-IlY0gZYvTWvemnbVFu8OXTwJsrg=",
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
             }
         },
         "azure-cognitiveservices-contentmoderator": {
@@ -1032,9 +1270,9 @@
             }
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
         },
         "base64url": {
             "version": "3.0.1",
@@ -1060,10 +1298,9 @@
             "integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
         },
         "binary-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
-            "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
-            "dev": true
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
         },
         "binary-search-bounds": {
             "version": "2.0.3",
@@ -1071,26 +1308,27 @@
             "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
         },
         "bot-solutions": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.0.0.tgz",
-            "integrity": "sha1-P1LISJL7sl+v6xbSqkiZmDER0tI=",
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.1.0.tgz",
+            "integrity": "sha1-bSF6Izy6EXFl1ztqsY2boN+UERc=",
             "requires": {
                 "@azure/cognitiveservices-luis-authoring": "^2.1.0",
+                "@azure/cosmos": "^3.11.3",
                 "@microsoft/recognizers-text": "^1.1.4",
                 "@microsoft/recognizers-text-choice": "^1.1.4",
                 "@types/lru-cache": "^5.1.0",
                 "adaptivecards": "^1.1.3",
                 "azure-cognitiveservices-contentmoderator": "^4.0.0",
-                "botbuilder": "^4.9.0",
-                "botbuilder-ai": "^4.9.0",
-                "botbuilder-azure": "^4.9.0",
-                "botbuilder-dialogs": "^4.9.0",
-                "botbuilder-lg": "^4.9.0",
-                "botframework-config": "^4.9.0",
-                "botframework-connector": "^4.9.0",
+                "botbuilder": "^4.13.5",
+                "botbuilder-ai": "^4.13.5",
+                "botbuilder-azure-blobs": "^4.13.5-preview",
+                "botbuilder-core": "^4.13.5",
+                "botbuilder-dialogs": "^4.13.5",
+                "botbuilder-lg": "^4.13.5",
+                "botframework-config": "^4.13.5-deprecated",
+                "botframework-connector": "^4.13.5",
+                "botframework-schema": "^4.13.5",
                 "dayjs": "1.8.17",
-                "i18next": "^15.0.6",
-                "i18next-node-fs-backend": "^2.1.1",
                 "jwks-rsa": "1.5.0",
                 "ms-rest-azure": "^2.5.0",
                 "p-queue": "^4.0.0",
@@ -1100,80 +1338,84 @@
             }
         },
         "botbuilder": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.9.2.tgz",
-            "integrity": "sha1-IObPpq0pndzey6Z39RXtdbVenGA=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.13.6.tgz",
+            "integrity": "sha1-gNBwzCGGSPKWWNRYRNd5Zc1r4gE=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
-                "@types/node": "^10.12.18",
-                "axios": "^0.19.0",
-                "botbuilder-core": "4.9.2",
-                "botframework-connector": "4.9.2",
-                "botframework-streaming": "4.9.2",
+                "@azure/ms-rest-js": "1.9.1",
+                "axios": "^0.21.1",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "botframework-streaming": "4.13.6",
+                "dayjs": "^1.10.3",
                 "filenamify": "^4.1.0",
                 "fs-extra": "^7.0.1",
-                "moment-timezone": "^0.5.28"
+                "htmlparser2": "^6.0.1",
+                "uuid": "^8.3.2"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
-                        "axios": "^0.18.0",
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
                         "uuid": "^3.2.1",
                         "xml2js": "^0.4.19"
                     },
                     "dependencies": {
-                        "axios": {
-                            "version": "0.18.1",
-                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                            "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                            "requires": {
-                                "follow-redirects": "1.5.10",
-                                "is-buffer": "^2.0.2"
-                            }
+                        "uuid": {
+                            "version": "3.4.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.4.0.tgz",
+                            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
                         }
                     }
                 },
-                "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+                "dayjs": {
+                    "version": "1.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dayjs/-/dayjs-1.10.5.tgz",
+                    "integrity": "sha1-VgDfRUj8JFOz8WPrsqu+llzPuYY="
                 },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
                 }
             }
         },
         "botbuilder-ai": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.9.2.tgz",
-            "integrity": "sha1-08UhW2Aw8c81U4fSLCiZWP22Hxk=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.13.6.tgz",
+            "integrity": "sha1-DDwHJlq/hYdgUMYJ98RMl0GqQ84=",
             "requires": {
                 "@azure/cognitiveservices-luis-runtime": "2.0.0",
-                "@azure/ms-rest-js": "1.8.13",
+                "@azure/ms-rest-js": "1.9.1",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
-                "botbuilder-dialogs": "4.9.2",
-                "moment": "^2.25.1",
-                "node-fetch": "^2.3.0",
-                "url-parse": "^1.4.4"
+                "adaptive-expressions": "4.13.6",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-dialogs-declarative": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "lodash": "^4.17.21",
+                "node-fetch": "^2.6.0",
+                "url-parse": "^1.5.1"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.8.13",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.13.tgz",
-                    "integrity": "sha1-7QzYZGlpc3jNOdedVYnod6O8h6Y=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
                         "@types/tunnel": "0.0.0",
-                        "axios": "^0.19.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
@@ -1182,71 +1424,172 @@
                         "xml2js": "^0.4.19"
                     }
                 },
-                "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
-                },
                 "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
                 }
             }
         },
         "botbuilder-applicationinsights": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.9.2.tgz",
-            "integrity": "sha1-FO/SCLrE8hK64mMJQdoqkHquPo0=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.13.6.tgz",
+            "integrity": "sha1-b+EmGtKcMFSc9iV8rOTxkZ3zqK8=",
             "requires": {
-                "applicationinsights": "1.7.5",
-                "botbuilder-core": "4.9.2",
+                "applicationinsights": "^1.7.5",
+                "botbuilder-core": "4.13.6",
                 "cls-hooked": "^4.2.2"
             }
         },
         "botbuilder-azure": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.9.2.tgz",
-            "integrity": "sha1-eNahVxGxk2UTQgibEqmsyhX2rJ8=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.13.6.tgz",
+            "integrity": "sha1-jmDB5bNaRFypg0H+J4Lfwod1Jlg=",
             "requires": {
                 "@azure/cosmos": "^3.3.1",
                 "@types/documentdb": "^1.10.5",
-                "@types/node": "^10.12.18",
                 "azure-storage": "2.10.2",
-                "botbuilder": "4.9.2",
+                "botbuilder": "4.13.6",
                 "documentdb": "1.14.5",
                 "flat": "^4.0.0",
                 "semaphore": "^1.1.0"
+            }
+        },
+        "botbuilder-azure-blobs": {
+            "version": "4.13.5-preview.dev.5bd62f8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure-blobs/-/botbuilder-azure-blobs-4.13.5-preview.dev.5bd62f8.tgz",
+            "integrity": "sha1-0fRzplEjF1bNhBFYkAAdq7j68X4=",
+            "requires": {
+                "@azure/storage-blob": "^12.2.1",
+                "botbuilder-core": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8",
+                "get-stream": "^6.0.0",
+                "p-map": "^4.0.0",
+                "runtypes": "~5.1.0"
             },
             "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.4.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.4.0.tgz",
+                            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+                        }
+                    }
+                },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+                    "version": "10.17.60",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.60.tgz",
+                    "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+                },
+                "botbuilder-core": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-jXVFVMd6Bkelrvqj8tzkg5PwUgc=",
+                    "requires": {
+                        "assert": "^1.4.1",
+                        "botbuilder-dialogs-adaptive-runtime-core": "4.13.5-preview.dev.5bd62f8+sha-5bd62f8",
+                        "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8",
+                        "botframework-connector": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "botframework-schema": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "uuid": "^8.3.2"
+                    }
+                },
+                "botbuilder-dialogs-adaptive-runtime-core": {
+                    "version": "4.13.5-preview.dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.5-preview.dev.5bd62f8.tgz",
+                    "integrity": "sha1-GCxDVviOyXmqeDja9Yqjr1E5Ux4=",
+                    "requires": {
+                        "dependency-graph": "^0.10.0",
+                        "runtypes": "~5.1.0"
+                    }
+                },
+                "botbuilder-stdlib": {
+                    "version": "4.13.5-internal.dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-stdlib/-/botbuilder-stdlib-4.13.5-internal.dev.5bd62f8.tgz",
+                    "integrity": "sha1-wr/FS/mRTcVXsM70E886x1/irpo="
+                },
+                "botframework-connector": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-T4+0oVNk3ciaOim1lI9bn/qi7Sc=",
+                    "requires": {
+                        "@azure/ms-rest-js": "1.9.1",
+                        "@types/jsonwebtoken": "7.2.8",
+                        "@types/node": "^10.17.27",
+                        "adal-node": "0.2.2",
+                        "base64url": "^3.0.0",
+                        "botframework-schema": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "cross-fetch": "^3.0.5",
+                        "jsonwebtoken": "8.0.1",
+                        "rsa-pem-from-mod-exp": "^0.8.4"
+                    }
+                },
+                "botframework-schema": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-isD13N/7kZN60/3qoWaiXvzek64=",
+                    "requires": {
+                        "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
                 }
             }
         },
         "botbuilder-core": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.9.2.tgz",
-            "integrity": "sha1-njBevc19gjHXH/OOZlPjb7uRxes=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.13.6.tgz",
+            "integrity": "sha1-M+ViJyw9Z7woW5g0JweOdyKkhGg=",
             "requires": {
                 "assert": "^1.4.1",
-                "botframework-schema": "4.9.2"
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "botframework-schema": "4.13.6",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "botbuilder-dialogs": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.9.2.tgz",
-            "integrity": "sha1-J6gzfowfrJaVm/JObykgJeD8Aj8=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.13.6.tgz",
+            "integrity": "sha1-GB/zHdsrU/d7tsTLRURQ3+SjKZk=",
             "requires": {
                 "@microsoft/recognizers-text-choice": "1.1.4",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
                 "@microsoft/recognizers-text-number": "1.1.4",
                 "@microsoft/recognizers-text-suite": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
-                "globalize": "^1.4.2"
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "globalize": "^1.4.2",
+                "lodash": "^4.17.21",
+                "runtypes": "~5.1.0",
+                "uuid": "^8.3.2"
             },
             "dependencies": {
                 "@microsoft/recognizers-text": {
@@ -1263,104 +1606,141 @@
                         "grapheme-splitter": "^1.0.2"
                     }
                 },
-                "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
                 }
             }
         },
-        "botbuilder-lg": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.9.2.tgz",
-            "integrity": "sha1-zesI6lBPlwJLl7wPSIYz2Ij2/0I=",
+        "botbuilder-dialogs-adaptive-runtime-core": {
+            "version": "4.13.6-preview",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.6-preview.tgz",
+            "integrity": "sha1-CyRdJareZJ4HM4CLCYOw0Cda4HA=",
             "requires": {
-                "adaptive-expressions": "4.9.2",
-                "antlr4ts": "0.5.0-alpha.1",
-                "lodash": "^4.17.11",
-                "path": "^0.12.7",
-                "uuid": "^3.3.3"
+                "dependency-graph": "^0.10.0",
+                "runtypes": "~5.1.0"
             }
         },
-        "botframework-config": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.9.2.tgz",
-            "integrity": "sha1-qFjKv/4+0ohWgtqaKetjX+SHlS4=",
+        "botbuilder-dialogs-declarative": {
+            "version": "4.13.6-preview",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-declarative/-/botbuilder-dialogs-declarative-4.13.6-preview.tgz",
+            "integrity": "sha1-hQKLi+f4wBeAB/ZhZoEKFibO3ZQ=",
             "requires": {
-                "fs-extra": "^7.0.0",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs": "4.13.6",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "chokidar": "^3.4.0"
+            }
+        },
+        "botbuilder-lg": {
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.13.6.tgz",
+            "integrity": "sha1-MZwAmM7/5ZXMX9Nblcl+ly/dG6M=",
+            "requires": {
+                "adaptive-expressions": "4.13.6",
+                "antlr4ts": "0.5.0-alpha.3",
+                "lodash": "^4.17.19",
+                "path": "^0.12.7",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "botbuilder-stdlib": {
+            "version": "4.13.6-internal",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-stdlib/-/botbuilder-stdlib-4.13.6-internal.tgz",
+            "integrity": "sha1-rzC5ufGKf4Dft5dj8LKvJgQxtP4="
+        },
+        "botframework-config": {
+            "version": "4.13.5-deprecated.dev.5bd62f8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.13.5-deprecated.dev.5bd62f8.tgz",
+            "integrity": "sha1-2gxN6SZk1lD5Nb/T3wkNW/kycCo=",
+            "requires": {
+                "fs-extra": "^7.0.1",
                 "read-text-file": "^1.1.0",
-                "uuid": "^3.3.2"
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "botframework-connector": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.9.2.tgz",
-            "integrity": "sha1-OS2NKEhrIXAm8GafphNCXeIOtNM=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.13.6.tgz",
+            "integrity": "sha1-9YmOfTqIVqYQgQ0SDGriZ3AH7kI=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
+                "@azure/ms-rest-js": "1.9.1",
                 "@types/jsonwebtoken": "7.2.8",
-                "@types/node": "^10.12.18",
-                "adal-node": "0.2.1",
+                "@types/node": "^10.17.27",
+                "adal-node": "0.2.2",
                 "base64url": "^3.0.0",
-                "botframework-schema": "4.9.2",
-                "form-data": "^2.3.3",
+                "botframework-schema": "4.13.6",
+                "cross-fetch": "^3.0.5",
                 "jsonwebtoken": "8.0.1",
-                "node-fetch": "^2.2.1",
                 "rsa-pem-from-mod-exp": "^0.8.4"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
-                        "axios": "^0.18.0",
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
                         "uuid": "^3.2.1",
                         "xml2js": "^0.4.19"
                     }
                 },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
-                },
-                "axios": {
-                    "version": "0.18.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                    "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                    "requires": {
-                        "follow-redirects": "1.5.10",
-                        "is-buffer": "^2.0.2"
-                    }
-                },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
-                },
-                "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                    "version": "10.17.60",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.60.tgz",
+                    "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
                 }
             }
         },
         "botframework-schema": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.9.2.tgz",
-            "integrity": "sha1-Lb7G+5WzRDf6QetzVN4qWjU4Oyo="
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.13.6.tgz",
+            "integrity": "sha1-Cf2dRv1AbT2zR5BKGrmeijNNumg=",
+            "requires": {
+                "botbuilder-stdlib": "4.13.6-internal"
+            }
         },
         "botframework-streaming": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.9.2.tgz",
-            "integrity": "sha1-Vg5Af11EqxKJfZcGqII8Pk2sYJ0=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.13.6.tgz",
+            "integrity": "sha1-w7rtPywGAl+equ89BlrkOZS/vuI=",
             "requires": {
+                "@types/node": "^10.17.27",
                 "@types/ws": "^6.0.3",
-                "uuid": "^3.3.2",
+                "uuid": "^8.3.2",
                 "ws": "^7.1.2"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.17.60",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.60.tgz",
+                    "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "boxen": {
@@ -1396,9 +1776,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -1419,7 +1799,6 @@
             "version": "3.0.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-3.0.2.tgz",
             "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
-            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -1435,18 +1814,23 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browserify-mime/-/browserify-mime-1.2.9.tgz",
             "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
         },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+        },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "bunyan": {
-            "version": "1.8.12",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.12.tgz",
-            "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+            "version": "1.8.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.15.tgz",
+            "integrity": "sha1-jONMqQihfQd2V2yhsvbL2RbpO0Y=",
             "requires": {
                 "dtrace-provider": "~0.8",
-                "moment": "^2.10.6",
+                "moment": "^2.19.3",
                 "mv": "~2",
                 "safe-json-stringify": "~1"
             }
@@ -1467,9 +1851,9 @@
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -1518,6 +1902,15 @@
                 }
             }
         },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/callsites/-/callsites-3.1.0.tgz",
@@ -1536,16 +1929,16 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chai": {
-            "version": "4.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.2.0.tgz",
-            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "version": "4.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.3.4.tgz",
+            "integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
             "dev": true,
             "requires": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.2",
                 "deep-eql": "^3.0.1",
                 "get-func-name": "^2.0.0",
-                "pathval": "^1.1.0",
+                "pathval": "^1.1.1",
                 "type-detect": "^4.0.5"
             }
         },
@@ -1605,19 +1998,18 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.4.0.tgz",
-            "integrity": "sha1-swYRQjzjdjV8dlubj5BLn7o8C+g=",
-            "dev": true,
+            "version": "3.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.5.2.tgz",
+            "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
             "requires": {
-                "anymatch": "~3.1.1",
+                "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
-                "glob-parent": "~5.1.0",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.4.0"
+                "readdirp": "~3.6.0"
             }
         },
         "ci-info": {
@@ -1627,14 +2019,19 @@
             "dev": true
         },
         "cldrjs": {
-            "version": "0.5.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.1.tgz",
-            "integrity": "sha1-tdxL6uAlVWNLBLlN644i4T/xAxk="
+            "version": "0.5.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.5.tgz",
+            "integrity": "sha1-XJLKLeiaihbep2yy38TgAQRCjlI="
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
         },
         "cli-boxes": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.0.tgz",
-            "integrity": "sha1-U47K6PnGylCOPDyVtFP+k8tMFo0=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.1.tgz",
+            "integrity": "sha1-3dUDXSUJT84iDpyrQKRYQKRAMY8=",
             "dev": true
         },
         "cli-cursor": {
@@ -1653,14 +2050,14 @@
             "dev": true
         },
         "cliui": {
-            "version": "6.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-6.0.0.tgz",
-            "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+            "version": "7.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
             "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^7.0.0"
             }
         },
         "clone-response": {
@@ -1740,9 +2137,9 @@
             }
         },
         "convert-source-map": {
-            "version": "1.7.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
-            "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+            "version": "1.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.8.0.tgz",
+            "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
@@ -1757,9 +2154,9 @@
             }
         },
         "copyfiles": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.3.0.tgz",
-            "integrity": "sha1-HCbrvj1Gu6LTCaP9jjqsz1OvjHY=",
+            "version": "2.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.4.1.tgz",
+            "integrity": "sha1-0tz/YKqtEBXwnQtm5/Dxxc08XaU=",
             "dev": true,
             "requires": {
                 "glob": "^7.0.5",
@@ -1767,13 +2164,14 @@
                 "mkdirp": "^1.0.4",
                 "noms": "0.0.0",
                 "through2": "^2.0.1",
-                "yargs": "^15.3.1"
+                "untildify": "^4.0.0",
+                "yargs": "^16.1.0"
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1822,10 +2220,26 @@
                 }
             }
         },
+        "cross-fetch": {
+            "version": "3.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-fetch/-/cross-fetch-3.1.4.tgz",
+            "integrity": "sha1-lyPzo6JHv4uJA586OAqSROj6Lzk=",
+            "requires": {
+                "node-fetch": "2.6.1"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+                }
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+            "dev": true,
             "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -1847,30 +2261,35 @@
             "dev": true
         },
         "csv": {
-            "version": "5.3.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-5.3.2.tgz",
-            "integrity": "sha1-ULNE4l37uMYmhKG87BjCJGiyFh4=",
+            "version": "5.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-5.5.0.tgz",
+            "integrity": "sha1-jviemsIlWQZK7fPLu5Eu1MKq+aw=",
             "requires": {
-                "csv-generate": "^3.2.4",
-                "csv-parse": "^4.8.8",
-                "csv-stringify": "^5.3.6",
-                "stream-transform": "^2.0.1"
+                "csv-generate": "^3.4.0",
+                "csv-parse": "^4.15.3",
+                "csv-stringify": "^5.6.2",
+                "stream-transform": "^2.1.0"
             }
         },
         "csv-generate": {
-            "version": "3.2.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.2.4.tgz",
-            "integrity": "sha1-RA2rkXcznuBnbJ5cFvUOKzRjwBk="
+            "version": "3.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.4.0.tgz",
+            "integrity": "sha1-Ng7XPvjscRlRWkfDvVlwrEuYjwA="
         },
         "csv-parse": {
-            "version": "4.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.10.1.tgz",
-            "integrity": "sha1-Hia6Y9KcdelNDrpunemoqvidcqY="
+            "version": "4.16.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.16.0.tgz",
+            "integrity": "sha1-tMh14oikH3/5F8sNfUWIDVYwNPY="
         },
         "csv-stringify": {
-            "version": "5.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.5.0.tgz",
-            "integrity": "sha1-C96q9g1uFbicdSoOzrS0wsivWoo="
+            "version": "5.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.6.2.tgz",
+            "integrity": "sha1-5lN4PiGJxMeX+7Eqv39JQ8eHyqk="
+        },
+        "d3-format": {
+            "version": "1.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/d3-format/-/d3-format-1.4.5.tgz",
+            "integrity": "sha1-N08roTIONxfrdKk1bGfa7hen7bQ="
         },
         "dashdash": {
             "version": "1.14.1",
@@ -1891,11 +2310,11 @@
             "integrity": "sha1-U+xBPyp7Aq++oYRtYbsmD6hWfOo="
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "version": "4.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
             "requires": {
-                "ms": "2.0.0"
+                "ms": "2.1.2"
             }
         },
         "decamelize": {
@@ -1982,28 +2401,33 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
         },
+        "dependency-graph": {
+            "version": "0.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dependency-graph/-/dependency-graph-0.10.0.tgz",
+            "integrity": "sha1-3+vjhPHzb693gr4gOnpxECpjNaY="
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "detect-node": {
-            "version": "2.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.0.4.tgz",
-            "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE="
         },
         "diagnostic-channel": {
-            "version": "0.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "version": "0.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+            "integrity": "sha1-f6oUPhB/hhvjBGU560kI+qs/U/0=",
             "requires": {
                 "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
-            "version": "0.3.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-            "integrity": "sha1-2GKlFWCQCT4NEvblno07EZ76lWM="
+            "version": "0.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
+            "integrity": "sha1-V8O4C35/V2+VvjolfV6UVQ8AgtY="
         },
         "diff": {
             "version": "3.5.0",
@@ -2051,10 +2475,43 @@
                 }
             }
         },
+        "dom-serializer": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dom-serializer/-/dom-serializer-1.3.2.tgz",
+            "integrity": "sha1-YgZDfTLO767HFhgDIwx6ILwbTZE=",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "domelementtype": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        },
+        "domhandler": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha1-+XaKXwNL5gqJonwuTQ9066DYsFk=",
+            "requires": {
+                "domelementtype": "^2.2.0"
+            }
+        },
+        "domutils": {
+            "version": "2.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domutils/-/domutils-2.7.0.tgz",
+            "integrity": "sha1-jrrwxB66/PVbC3LsMcVjI3EsVEI=",
+            "requires": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            }
+        },
         "dot-prop": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.2.0.tgz",
-            "integrity": "sha1-w07MKVVtxF8fTCJpe29JBODMT8s=",
+            "version": "5.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
             "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
@@ -2070,9 +2527,9 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY="
         },
         "duplexer3": {
             "version": "0.1.4",
@@ -2122,20 +2579,26 @@
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "encoding": {
-            "version": "0.1.12",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "version": "0.1.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
             "requires": {
-                "iconv-lite": "~0.4.13"
+                "iconv-lite": "^0.6.2"
             }
         },
         "end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
+        },
+        "entities": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -2147,22 +2610,41 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.17.5.tgz",
-            "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+            "version": "1.18.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha1-JcTDOAonqiA8RLK2hbupTaMbY+A=",
             "dev": true,
             "requires": {
+                "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
-                "object-inspect": "^1.7.0",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "dependencies": {
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "es-to-primitive": {
@@ -2186,6 +2668,12 @@
             "version": "4.2.8",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es6-promise/-/es6-promise-4.2.8.tgz",
             "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+            "dev": true
         },
         "escape-goat": {
             "version": "2.1.1",
@@ -2258,15 +2746,6 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "eslint-scope": {
                     "version": "4.0.3",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -2287,9 +2766,9 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -2299,12 +2778,6 @@
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
                 },
                 "regexpp": {
                     "version": "2.0.1",
@@ -2330,28 +2803,28 @@
             "dev": true
         },
         "eslint-scope": {
-            "version": "5.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
-            "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+            "version": "5.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
+                "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
-            "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
             "dev": true
         },
         "espree": {
@@ -2368,32 +2841,41 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "dev": true
         },
         "esquery": {
-            "version": "1.3.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esquery/-/esquery-1.3.1.tgz",
-            "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
             "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha1-N0MJ05/ZNa5QDnuS6Ka0xyDllkI=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
                     "dev": true
                 }
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -2418,26 +2900,17 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
             "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
         },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/events/-/events-3.3.0.tgz",
+            "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+        },
         "ewma": {
             "version": "2.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ewma/-/ewma-2.0.1.tgz",
             "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
             "requires": {
                 "assert-plus": "^1.0.0"
-            }
-        },
-        "execa": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
-            "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
-            "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
             }
         },
         "extend": {
@@ -2454,6 +2927,17 @@
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
                 "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
             }
         },
         "extsprintf": {
@@ -2467,9 +2951,9 @@
             "integrity": "sha1-Rvi2wisw/3qBNX1PWav66TggJUM="
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ="
+            "version": "3.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -2506,9 +2990,9 @@
             "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
         },
         "filenamify": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.1.0.tgz",
-            "integrity": "sha1-VNEQgQrnTuv+EVwbmVvQfgPPIYQ=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha1-YjkctY8CsJlxydT51js8+augMQY=",
             "requires": {
                 "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.1",
@@ -2519,7 +3003,6 @@
             "version": "7.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
-            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -2548,9 +3031,9 @@
             }
         },
         "find-my-way": {
-            "version": "2.2.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.3.tgz",
-            "integrity": "sha1-Up9ZadvR5uvtZ0p6EIfDQwmI454=",
+            "version": "2.2.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.5.tgz",
+            "integrity": "sha1-hs6CUmb6KM2WLlOKRewqqoTD1RQ=",
             "requires": {
                 "fast-decode-uri-component": "^1.0.0",
                 "safe-regex2": "^2.0.0",
@@ -2558,27 +3041,26 @@
             }
         },
         "find-up": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
             "dev": true,
             "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
+                "locate-path": "^3.0.0"
             }
         },
         "flat": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.0.tgz",
-            "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.1.tgz",
+            "integrity": "sha1-o5IFnMOCiB/5hkL12k3eCpWfMJs=",
             "requires": {
                 "is-buffer": "~2.0.3"
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                    "version": "2.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE="
                 }
             }
         },
@@ -2594,9 +3076,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -2625,12 +3107,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
-            "requires": {
-                "debug": "=3.1.0"
-            }
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha1-2RFN7Qoc/dM04WTmZirQK/2R/0M="
         },
         "foreground-child": {
             "version": "1.5.6",
@@ -2712,17 +3191,15 @@
             "dev": true
         },
         "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
-            "dev": true,
+            "version": "2.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
             "optional": true
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-            "dev": true
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -2742,13 +3219,20 @@
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
             "requires": {
-                "pump": "^3.0.0"
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
             }
+        },
+        "get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
         },
         "getpass": {
             "version": "0.1.7",
@@ -2772,29 +3256,28 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
-            "dev": true,
+            "version": "5.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
             "requires": {
                 "is-glob": "^4.0.1"
             }
         },
         "global-dirs": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-2.0.1.tgz",
-            "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-2.1.0.tgz",
+            "integrity": "sha1-6QRqScgG/wTWwYJeGWyPAJHo300=",
             "dev": true,
             "requires": {
-                "ini": "^1.3.5"
+                "ini": "1.3.7"
             }
         },
         "globalize": {
-            "version": "1.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.5.0.tgz",
-            "integrity": "sha1-w0Gd54uS0+/uDVTm2jiJNMe0WxE=",
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.6.0.tgz",
+            "integrity": "sha1-tsZZz6akf6GoJ5GHpFaJVg2FkbE=",
             "requires": {
-                "cldrjs": "^0.5.0"
+                "cldrjs": "^0.5.4"
             }
         },
         "globals": {
@@ -2820,12 +3303,23 @@
                 "p-cancelable": "^1.0.0",
                 "to-readable-stream": "^1.0.0",
                 "url-parse-lax": "^3.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
             }
         },
         "graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
+            "version": "4.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4="
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -2849,11 +3343,11 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "version": "5.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -2861,10 +3355,15 @@
             "version": "1.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has/-/has-1.0.3.tgz",
             "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
+        },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
+            "dev": true
         },
         "has-flag": {
             "version": "3.0.0",
@@ -2873,10 +3372,9 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
-            "dev": true
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
         },
         "has-yarn": {
             "version": "2.1.0",
@@ -2927,9 +3425,9 @@
             "dev": true
         },
         "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
+            "version": "2.8.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
             "dev": true
         },
         "hpack.js": {
@@ -2948,6 +3446,17 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
             "dev": true
+        },
+        "htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha1-xNditsM3GgXb5l6UrkOp+EX7j7c=",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
         },
         "http-cache-semantics": {
             "version": "4.1.0",
@@ -2978,6 +3487,16 @@
                 }
             }
         },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-signature/-/http-signature-1.2.0.tgz",
@@ -2988,29 +3507,21 @@
                 "sshpk": "^1.7.0"
             }
         },
-        "i18next": {
-            "version": "15.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.3.tgz",
-            "integrity": "sha1-8ZhMvuDjywDP+QCLA3JkKJzohAo=",
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
             "requires": {
-                "@babel/runtime": "^7.3.1"
-            }
-        },
-        "i18next-node-fs-backend": {
-            "version": "2.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
-            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
-            "requires": {
-                "js-yaml": "3.13.1",
-                "json5": "2.0.0"
+                "agent-base": "6",
+                "debug": "4"
             }
         },
         "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+            "version": "0.6.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
         },
         "ignore": {
@@ -3026,9 +3537,9 @@
             "dev": true
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -3047,6 +3558,11 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inflight/-/inflight-1.0.6.tgz",
@@ -3062,9 +3578,9 @@
             "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "version": "1.3.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.7.tgz",
+            "integrity": "sha1-oJNj4ZEZcuoW16iFEAXYTPCamoQ=",
             "dev": true
         },
         "inquirer": {
@@ -3146,10 +3662,13 @@
             "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
         },
         "is-arguments": {
-            "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arguments/-/is-arguments-1.0.4.tgz",
-            "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
-            "dev": true
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arguments/-/is-arguments-1.1.0.tgz",
+            "integrity": "sha1-YjUwMd++4HzrNGVqa95Z7+yujdk=",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0"
+            }
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -3157,13 +3676,27 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha1-/7OBRCUDI1rSReqJ5Fs9v/BA7lo=",
+            "dev": true
+        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha1-PAh48DXLghIo01DS4eNnGXFqPeg=",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
             }
         },
         "is-buffer": {
@@ -3172,9 +3705,9 @@
             "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
+            "version": "1.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha1-ix4FALc6HXbHBIdjbzaOUZ3o244=",
             "dev": true
         },
         "is-ci": {
@@ -3186,17 +3719,25 @@
                 "ci-info": "^2.0.0"
             }
         },
+        "is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha1-jp/I4VAnsBFBgCbpjw5vTYYwXME=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
         "is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha1-VQz8wDr62gXuo90wmBx7CVUfc+U=",
             "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -3208,7 +3749,6 @@
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -3223,6 +3763,12 @@
                 "is-path-inside": "^3.0.1"
             }
         },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
+            "dev": true
+        },
         "is-npm": {
             "version": "4.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-npm/-/is-npm-4.0.0.tgz",
@@ -3232,7 +3778,12 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha1-bt+u7XlQz/Ga/tzp+/yp7m3Sies=",
             "dev": true
         },
         "is-obj": {
@@ -3242,18 +3793,19 @@
             "dev": true
         },
         "is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
             "dev": true
         },
         "is-regex": {
-            "version": "1.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.0.5.tgz",
-            "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha1-0Cn5r/ZEi5Prvj8z2scVEf3L758=",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
             }
         },
         "is-stream": {
@@ -3261,13 +3813,19 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha1-P+XVmS+w2TQE8yWE1LAXmnG1Sl8=",
+            "dev": true
+        },
         "is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             }
         },
         "is-typedarray": {
@@ -3289,7 +3847,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isomorphic-fetch": {
             "version": "2.2.1",
@@ -3388,15 +3947,6 @@
                 "source-map": "^0.6.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "make-dir": {
                     "version": "2.1.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
@@ -3406,12 +3956,6 @@
                         "pify": "^4.0.1",
                         "semver": "^5.6.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
@@ -3437,13 +3981,19 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "version": "3.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "jsbi": {
+            "version": "3.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbi/-/jsbi-3.1.5.tgz",
+            "integrity": "sha1-cMKqovdeHcdgT+1FKYBhyiNyQEY="
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3501,14 +4051,6 @@
             "version": "5.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "json5": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
-            "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -3585,6 +4127,13 @@
                     "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
                     "requires": {
                         "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
                     }
                 }
             }
@@ -3652,12 +4201,13 @@
             }
         },
         "locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
             "dev": true,
             "requires": {
-                "p-locate": "^4.1.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lock": {
@@ -3666,9 +4216,9 @@
             "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+            "version": "4.17.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
         },
         "lodash.escaperegexp": {
             "version": "4.1.2",
@@ -3796,11 +4346,6 @@
                 }
             }
         },
-        "macos-release": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/macos-release/-/macos-release-2.3.0.tgz",
-            "integrity": "sha1-6xkwsDbAgArevM1fF7xMEt6Ltx8="
-        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-3.1.0.tgz",
@@ -3819,14 +4364,14 @@
             }
         },
         "md5": {
-            "version": "2.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.2.1.tgz",
-            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "version": "2.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha1-w9qaaq46MLRreww0m4exENw72k8=",
             "dev": true,
             "requires": {
-                "charenc": "~0.0.1",
-                "crypt": "~0.0.1",
-                "is-buffer": "~1.1.1"
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
             }
         },
         "md5.js": {
@@ -3856,21 +4401,21 @@
             }
         },
         "mime": {
-            "version": "2.4.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.4.6.tgz",
-            "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE="
+            "version": "2.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.5.2.tgz",
+            "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4="
         },
         "mime-db": {
-            "version": "1.44.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.44.0.tgz",
-            "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
+            "version": "1.48.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.48.0.tgz",
+            "integrity": "sha1-41sxBF3X6to6qtU37YijOvvvLR0="
         },
         "mime-types": {
-            "version": "2.1.27",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.27.tgz",
-            "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+            "version": "2.1.31",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.31.tgz",
+            "integrity": "sha1-oA12t0MXxh+cLbIhi46fjpxcnms=",
             "requires": {
-                "mime-db": "1.44.0"
+                "mime-db": "1.48.0"
             }
         },
         "mimic-fn": {
@@ -3904,9 +4449,9 @@
             "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
         },
         "mixme": {
-            "version": "0.3.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.3.5.tgz",
-            "integrity": "sha1-MEZSza8ko98EhyBeYaxhYsaQbd0="
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.5.1.tgz",
+            "integrity": "sha1-s9p5pWOy2kbvupUZgwBZ5MKp5A8="
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -4003,15 +4548,6 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "glob": {
                     "version": "7.1.3",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.3.tgz",
@@ -4032,14 +4568,14 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                "js-yaml": {
+                    "version": "3.13.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+                    "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "mkdirp": {
@@ -4055,21 +4591,6 @@
                     "version": "2.1.1",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
-                    "dev": true
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -4111,6 +4632,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",
@@ -4170,6 +4697,12 @@
                         "ms": "2.0.0"
                     }
                 },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4182,22 +4715,14 @@
             }
         },
         "moment": {
-            "version": "2.26.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.26.0.tgz",
-            "integrity": "sha1-Xh+Cxrr8pug+gIswyHBe7Q3L05o="
-        },
-        "moment-timezone": {
-            "version": "0.5.31",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment-timezone/-/moment-timezone-0.5.31.tgz",
-            "integrity": "sha1-nEDYxQJvDHq0bto9Y+ScFVFI3gU=",
-            "requires": {
-                "moment": ">= 2.9.0"
-            }
+            "version": "2.29.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "ms-rest": {
             "version": "2.5.4",
@@ -4235,9 +4760,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 },
                 "adal-node": {
                     "version": "0.1.28",
@@ -4294,9 +4819,9 @@
             }
         },
         "nan": {
-            "version": "2.14.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
+            "version": "2.14.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
             "optional": true
         },
         "natural-compare": {
@@ -4325,7 +4850,8 @@
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
         },
         "nock": {
             "version": "10.0.6",
@@ -4342,29 +4868,12 @@
                 "propagate": "^1.0.0",
                 "qs": "^6.5.1",
                 "semver": "^5.5.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
-                }
             }
         },
         "node-abort-controller": {
-            "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.0.4.tgz",
-            "integrity": "sha1-QJXkHViy+uFp0vmJKQTWA+Ecejk="
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+            "integrity": "sha1-Ht21frj+pzQZixGyiFdZbcYWVwg="
         },
         "node-environment-flags": {
             "version": "1.0.5",
@@ -4386,9 +4895,9 @@
             }
         },
         "nodemon": {
-            "version": "2.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.4.tgz",
-            "integrity": "sha1-VbCTGetIjWOUqpgYFIwMLRwExBY=",
+            "version": "2.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.7.tgz",
+            "integrity": "sha1-bwMKCg6+PqG6Kjj3G/m6tIQc7TI=",
             "dev": true,
             "requires": {
                 "chokidar": "^3.2.2",
@@ -4399,24 +4908,18 @@
                 "semver": "^5.7.1",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
-                "undefsafe": "^2.0.2",
-                "update-notifier": "^4.0.0"
+                "undefsafe": "^2.0.3",
+                "update-notifier": "^4.1.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+                    "version": "3.2.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
                 }
             }
         },
@@ -4480,22 +4983,13 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-            "dev": true
+            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
         },
         "normalize-url": {
-            "version": "4.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-url/-/normalize-url-4.5.0.tgz",
-            "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
+            "version": "4.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-url/-/normalize-url-4.5.1.tgz",
+            "integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
             "dev": true
-        },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "^2.0.0"
-            }
         },
         "nyc": {
             "version": "14.1.1",
@@ -4577,19 +5071,10 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4606,16 +5091,6 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
                 "make-dir": {
                     "version": "2.1.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
@@ -4625,21 +5100,6 @@
                         "pify": "^4.0.1",
                         "semver": "^5.6.0"
                     }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
                 },
                 "string-width": {
                     "version": "3.1.0",
@@ -4671,6 +5131,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",
@@ -4713,19 +5179,18 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
-            "dev": true
+            "version": "1.10.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha1-wqp9LQn1DJk3VwT3oK3yTFeC02k="
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha1-xdLof/nhGfeLegiEQVGeLuwVc7Y=",
+            "version": "1.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "object-keys": {
@@ -4747,13 +5212,14 @@
             }
         },
         "object.getownpropertydescriptors": {
-            "version": "2.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-            "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+            "integrity": "sha1-G9Y66s8NXS0vMbXjk7A6fGAaI/c=",
             "dev": true,
             "requires": {
+                "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
+                "es-abstract": "^1.18.0-next.2"
             }
         },
         "obuf": {
@@ -4806,15 +5272,6 @@
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
-        "os-name": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-name/-/os-name-3.1.0.tgz",
-            "integrity": "sha1-3sGdlmKW4c1i1wGlpm7h3ernCAE=",
-            "requires": {
-                "macos-release": "^2.2.0",
-                "windows-release": "^3.1.0"
-            }
-        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4827,11 +5284,6 @@
             "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
             "dev": true
         },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
         "p-limit": {
             "version": "2.3.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-limit/-/p-limit-2.3.0.tgz",
@@ -4842,12 +5294,20 @@
             }
         },
         "p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
             "dev": true,
             "requires": {
-                "p-limit": "^2.2.0"
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-map": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
+            "requires": {
+                "aggregate-error": "^3.0.0"
             }
         },
         "p-queue": {
@@ -4925,9 +5385,9 @@
             }
         },
         "path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
@@ -4944,12 +5404,13 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "version": "1.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
             "dev": true
         },
         "path-type": {
@@ -4970,9 +5431,9 @@
             }
         },
         "pathval": {
-            "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pathval/-/pathval-1.1.0.tgz",
-            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pathval/-/pathval-1.1.1.tgz",
+            "integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
             "dev": true
         },
         "performance-now": {
@@ -4981,17 +5442,16 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
-            "dev": true
+            "version": "2.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI="
         },
         "pidusage": {
-            "version": "2.0.20",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.20.tgz",
-            "integrity": "sha1-IGrZLwhsiSwBTc+5FZkJ6uwHLhg=",
+            "version": "2.0.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.21.tgz",
+            "integrity": "sha1-cGiWez2VK66nPldmjJi56qh2iU4=",
             "requires": {
-                "safe-buffer": "^5.1.2"
+                "safe-buffer": "^5.2.1"
             }
         },
         "pify": {
@@ -5007,42 +5467,6 @@
             "dev": true,
             "requires": {
                 "find-up": "^3.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
-                }
             }
         },
         "prelude-ls": {
@@ -5104,6 +5528,7 @@
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pump/-/pump-3.0.0.tgz",
             "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -5115,9 +5540,9 @@
             "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
         },
         "pupa": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.0.1.tgz",
-            "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.1.1.tgz",
+            "integrity": "sha1-9ej9SvwsXZeCj6pSNUnth0SiDWI=",
             "dev": true,
             "requires": {
                 "escape-goat": "^2.0.0"
@@ -5129,9 +5554,9 @@
             "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4="
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y="
         },
         "range-parser": {
             "version": "1.2.1",
@@ -5169,42 +5594,6 @@
             "requires": {
                 "find-up": "^3.0.0",
                 "read-pkg": "^3.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
-                }
             }
         },
         "read-text-file": {
@@ -5214,6 +5603,16 @@
             "requires": {
                 "iconv-lite": "^0.4.17",
                 "jschardet": "^1.4.2"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -5237,39 +5636,33 @@
             }
         },
         "readdirp": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.4.0.tgz",
-            "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
-            "dev": true,
+            "version": "3.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
             "requires": {
                 "picomatch": "^2.2.1"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc="
-        },
         "regexp.prototype.flags": {
-            "version": "1.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-            "integrity": "sha1-erqJs8E6ZFCdq888qNn7ub31y3U=",
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+            "integrity": "sha1-fvNSro0VnnWMDq3Kb4/LTu8HviY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "regexpp": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-3.1.0.tgz",
-            "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
+            "version": "3.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
             "dev": true
         },
         "registry-auth-token": {
-            "version": "4.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-            "integrity": "sha1-QKM74eglOUYPlDKLD38PhMFtlHk=",
+            "version": "4.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+            "integrity": "sha1-bXtABkQZGJcszV/tzUHcMix5slA=",
             "dev": true,
             "requires": {
                 "rc": "^1.2.8"
@@ -5333,19 +5726,19 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.3.tgz",
-            "integrity": "sha1-6aPAgbUTgN/qZ3M2Bh/qh5qCnuk=",
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
             "requires": {
-                "lodash": "^4.17.15"
+                "lodash": "^4.17.19"
             }
         },
         "request-promise-native": {
-            "version": "1.0.8",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.8.tgz",
-            "integrity": "sha1-pFW5YLgm5E4r+Jma9k3/K/5YyzY=",
+            "version": "1.0.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
             "requires": {
-                "request-promise-core": "1.1.3",
+                "request-promise-core": "1.1.4",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             }
@@ -5368,11 +5761,12 @@
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+            "version": "1.20.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -5421,9 +5815,12 @@
             },
             "dependencies": {
                 "qs": {
-                    "version": "6.9.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.9.4.tgz",
-                    "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
+                    "version": "6.10.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.10.1.tgz",
+                    "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 },
                 "semver": {
                     "version": "6.3.0",
@@ -5468,9 +5865,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -5494,10 +5891,15 @@
             "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
             "dev": true
         },
+        "runtypes": {
+            "version": "5.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/runtypes/-/runtypes-5.1.0.tgz",
+            "integrity": "sha1-ofJQG1yo/aR9UeoVtszKRekkqMM="
+        },
         "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
+            "version": "6.6.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.6.7.tgz",
+            "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -5601,6 +6003,11 @@
                     "version": "1.4.1",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-1.4.1.tgz",
                     "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -5619,6 +6026,7 @@
             "version": "1.2.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -5626,17 +6034,29 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shimmer": {
             "version": "1.2.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shimmer/-/shimmer-1.2.1.tgz",
             "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc="
         },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -5728,9 +6148,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+            "version": "3.0.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+            "integrity": "sha1-illRNd75WSvaaXCUdPHL7qfCRn8=",
             "dev": true
         },
         "spdy": {
@@ -5743,21 +6163,6 @@
                 "http-deceiver": "^1.2.7",
                 "select-hose": "^2.0.0",
                 "spdy-transport": "^3.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-                }
             }
         },
         "spdy-transport": {
@@ -5773,23 +6178,10 @@
                 "wbuf": "^1.7.3"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "inherits": {
                     "version": "2.0.4",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.4.tgz",
                     "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
                 },
                 "readable-stream": {
                     "version": "3.6.0",
@@ -5806,7 +6198,8 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "sshpk": {
             "version": "1.16.1",
@@ -5840,17 +6233,17 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
         },
         "stream-transform": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.0.2.tgz",
-            "integrity": "sha1-PLehTIAus5vEDKqrBTXlhPOmXK8=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.1.0.tgz",
+            "integrity": "sha1-5ozAYsztW47maa6X9L5HPu5dkic=",
             "requires": {
-                "mixme": "^0.3.1"
+                "mixme": "^0.5.0"
             }
         },
         "string-width": {
-            "version": "4.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-4.2.0.tgz",
-            "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
             "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
@@ -5859,45 +6252,23 @@
             }
         },
         "string.prototype.trimend": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-            "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
-            }
-        },
-        "string.prototype.trimleft": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-            "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimstart": "^1.0.0"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-            "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimend": "^1.0.0"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-            "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "string_decoder": {
@@ -5922,11 +6293,6 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
-        },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
             "version": "2.0.1",
@@ -6004,9 +6370,9 @@
             }
         },
         "term-size": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.0.tgz",
-            "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.1.tgz",
+            "integrity": "sha1-KmpUhAQywvtjIP6g9BVTHpAYn1Q=",
             "dev": true
         },
         "test-exclude": {
@@ -6022,9 +6388,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -6127,7 +6493,6 @@
             "version": "5.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -6159,14 +6524,14 @@
             }
         },
         "tslib": {
-            "version": "1.13.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.13.0.tgz",
-            "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
         },
         "tsutils": {
-            "version": "3.17.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-3.17.1.tgz",
-            "integrity": "sha1-7XGZF/EcoN7lhicrKsSeAVot11k=",
+            "version": "3.21.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=",
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
@@ -6221,10 +6586,22 @@
             }
         },
         "typescript": {
-            "version": "3.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.9.3.tgz",
-            "integrity": "sha1-06yIg6l8JhOeQt9ek+7s4z1hC4o=",
+            "version": "3.9.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.9.10.tgz",
+            "integrity": "sha1-cPORCselHta+952ngAaQsZv3eLg=",
             "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha1-CF4hViXsMWJXTciFmr7nilmxRHE=",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
         },
         "undefsafe": {
             "version": "2.0.3",
@@ -6243,13 +6620,19 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "underscore": {
-            "version": "1.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.10.2.tgz",
-            "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8="
+            "version": "1.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.13.1.tgz",
+            "integrity": "sha1-DBxr0t9UtrafIxQGbWW2zeb8+dE="
         },
         "unique-string": {
             "version": "2.0.0",
@@ -6260,15 +6643,26 @@
                 "crypto-random-string": "^2.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4="
+        },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
         },
+        "untildify": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs=",
+            "dev": true
+        },
         "update-notifier": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.0.tgz",
-            "integrity": "sha1-SGa5jDvFtUc8AgsSUFg2KPmjKPM=",
+            "version": "4.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.3.tgz",
+            "integrity": "sha1-vobuE+jOSPtQBD/3IFe1vVmOHqM=",
             "dev": true,
             "requires": {
                 "boxen": "^4.2.0",
@@ -6303,9 +6697,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -6314,17 +6708,17 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "version": "4.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
             "requires": {
                 "punycode": "^2.1.0"
             }
         },
         "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+            "version": "1.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha1-1fqYkK+KXh8nSiyYN2UQ9kJfbjs=",
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -6404,16 +6798,30 @@
             }
         },
         "whatwg-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-            "integrity": "sha1-/IBORYzEYACbGiuWa8iBfSV4rvs="
+            "version": "3.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+            "integrity": "sha1-3O0k838mJO0CgXJdUdDi4/5nf4w="
         },
         "which": {
             "version": "1.3.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which/-/which-1.3.1.tgz",
             "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
             }
         },
         "which-module": {
@@ -6473,14 +6881,6 @@
                 "string-width": "^4.0.0"
             }
         },
-        "windows-release": {
-            "version": "3.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/windows-release/-/windows-release-3.3.0.tgz",
-            "integrity": "sha1-3OFn6fi+cz8hyEnr1NA/5mspufA=",
-            "requires": {
-                "execa": "^1.0.0"
-            }
-        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6488,9 +6888,9 @@
             "dev": true
         },
         "wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
@@ -6525,9 +6925,24 @@
             }
         },
         "ws": {
-            "version": "7.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.3.0.tgz",
-            "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0="
+            "version": "7.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.5.0.tgz",
+            "integrity": "sha1-ADO6/qAx+53wQbICb8cqVxykRpE="
+        },
+        "x2js": {
+            "version": "3.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/x2js/-/x2js-3.4.1.tgz",
+            "integrity": "sha1-ni8rnUGB7VBKWQcRDcNg6YKdHO4=",
+            "requires": {
+                "xmldom": "^0.5.0"
+            },
+            "dependencies": {
+                "xmldom": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.5.0.tgz",
+                    "integrity": "sha1-GTy5a4SqNIYSfqYnLEWWNUy0li4="
+                }
+            }
         },
         "xdg-basedir": {
             "version": "4.0.0",
@@ -6564,9 +6979,14 @@
             "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
         },
         "xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha1-5iVFf0MAtd+cLh7Ld2FH7OR/Plo="
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.6.0.tgz",
+            "integrity": "sha1-Q6luy4vuzpkc7zgsCDl9gtTQxG8="
+        },
+        "xpath": {
+            "version": "0.0.32",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xpath/-/xpath-0.0.32.tgz",
+            "integrity": "sha1-G3PTNRr3NuF+wHjW2kuBdUBcSK8="
         },
         "xpath.js": {
             "version": "1.1.0",
@@ -6579,9 +6999,9 @@
             "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "version": "5.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
             "dev": true
         },
         "yallist": {
@@ -6590,33 +7010,25 @@
             "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
         },
         "yargs": {
-            "version": "15.3.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-15.3.1.tgz",
-            "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
+            "version": "16.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
             "dev": true,
             "requires": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
                 "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.1"
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
             }
         },
         "yargs-parser": {
-            "version": "18.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
-            "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-            }
+            "version": "20.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+            "dev": true
         },
         "yargs-unparser": {
             "version": "1.6.0",
@@ -6676,44 +7088,10 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -6746,6 +7124,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",

--- a/templates/typescript/samples/sample-skill/package-lock.json
+++ b/templates/typescript/samples/sample-skill/package-lock.json
@@ -4,6 +4,21 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@azure/abort-controller": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/abort-controller/-/@azure/abort-controller-1.0.4.tgz",
+            "integrity": "sha1-/TxNRsjtZ6rOQkmMjiJwlgJQ6v0=",
+            "requires": {
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
         "@azure/cognitiveservices-luis-authoring": {
             "version": "2.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cognitiveservices-luis-authoring/-/@azure/cognitiveservices-luis-authoring-2.1.0.tgz",
@@ -22,45 +37,223 @@
                 "tslib": "^1.9.3"
             }
         },
-        "@azure/cosmos": {
-            "version": "3.6.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.6.3.tgz",
-            "integrity": "sha1-u1O941+/M4FgaR0ramL0e0qaHLs=",
+        "@azure/core-asynciterator-polyfill": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-asynciterator-polyfill/-/@azure/core-asynciterator-polyfill-1.0.0.tgz",
+            "integrity": "sha1-3MzruIQG5cduDh1S6MxMQ6aLPuc="
+        },
+        "@azure/core-auth": {
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-auth/-/@azure/core-auth-1.3.0.tgz",
+            "integrity": "sha1-DVVRfPBlCu/nVWaayoovNyT89TY=",
             "requires": {
-                "@types/debug": "^4.1.4",
-                "debug": "^4.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "node-abort-controller": "^1.0.4",
-                "node-fetch": "^2.6.0",
-                "os-name": "^3.1.0",
-                "priorityqueuejs": "^1.0.0",
-                "semaphore": "^1.0.5",
-                "tslib": "^1.10.0",
-                "uuid": "^3.3.2"
+                "@azure/abort-controller": "^1.0.0",
+                "tslib": "^2.0.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/core-http": {
+            "version": "1.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-http/-/@azure/core-http-1.2.6.tgz",
+            "integrity": "sha1-nNUIQYVy0gYv0xdSdCGUOHcr22U=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-asynciterator-polyfill": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "@types/node-fetch": "^2.5.0",
+                "@types/tunnel": "^0.0.1",
+                "form-data": "^3.0.0",
+                "node-fetch": "^2.6.0",
+                "process": "^0.11.10",
+                "tough-cookie": "^4.0.0",
+                "tslib": "^2.2.0",
+                "tunnel": "^0.0.6",
+                "uuid": "^8.3.0",
+                "xml2js": "^0.4.19"
+            },
+            "dependencies": {
+                "@types/tunnel": {
+                    "version": "0.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/tunnel/-/@types/tunnel-0.0.1.tgz",
+                    "integrity": "sha1-DXJ3R2i3PfJvJd+RhCc6QtpysZw=",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "@types/node": "*"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+                    "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+                    "requires": {
+                        "psl": "^1.1.33",
+                        "punycode": "^2.1.1",
+                        "universalify": "^0.1.2"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/core-lro": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-lro/-/@azure/core-lro-1.0.5.tgz",
+            "integrity": "sha1-hWostqm+xznunN4zonzCj4GsBSI=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-http": "^1.2.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "events": "^3.0.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/core-paging": {
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-paging/-/@azure/core-paging-1.1.3.tgz",
+            "integrity": "sha1-NYfJiYoFMMrLZLqyFtcxhGiqXvw=",
+            "requires": {
+                "@azure/core-asynciterator-polyfill": "^1.0.0"
+            }
+        },
+        "@azure/core-rest-pipeline": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-rest-pipeline/-/@azure/core-rest-pipeline-1.0.4.tgz",
+            "integrity": "sha1-+bVb+ljg2dLkupCSvth0kG04Cig=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "form-data": "^3.0.0",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "tslib": "^2.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/core-tracing": {
+            "version": "1.0.0-preview.11",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/core-tracing/-/@azure/core-tracing-1.0.0-preview.11.tgz",
+            "integrity": "sha1-vfsrpzzWw5t9bCB7lSLrmOCLTd0=",
+            "requires": {
+                "@opencensus/web-types": "0.0.7",
+                "@opentelemetry/api": "1.0.0-rc.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
+        "@azure/cosmos": {
+            "version": "3.11.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.11.5.tgz",
+            "integrity": "sha1-Kk4LWgjtcQ9jCZkWjIy5NJRJuGI=",
+            "requires": {
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-rest-pipeline": "^1.0.3",
+                "debug": "^4.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "jsbi": "^3.1.3",
+                "node-abort-controller": "^1.2.0",
+                "priorityqueuejs": "^1.0.0",
+                "semaphore": "^1.0.5",
+                "tslib": "^2.0.0",
+                "universal-user-agent": "^6.0.0",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "@azure/logger": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/logger/-/@azure/logger-1.0.2.tgz",
+            "integrity": "sha1-rS0GR47tp4NfU9735FZpgbR9l4c=",
+            "requires": {
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
                 }
             }
         },
         "@azure/ms-rest-js": {
-            "version": "1.8.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.15.tgz",
-            "integrity": "sha1-Qme2uMANhTAXkf4M80fgRVqAczg=",
+            "version": "1.11.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.11.2.tgz",
+            "integrity": "sha1-6D1RKxAsMCQl2l/wOm12rfKqSuY=",
             "requires": {
-                "@types/tunnel": "0.0.0",
-                "axios": "^0.19.0",
+                "@azure/core-auth": "^1.1.4",
+                "axios": "^0.21.1",
                 "form-data": "^2.3.2",
                 "tough-cookie": "^2.4.3",
                 "tslib": "^1.9.2",
@@ -69,140 +262,144 @@
                 "xml2js": "^0.4.19"
             }
         },
+        "@azure/storage-blob": {
+            "version": "12.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/storage-blob/-/@azure/storage-blob-12.6.0.tgz",
+            "integrity": "sha1-mQXYDl+Qilc8xl4cuDAqvDKBiEQ=",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-http": "^1.2.0",
+                "@azure/core-lro": "^1.0.2",
+                "@azure/core-paging": "^1.1.1",
+                "@azure/core-tracing": "1.0.0-preview.11",
+                "@azure/logger": "^1.0.0",
+                "events": "^3.0.0",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.3.0.tgz",
+                    "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+                }
+            }
+        },
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.10.1.tgz",
-            "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.14.5.tgz",
+            "integrity": "sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.14.5"
             }
         },
         "@babel/generator": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.10.2.tgz",
-            "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.14.5.tgz",
+            "integrity": "sha1-hI17nwMcrKnQzQrwGwY/Im9S14U=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.2",
+                "@babel/types": "^7.14.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.10.1.tgz",
-            "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.14.5.tgz",
+            "integrity": "sha1-ieLEdJcvFdjiM7Uu6MSA4s/NUMQ=",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-get-function-arity": "^7.14.5",
+                "@babel/template": "^7.14.5",
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.10.1.tgz",
-            "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.14.5.tgz",
+            "integrity": "sha1-Jfv6V5sJN+7h87gF7OTOOYxDGBU=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.14.5"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-hoist-variables/-/@babel/helper-hoist-variables-7.14.5.tgz",
+            "integrity": "sha1-4N0nwzp45XfXyIhJFqPn7x98f40=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.10.1.tgz",
-            "integrity": "sha1-xvS+HLwV46ho5MZKF9XTHXVNo18=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.14.5.tgz",
+            "integrity": "sha1-IrI6VO9RwrdgXYUZMMGXbdC8aTo=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.14.5.tgz",
+            "integrity": "sha1-0PDid8US4Mk4J3+qhaOWjJpEwOg=",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.10.1.tgz",
-            "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.14.5.tgz",
+            "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.10.2.tgz",
-            "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
+            "version": "7.14.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.14.7.tgz",
+            "integrity": "sha1-YJlyDIg5yoZaJjfmyFhS6tC9tZU=",
             "dev": true
         },
-        "@babel/runtime": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.10.2.tgz",
-            "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
         "@babel/template": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.10.1.tgz",
-            "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.14.5.tgz",
+            "integrity": "sha1-qbydizM1T/blWpxg0RCSAKaJdPQ=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/code-frame": "^7.14.5",
+                "@babel/parser": "^7.14.5",
+                "@babel/types": "^7.14.5"
             }
         },
         "@babel/traverse": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.10.1.tgz",
-            "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
+            "version": "7.14.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.14.7.tgz",
+            "integrity": "sha1-ZAB8l3TP3Dq9I7B4C8GKPONjF1M=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.1",
-                "@babel/helper-function-name": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/code-frame": "^7.14.5",
+                "@babel/generator": "^7.14.5",
+                "@babel/helper-function-name": "^7.14.5",
+                "@babel/helper-hoist-variables": "^7.14.5",
+                "@babel/helper-split-export-declaration": "^7.14.5",
+                "@babel/parser": "^7.14.7",
+                "@babel/types": "^7.14.5",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
-                }
+                "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.10.2.tgz",
-            "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
+            "version": "7.14.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.14.5.tgz",
+            "integrity": "sha1-O7mXuoKaIQTO2yBonEpbgSHTg/8=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -221,9 +418,9 @@
             }
         },
         "@microsoft/recognizers-text-data-types-timex-expression": {
-            "version": "1.1.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-data-types-timex-expression/-/@microsoft/recognizers-text-data-types-timex-expression-1.1.4.tgz",
-            "integrity": "sha1-YjRTrmXo3yEtgVb2oxRnXDBpbB0="
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/recognizers-text-data-types-timex-expression/-/@microsoft/recognizers-text-data-types-timex-expression-1.3.0.tgz",
+            "integrity": "sha1-/F1YbIJuR46Ed7f8sh6eKDDoHGc="
         },
         "@microsoft/recognizers-text-date-time": {
             "version": "1.1.4",
@@ -339,10 +536,20 @@
             "dependencies": {
                 "extsprintf": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.4.0.tgz",
                     "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
                 }
             }
+        },
+        "@opencensus/web-types": {
+            "version": "0.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@opencensus/web-types/-/@opencensus/web-types-0.0.7.tgz",
+            "integrity": "sha1-RCbeH+Wqj2JNs5XSFSuQKHTwVwo="
+        },
+        "@opentelemetry/api": {
+            "version": "1.0.0-rc.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@opentelemetry/api/-/@opentelemetry/api-1.0.0-rc.0.tgz",
+            "integrity": "sha1-DHw/XhKF+ZzttWPXStGtuYIrUUQ="
         },
         "@sindresorhus/is": {
             "version": "0.14.0",
@@ -359,10 +566,15 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
-        "@types/atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob/-/@types/atob-2.1.2.tgz",
-            "integrity": "sha1-FX6wzEYmSoxV8ic6g2x6GmRPuCA="
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@tootallnate/once/-/@tootallnate/once-1.1.2.tgz",
+            "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
+        },
+        "@types/atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob-lite/-/@types/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM="
         },
         "@types/body-parser": {
             "version": "1.19.0",
@@ -373,6 +585,11 @@
                 "@types/node": "*"
             }
         },
+        "@types/btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/btoa-lite/-/@types/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-4ZClpUjgs0itsN+ax/pfEVHHzKQ="
+        },
         "@types/bunyan": {
             "version": "1.8.6",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/bunyan/-/@types/bunyan-1.8.6.tgz",
@@ -382,29 +599,18 @@
                 "@types/node": "*"
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/color-name/-/@types/color-name-1.1.1.tgz",
-            "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
-            "dev": true
-        },
         "@types/connect": {
-            "version": "3.4.33",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.33.tgz",
-            "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
+            "version": "3.4.34",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.34.tgz",
+            "integrity": "sha1-FwpAIjptZmAG2TyhKK8r6x2bGQE=",
             "requires": {
                 "@types/node": "*"
             }
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/debug/-/@types/debug-4.1.5.tgz",
-            "integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0="
-        },
         "@types/documentdb": {
-            "version": "1.10.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.6.tgz",
-            "integrity": "sha1-FWwV1yDmhx3gY3HJbZPHtX7htic=",
+            "version": "1.10.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.8.tgz",
+            "integrity": "sha1-zyAI+KSUSrvZcfKsHbuBq/LZL5I=",
             "requires": {
                 "@types/node": "*"
             }
@@ -415,26 +621,20 @@
             "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0=",
             "dev": true
         },
-        "@types/events": {
-            "version": "3.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/events/-/@types/events-3.0.0.tgz",
-            "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
-            "dev": true
-        },
         "@types/express": {
-            "version": "4.17.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.6.tgz",
-            "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
+            "version": "4.17.12",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.12.tgz",
+            "integrity": "sha1-S8G/PNDP5tP28oU2SLQNt9VN41A=",
             "requires": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "*",
+                "@types/express-serve-static-core": "^4.17.18",
                 "@types/qs": "*",
                 "@types/serve-static": "*"
             }
         },
         "@types/express-jwt": {
             "version": "0.0.34",
-            "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.34.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-jwt/-/@types/express-jwt-0.0.34.tgz",
             "integrity": "sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=",
             "requires": {
                 "@types/express": "*",
@@ -442,9 +642,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.7.tgz",
-            "integrity": "sha1-3+Yfhw61SdxtfhIFCQGEfH1+kVs=",
+            "version": "4.17.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.21.tgz",
+            "integrity": "sha1-pCcnjhBryne4OthSIernCaNBTUI=",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -460,19 +660,18 @@
             }
         },
         "@types/formidable": {
-            "version": "1.0.31",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/formidable/-/@types/formidable-1.0.31.tgz",
-            "integrity": "sha1-J0+dwtChqc4f7vSMJMoIWefslHs=",
+            "version": "1.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/formidable/-/@types/formidable-1.2.2.tgz",
+            "integrity": "sha1-5pDWBzLunT8KRBvFcsF0CXhbKDw=",
             "dev": true,
             "requires": {
-                "@types/events": "*",
                 "@types/node": "*"
             }
         },
         "@types/json-schema": {
-            "version": "7.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.4.tgz",
-            "integrity": "sha1-OP1z3f2bVaux4bLtV4y1W9e30zk=",
+            "version": "7.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.7.tgz",
+            "integrity": "sha1-mKmTUWyFnrDVxMjwmDF6nqaNua0=",
             "dev": true
         },
         "@types/jsonwebtoken": {
@@ -489,27 +688,40 @@
             "integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM="
         },
         "@types/mime": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.2.tgz",
-            "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU="
-        },
-        "@types/moment-timezone": {
-            "version": "0.5.13",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/moment-timezone/-/@types/moment-timezone-0.5.13.tgz",
-            "integrity": "sha1-AxfMyR60x/SQFwQWYWY5XDknZSg=",
-            "requires": {
-                "moment": ">=2.14.0"
-            }
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-1.3.2.tgz",
+            "integrity": "sha1-k+Jb+e51/g/YC1lLxP6w6GIRG1o="
         },
         "@types/node": {
-            "version": "10.17.24",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-            "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+            "version": "10.17.60",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.60.tgz",
+            "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+        },
+        "@types/node-fetch": {
+            "version": "2.5.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node-fetch/-/@types/node-fetch-2.5.10.tgz",
+            "integrity": "sha1-m01KBCVWL5/OpwsSyz/N2UbKgTI=",
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
+            }
         },
         "@types/qs": {
-            "version": "6.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.3.tgz",
-            "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM="
+            "version": "6.9.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.6.tgz",
+            "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E="
         },
         "@types/range-parser": {
             "version": "1.2.3",
@@ -517,9 +729,9 @@
             "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
         },
         "@types/restify": {
-            "version": "8.4.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-8.4.2.tgz",
-            "integrity": "sha1-8HHZcdEK159gc9+77tdynWh2Dn8=",
+            "version": "8.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/restify/-/@types/restify-8.5.1.tgz",
+            "integrity": "sha1-eQltaUhpVr6DpA+wZjIyVfIKQk8=",
             "dev": true,
             "requires": {
                 "@types/bunyan": "*",
@@ -529,12 +741,12 @@
             }
         },
         "@types/serve-static": {
-            "version": "1.13.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.4.tgz",
-            "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
+            "version": "1.13.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.9.tgz",
+            "integrity": "sha1-qs8oqFoF7imhH7fD6tk1rFbzPk4=",
             "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
+                "@types/mime": "^1",
+                "@types/node": "*"
             }
         },
         "@types/spdy": {
@@ -555,9 +767,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.0.9",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-14.0.9.tgz",
-                    "integrity": "sha1-Q4lquH/IK9od/WAM30SgyKZOEdI="
+                    "version": "15.12.4",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-15.12.4.tgz",
+                    "integrity": "sha1-4c+BfXCh4RjoGSLE/2aDzp1CLiY="
                 }
             }
         },
@@ -570,9 +782,9 @@
             }
         },
         "@types/xmldom": {
-            "version": "0.1.29",
-            "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.29.tgz",
-            "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E="
+            "version": "0.1.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/xmldom/-/@types/xmldom-0.1.30.tgz",
+            "integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "2.34.0",
@@ -625,19 +837,10 @@
                 "tsutils": "^3.17.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -648,16 +851,28 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
                 },
                 "semver": {
-                    "version": "7.3.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-7.3.2.tgz",
-                    "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+                    "version": "7.3.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
                     "dev": true
                 }
             }
@@ -669,27 +884,27 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.4.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.4.1.tgz",
-            "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
+            "version": "6.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-            "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+            "version": "5.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
             "dev": true
         },
         "adal-node": {
-            "version": "0.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.2.1.tgz",
-            "integrity": "sha1-GeQBvVeZd0SMGnfODltMmszcM04=",
+            "version": "0.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.2.2.tgz",
+            "integrity": "sha1-lfbM4PtsUI8bvNZ3t2SyFyxOjDs=",
             "requires": {
                 "@types/node": "^8.0.47",
                 "async": "^2.6.3",
+                "axios": "^0.21.1",
                 "date-utils": "*",
                 "jws": "3.x.x",
-                "request": "^2.88.0",
                 "underscore": ">= 1.3.1",
                 "uuid": "^3.1.0",
                 "xmldom": ">= 0.1.x",
@@ -697,30 +912,52 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 }
             }
         },
         "adaptive-expressions": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.9.2.tgz",
-            "integrity": "sha1-Cj0ng3DTAQiHACEKAmZ33sY8WfY=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.13.6.tgz",
+            "integrity": "sha1-GbYjcO/SDZRfJ0ext0Ig142syPs=",
             "requires": {
-                "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-                "@types/atob": "^2.1.2",
+                "@microsoft/recognizers-text-data-types-timex-expression": "1.3.0",
+                "@types/atob-lite": "^2.0.0",
+                "@types/btoa-lite": "^1.0.0",
                 "@types/lru-cache": "^5.1.0",
-                "@types/moment-timezone": "^0.5.12",
-                "@types/xmldom": "^0.1.29",
-                "antlr4ts": "0.5.0-alpha.1",
-                "atob": "^2.1.2",
+                "@types/xmldom": "^0.1.30",
+                "antlr4ts": "0.5.0-alpha.3",
+                "atob-lite": "^2.0.0",
                 "big-integer": "^1.6.48",
+                "btoa-lite": "^1.0.0",
+                "d3-format": "^1.4.4",
+                "dayjs": "^1.10.3",
                 "jspath": "^0.4.0",
-                "lodash": "^4.17.15",
                 "lru-cache": "^5.1.1",
-                "moment": "^2.25.1",
-                "moment-timezone": "^0.5.28"
+                "uuid": "^8.3.2",
+                "x2js": "^3.4.0",
+                "xml2js": "^0.4.23",
+                "xmldom": "^0.5.0",
+                "xpath": "^0.0.32"
+            },
+            "dependencies": {
+                "dayjs": {
+                    "version": "1.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dayjs/-/dayjs-1.10.5.tgz",
+                    "integrity": "sha1-VgDfRUj8JFOz8WPrsqu+llzPuYY="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                },
+                "xmldom": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.5.0.tgz",
+                    "integrity": "sha1-GTy5a4SqNIYSfqYnLEWWNUy0li4="
+                }
             }
         },
         "adaptivecards": {
@@ -728,10 +965,27 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptivecards/-/adaptivecards-1.2.6.tgz",
             "integrity": "sha1-K+H3FFaT29Y+nxthKNUsMn//a4Q="
         },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+            "requires": {
+                "debug": "4"
+            }
+        },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
         "ajv": {
-            "version": "6.12.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.2.tgz",
-            "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
+            "version": "6.12.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -807,25 +1061,23 @@
             "dev": true
         },
         "ansi-styles": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-            "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
             "dev": true,
             "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
             }
         },
         "antlr4ts": {
-            "version": "0.5.0-alpha.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.1.tgz",
-            "integrity": "sha1-xCHYJpUjNWxCxVM2A67AQQtCOAY="
+            "version": "0.5.0-alpha.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+            "integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y="
         },
         "anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
-            "dev": true,
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -841,19 +1093,19 @@
             }
         },
         "applicationinsights": {
-            "version": "1.7.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.7.5.tgz",
-            "integrity": "sha1-Qj2bWM0gEX1yS4aBGTXendq4uFI=",
+            "version": "1.8.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.8.10.tgz",
+            "integrity": "sha1-//pILNFRmID7iIU2qHCBrAUTBmc=",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.4"
+                "diagnostic-channel": "0.3.1",
+                "diagnostic-channel-publishers": "0.4.4"
             }
         },
         "archy": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/archy/-/archy-1.0.0.tgz",
             "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
             "dev": true
         },
@@ -861,6 +1113,7 @@
             "version": "1.0.10",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -884,7 +1137,7 @@
         },
         "assert-plus": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "assertion-error": {
@@ -926,30 +1179,30 @@
         },
         "asynckit": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+        "atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob-lite/-/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
         },
         "aws-sign2": {
             "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI="
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+            "version": "0.21.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha1-IlY0gZYvTWvemnbVFu8OXTwJsrg=",
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
             }
         },
         "azure-cognitiveservices-contentmoderator": {
@@ -980,17 +1233,17 @@
             "dependencies": {
                 "sax": {
                     "version": "0.5.8",
-                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sax/-/sax-0.5.8.tgz",
                     "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
                 },
                 "underscore": {
                     "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.8.3.tgz",
                     "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 },
                 "xml2js": {
                     "version": "0.2.8",
-                    "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml2js/-/xml2js-0.2.8.tgz",
                     "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
                     "requires": {
                         "sax": "0.5.x"
@@ -998,15 +1251,15 @@
                 },
                 "xmlbuilder": {
                     "version": "9.0.7",
-                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
                     "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
                 }
             }
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
         },
         "base64url": {
             "version": "3.0.1",
@@ -1015,7 +1268,7 @@
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
                 "tweetnacl": "^0.14.3"
@@ -1032,37 +1285,37 @@
             "integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
         },
         "binary-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
-            "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
-            "dev": true
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0="
         },
         "binary-search-bounds": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
             "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
         },
         "bot-solutions": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.0.0.tgz",
-            "integrity": "sha1-P1LISJL7sl+v6xbSqkiZmDER0tI=",
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.1.0.tgz",
+            "integrity": "sha1-bSF6Izy6EXFl1ztqsY2boN+UERc=",
             "requires": {
                 "@azure/cognitiveservices-luis-authoring": "^2.1.0",
+                "@azure/cosmos": "^3.11.3",
                 "@microsoft/recognizers-text": "^1.1.4",
                 "@microsoft/recognizers-text-choice": "^1.1.4",
                 "@types/lru-cache": "^5.1.0",
                 "adaptivecards": "^1.1.3",
                 "azure-cognitiveservices-contentmoderator": "^4.0.0",
-                "botbuilder": "^4.9.0",
-                "botbuilder-ai": "^4.9.0",
-                "botbuilder-azure": "^4.9.0",
-                "botbuilder-dialogs": "^4.9.0",
-                "botbuilder-lg": "^4.9.0",
-                "botframework-config": "^4.9.0",
-                "botframework-connector": "^4.9.0",
+                "botbuilder": "^4.13.5",
+                "botbuilder-ai": "^4.13.5",
+                "botbuilder-azure-blobs": "^4.13.5-preview",
+                "botbuilder-core": "^4.13.5",
+                "botbuilder-dialogs": "^4.13.5",
+                "botbuilder-lg": "^4.13.5",
+                "botframework-config": "^4.13.5-deprecated",
+                "botframework-connector": "^4.13.5",
+                "botframework-schema": "^4.13.5",
                 "dayjs": "1.8.17",
-                "i18next": "^15.0.6",
-                "i18next-node-fs-backend": "^2.1.1",
                 "jwks-rsa": "1.5.0",
                 "ms-rest-azure": "^2.5.0",
                 "p-queue": "^4.0.0",
@@ -1072,75 +1325,84 @@
             }
         },
         "botbuilder": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.9.2.tgz",
-            "integrity": "sha1-IObPpq0pndzey6Z39RXtdbVenGA=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.13.6.tgz",
+            "integrity": "sha1-gNBwzCGGSPKWWNRYRNd5Zc1r4gE=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
-                "@types/node": "^10.12.18",
-                "axios": "^0.19.0",
-                "botbuilder-core": "4.9.2",
-                "botframework-connector": "4.9.2",
-                "botframework-streaming": "4.9.2",
+                "@azure/ms-rest-js": "1.9.1",
+                "axios": "^0.21.1",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "botframework-streaming": "4.13.6",
+                "dayjs": "^1.10.3",
                 "filenamify": "^4.1.0",
                 "fs-extra": "^7.0.1",
-                "moment-timezone": "^0.5.28"
+                "htmlparser2": "^6.0.1",
+                "uuid": "^8.3.2"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
-                        "axios": "^0.18.0",
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
                         "uuid": "^3.2.1",
                         "xml2js": "^0.4.19"
                     },
                     "dependencies": {
-                        "axios": {
-                            "version": "0.18.1",
-                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                            "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                            "requires": {
-                                "follow-redirects": "1.5.10",
-                                "is-buffer": "^2.0.2"
-                            }
+                        "uuid": {
+                            "version": "3.4.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.4.0.tgz",
+                            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
                         }
                     }
                 },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                "dayjs": {
+                    "version": "1.10.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dayjs/-/dayjs-1.10.5.tgz",
+                    "integrity": "sha1-VgDfRUj8JFOz8WPrsqu+llzPuYY="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
                 }
             }
         },
         "botbuilder-ai": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.9.2.tgz",
-            "integrity": "sha1-08UhW2Aw8c81U4fSLCiZWP22Hxk=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.13.6.tgz",
+            "integrity": "sha1-DDwHJlq/hYdgUMYJ98RMl0GqQ84=",
             "requires": {
                 "@azure/cognitiveservices-luis-runtime": "2.0.0",
-                "@azure/ms-rest-js": "1.8.13",
+                "@azure/ms-rest-js": "1.9.1",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
-                "botbuilder-dialogs": "4.9.2",
-                "moment": "^2.25.1",
-                "node-fetch": "^2.3.0",
-                "url-parse": "^1.4.4"
+                "adaptive-expressions": "4.13.6",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-dialogs-declarative": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "lodash": "^4.17.21",
+                "node-fetch": "^2.6.0",
+                "url-parse": "^1.5.1"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.8.13",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.13.tgz",
-                    "integrity": "sha1-7QzYZGlpc3jNOdedVYnod6O8h6Y=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
                         "@types/tunnel": "0.0.0",
-                        "axios": "^0.19.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
@@ -1152,51 +1414,159 @@
             }
         },
         "botbuilder-applicationinsights": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.9.2.tgz",
-            "integrity": "sha1-FO/SCLrE8hK64mMJQdoqkHquPo0=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.13.6.tgz",
+            "integrity": "sha1-b+EmGtKcMFSc9iV8rOTxkZ3zqK8=",
             "requires": {
-                "applicationinsights": "1.7.5",
-                "botbuilder-core": "4.9.2",
+                "applicationinsights": "^1.7.5",
+                "botbuilder-core": "4.13.6",
                 "cls-hooked": "^4.2.2"
             }
         },
         "botbuilder-azure": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.9.2.tgz",
-            "integrity": "sha1-eNahVxGxk2UTQgibEqmsyhX2rJ8=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.13.6.tgz",
+            "integrity": "sha1-jmDB5bNaRFypg0H+J4Lfwod1Jlg=",
             "requires": {
                 "@azure/cosmos": "^3.3.1",
                 "@types/documentdb": "^1.10.5",
-                "@types/node": "^10.12.18",
                 "azure-storage": "2.10.2",
-                "botbuilder": "4.9.2",
+                "botbuilder": "4.13.6",
                 "documentdb": "1.14.5",
                 "flat": "^4.0.0",
                 "semaphore": "^1.1.0"
             }
         },
+        "botbuilder-azure-blobs": {
+            "version": "4.13.5-preview.dev.5bd62f8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure-blobs/-/botbuilder-azure-blobs-4.13.5-preview.dev.5bd62f8.tgz",
+            "integrity": "sha1-0fRzplEjF1bNhBFYkAAdq7j68X4=",
+            "requires": {
+                "@azure/storage-blob": "^12.2.1",
+                "botbuilder-core": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8",
+                "get-stream": "^6.0.0",
+                "p-map": "^4.0.0",
+                "runtypes": "~5.1.0"
+            },
+            "dependencies": {
+                "@azure/ms-rest-js": {
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
+                    "requires": {
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
+                        "form-data": "^2.3.2",
+                        "tough-cookie": "^2.4.3",
+                        "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
+                        "uuid": "^3.2.1",
+                        "xml2js": "^0.4.19"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.4.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.4.0.tgz",
+                            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+                        }
+                    }
+                },
+                "botbuilder-core": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-jXVFVMd6Bkelrvqj8tzkg5PwUgc=",
+                    "requires": {
+                        "assert": "^1.4.1",
+                        "botbuilder-dialogs-adaptive-runtime-core": "4.13.5-preview.dev.5bd62f8+sha-5bd62f8",
+                        "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8",
+                        "botframework-connector": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "botframework-schema": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "uuid": "^8.3.2"
+                    }
+                },
+                "botbuilder-dialogs-adaptive-runtime-core": {
+                    "version": "4.13.5-preview.dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.5-preview.dev.5bd62f8.tgz",
+                    "integrity": "sha1-GCxDVviOyXmqeDja9Yqjr1E5Ux4=",
+                    "requires": {
+                        "dependency-graph": "^0.10.0",
+                        "runtypes": "~5.1.0"
+                    }
+                },
+                "botbuilder-stdlib": {
+                    "version": "4.13.5-internal.dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-stdlib/-/botbuilder-stdlib-4.13.5-internal.dev.5bd62f8.tgz",
+                    "integrity": "sha1-wr/FS/mRTcVXsM70E886x1/irpo="
+                },
+                "botframework-connector": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-T4+0oVNk3ciaOim1lI9bn/qi7Sc=",
+                    "requires": {
+                        "@azure/ms-rest-js": "1.9.1",
+                        "@types/jsonwebtoken": "7.2.8",
+                        "@types/node": "^10.17.27",
+                        "adal-node": "0.2.2",
+                        "base64url": "^3.0.0",
+                        "botframework-schema": "4.13.5-dev.5bd62f8+sha-5bd62f8",
+                        "cross-fetch": "^3.0.5",
+                        "jsonwebtoken": "8.0.1",
+                        "rsa-pem-from-mod-exp": "^0.8.4"
+                    }
+                },
+                "botframework-schema": {
+                    "version": "4.13.5-dev.5bd62f8",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.13.5-dev.5bd62f8.tgz",
+                    "integrity": "sha1-isD13N/7kZN60/3qoWaiXvzek64=",
+                    "requires": {
+                        "botbuilder-stdlib": "4.13.5-internal.dev.5bd62f8+sha-5bd62f8"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
         "botbuilder-core": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.9.2.tgz",
-            "integrity": "sha1-njBevc19gjHXH/OOZlPjb7uRxes=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.13.6.tgz",
+            "integrity": "sha1-M+ViJyw9Z7woW5g0JweOdyKkhGg=",
             "requires": {
                 "assert": "^1.4.1",
-                "botframework-schema": "4.9.2"
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "botframework-schema": "4.13.6",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "botbuilder-dialogs": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.9.2.tgz",
-            "integrity": "sha1-J6gzfowfrJaVm/JObykgJeD8Aj8=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.13.6.tgz",
+            "integrity": "sha1-GB/zHdsrU/d7tsTLRURQ3+SjKZk=",
             "requires": {
                 "@microsoft/recognizers-text-choice": "1.1.4",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
                 "@microsoft/recognizers-text-number": "1.1.4",
                 "@microsoft/recognizers-text-suite": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
-                "globalize": "^1.4.2"
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs-adaptive-runtime-core": "4.13.6-preview",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "botframework-connector": "4.13.6",
+                "globalize": "^1.4.2",
+                "lodash": "^4.17.21",
+                "runtypes": "~5.1.0",
+                "uuid": "^8.3.2"
             },
             "dependencies": {
                 "@microsoft/recognizers-text": {
@@ -1212,90 +1582,132 @@
                         "@microsoft/recognizers-text": "~1.1.4",
                         "grapheme-splitter": "^1.0.2"
                     }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
                 }
             }
         },
-        "botbuilder-lg": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.9.2.tgz",
-            "integrity": "sha1-zesI6lBPlwJLl7wPSIYz2Ij2/0I=",
+        "botbuilder-dialogs-adaptive-runtime-core": {
+            "version": "4.13.6-preview",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.6-preview.tgz",
+            "integrity": "sha1-CyRdJareZJ4HM4CLCYOw0Cda4HA=",
             "requires": {
-                "adaptive-expressions": "4.9.2",
-                "antlr4ts": "0.5.0-alpha.1",
-                "lodash": "^4.17.11",
-                "path": "^0.12.7",
-                "uuid": "^3.3.3"
+                "dependency-graph": "^0.10.0",
+                "runtypes": "~5.1.0"
             }
         },
-        "botframework-config": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.9.2.tgz",
-            "integrity": "sha1-qFjKv/4+0ohWgtqaKetjX+SHlS4=",
+        "botbuilder-dialogs-declarative": {
+            "version": "4.13.6-preview",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs-declarative/-/botbuilder-dialogs-declarative-4.13.6-preview.tgz",
+            "integrity": "sha1-hQKLi+f4wBeAB/ZhZoEKFibO3ZQ=",
             "requires": {
-                "fs-extra": "^7.0.0",
+                "botbuilder-core": "4.13.6",
+                "botbuilder-dialogs": "4.13.6",
+                "botbuilder-stdlib": "4.13.6-internal",
+                "chokidar": "^3.4.0"
+            }
+        },
+        "botbuilder-lg": {
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.13.6.tgz",
+            "integrity": "sha1-MZwAmM7/5ZXMX9Nblcl+ly/dG6M=",
+            "requires": {
+                "adaptive-expressions": "4.13.6",
+                "antlr4ts": "0.5.0-alpha.3",
+                "lodash": "^4.17.19",
+                "path": "^0.12.7",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
+            }
+        },
+        "botbuilder-stdlib": {
+            "version": "4.13.6-internal",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-stdlib/-/botbuilder-stdlib-4.13.6-internal.tgz",
+            "integrity": "sha1-rzC5ufGKf4Dft5dj8LKvJgQxtP4="
+        },
+        "botframework-config": {
+            "version": "4.13.5-deprecated.dev.5bd62f8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.13.5-deprecated.dev.5bd62f8.tgz",
+            "integrity": "sha1-2gxN6SZk1lD5Nb/T3wkNW/kycCo=",
+            "requires": {
+                "fs-extra": "^7.0.1",
                 "read-text-file": "^1.1.0",
-                "uuid": "^3.3.2"
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "botframework-connector": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.9.2.tgz",
-            "integrity": "sha1-OS2NKEhrIXAm8GafphNCXeIOtNM=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.13.6.tgz",
+            "integrity": "sha1-9YmOfTqIVqYQgQ0SDGriZ3AH7kI=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
+                "@azure/ms-rest-js": "1.9.1",
                 "@types/jsonwebtoken": "7.2.8",
-                "@types/node": "^10.12.18",
-                "adal-node": "0.2.1",
+                "@types/node": "^10.17.27",
+                "adal-node": "0.2.2",
                 "base64url": "^3.0.0",
-                "botframework-schema": "4.9.2",
-                "form-data": "^2.3.3",
+                "botframework-schema": "4.13.6",
+                "cross-fetch": "^3.0.5",
                 "jsonwebtoken": "8.0.1",
-                "node-fetch": "^2.2.1",
                 "rsa-pem-from-mod-exp": "^0.8.4"
             },
             "dependencies": {
                 "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
+                    "version": "1.9.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.1.tgz",
+                    "integrity": "sha1-k67xEbAL/cxHCmvLRSChOzbyF4g=",
                     "requires": {
-                        "axios": "^0.18.0",
+                        "@types/tunnel": "0.0.0",
+                        "axios": "^0.21.1",
                         "form-data": "^2.3.2",
                         "tough-cookie": "^2.4.3",
                         "tslib": "^1.9.2",
+                        "tunnel": "0.0.6",
                         "uuid": "^3.2.1",
                         "xml2js": "^0.4.19"
                     }
-                },
-                "axios": {
-                    "version": "0.18.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                    "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                    "requires": {
-                        "follow-redirects": "1.5.10",
-                        "is-buffer": "^2.0.2"
-                    }
-                },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
                 }
             }
         },
         "botframework-schema": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.9.2.tgz",
-            "integrity": "sha1-Lb7G+5WzRDf6QetzVN4qWjU4Oyo="
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.13.6.tgz",
+            "integrity": "sha1-Cf2dRv1AbT2zR5BKGrmeijNNumg=",
+            "requires": {
+                "botbuilder-stdlib": "4.13.6-internal"
+            }
         },
         "botframework-streaming": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.9.2.tgz",
-            "integrity": "sha1-Vg5Af11EqxKJfZcGqII8Pk2sYJ0=",
+            "version": "4.13.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.13.6.tgz",
+            "integrity": "sha1-w7rtPywGAl+equ89BlrkOZS/vuI=",
             "requires": {
+                "@types/node": "^10.17.27",
                 "@types/ws": "^6.0.3",
-                "uuid": "^3.3.2",
+                "uuid": "^8.3.2",
                 "ws": "^7.1.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I="
+                }
             }
         },
         "boxen": {
@@ -1331,9 +1743,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -1354,7 +1766,6 @@
             "version": "3.0.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/braces/-/braces-3.0.2.tgz",
             "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
-            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -1367,21 +1778,26 @@
         },
         "browserify-mime": {
             "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/browserify-mime/-/browserify-mime-1.2.9.tgz",
             "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+        },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
         },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "bunyan": {
-            "version": "1.8.12",
-            "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-            "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+            "version": "1.8.15",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.15.tgz",
+            "integrity": "sha1-jONMqQihfQd2V2yhsvbL2RbpO0Y=",
             "requires": {
                 "dtrace-provider": "~0.8",
-                "moment": "^2.10.6",
+                "moment": "^2.19.3",
                 "mv": "~2",
                 "safe-json-stringify": "~1"
             }
@@ -1402,9 +1818,9 @@
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -1453,6 +1869,15 @@
                 }
             }
         },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/callsites/-/callsites-3.1.0.tgz",
@@ -1467,20 +1892,20 @@
         },
         "caseless": {
             "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chai": {
-            "version": "4.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.2.0.tgz",
-            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "version": "4.3.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chai/-/chai-4.3.4.tgz",
+            "integrity": "sha1-tV5lWzHh6scJm+TAjCGWT84ubEk=",
             "dev": true,
             "requires": {
                 "assertion-error": "^1.1.0",
                 "check-error": "^1.0.2",
                 "deep-eql": "^3.0.1",
                 "get-func-name": "^2.0.0",
-                "pathval": "^1.1.0",
+                "pathval": "^1.1.1",
                 "type-detect": "^4.0.5"
             }
         },
@@ -1529,30 +1954,29 @@
         },
         "charenc": {
             "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
             "dev": true
         },
         "check-error": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/check-error/-/check-error-1.0.2.tgz",
             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
         },
         "chokidar": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.4.0.tgz",
-            "integrity": "sha1-swYRQjzjdjV8dlubj5BLn7o8C+g=",
-            "dev": true,
+            "version": "3.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.5.2.tgz",
+            "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
             "requires": {
-                "anymatch": "~3.1.1",
+                "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
-                "glob-parent": "~5.1.0",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.4.0"
+                "readdirp": "~3.6.0"
             }
         },
         "ci-info": {
@@ -1562,19 +1986,24 @@
             "dev": true
         },
         "cldrjs": {
-            "version": "0.5.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.1.tgz",
-            "integrity": "sha1-tdxL6uAlVWNLBLlN644i4T/xAxk="
+            "version": "0.5.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.5.tgz",
+            "integrity": "sha1-XJLKLeiaihbep2yy38TgAQRCjlI="
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
         },
         "cli-boxes": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.0.tgz",
-            "integrity": "sha1-U47K6PnGylCOPDyVtFP+k8tMFo0=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.1.tgz",
+            "integrity": "sha1-3dUDXSUJT84iDpyrQKRYQKRAMY8=",
             "dev": true
         },
         "cli-cursor": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
@@ -1588,19 +2017,19 @@
             "dev": true
         },
         "cliui": {
-            "version": "6.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-6.0.0.tgz",
-            "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+            "version": "7.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
             "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^7.0.0"
             }
         },
         "clone-response": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/clone-response/-/clone-response-1.0.2.tgz",
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
             "dev": true,
             "requires": {
@@ -1642,13 +2071,13 @@
         },
         "commondir": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
@@ -1675,9 +2104,9 @@
             }
         },
         "convert-source-map": {
-            "version": "1.7.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
-            "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+            "version": "1.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/convert-source-map/-/convert-source-map-1.8.0.tgz",
+            "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
@@ -1692,9 +2121,9 @@
             }
         },
         "copyfiles": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.3.0.tgz",
-            "integrity": "sha1-HCbrvj1Gu6LTCaP9jjqsz1OvjHY=",
+            "version": "2.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.4.1.tgz",
+            "integrity": "sha1-0tz/YKqtEBXwnQtm5/Dxxc08XaU=",
             "dev": true,
             "requires": {
                 "glob": "^7.0.5",
@@ -1702,13 +2131,14 @@
                 "mkdirp": "^1.0.4",
                 "noms": "0.0.0",
                 "through2": "^2.0.1",
-                "yargs": "^15.3.1"
+                "untildify": "^4.0.0",
+                "yargs": "^16.1.0"
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -1729,7 +2159,7 @@
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cp-file": {
@@ -1757,10 +2187,19 @@
                 }
             }
         },
+        "cross-fetch": {
+            "version": "3.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-fetch/-/cross-fetch-3.1.4.tgz",
+            "integrity": "sha1-lyPzo6JHv4uJA586OAqSROj6Lzk=",
+            "requires": {
+                "node-fetch": "2.6.1"
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+            "dev": true,
             "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -1771,7 +2210,7 @@
         },
         "crypt": {
             "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
             "dev": true
         },
@@ -1782,34 +2221,39 @@
             "dev": true
         },
         "csv": {
-            "version": "5.3.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-5.3.2.tgz",
-            "integrity": "sha1-ULNE4l37uMYmhKG87BjCJGiyFh4=",
+            "version": "5.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv/-/csv-5.5.0.tgz",
+            "integrity": "sha1-jviemsIlWQZK7fPLu5Eu1MKq+aw=",
             "requires": {
-                "csv-generate": "^3.2.4",
-                "csv-parse": "^4.8.8",
-                "csv-stringify": "^5.3.6",
-                "stream-transform": "^2.0.1"
+                "csv-generate": "^3.4.0",
+                "csv-parse": "^4.15.3",
+                "csv-stringify": "^5.6.2",
+                "stream-transform": "^2.1.0"
             }
         },
         "csv-generate": {
-            "version": "3.2.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.2.4.tgz",
-            "integrity": "sha1-RA2rkXcznuBnbJ5cFvUOKzRjwBk="
+            "version": "3.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.4.0.tgz",
+            "integrity": "sha1-Ng7XPvjscRlRWkfDvVlwrEuYjwA="
         },
         "csv-parse": {
-            "version": "4.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.10.1.tgz",
-            "integrity": "sha1-Hia6Y9KcdelNDrpunemoqvidcqY="
+            "version": "4.16.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.16.0.tgz",
+            "integrity": "sha1-tMh14oikH3/5F8sNfUWIDVYwNPY="
         },
         "csv-stringify": {
-            "version": "5.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.5.0.tgz",
-            "integrity": "sha1-C96q9g1uFbicdSoOzrS0wsivWoo="
+            "version": "5.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.6.2.tgz",
+            "integrity": "sha1-5lN4PiGJxMeX+7Eqv39JQ8eHyqk="
+        },
+        "d3-format": {
+            "version": "1.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/d3-format/-/d3-format-1.4.5.tgz",
+            "integrity": "sha1-N08roTIONxfrdKk1bGfa7hen7bQ="
         },
         "dashdash": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
                 "assert-plus": "^1.0.0"
@@ -1817,7 +2261,7 @@
         },
         "date-utils": {
             "version": "1.2.21",
-            "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/date-utils/-/date-utils-1.2.21.tgz",
             "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
         },
         "dayjs": {
@@ -1826,22 +2270,22 @@
             "integrity": "sha1-U+xBPyp7Aq++oYRtYbsmD6hWfOo="
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "version": "4.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
             "requires": {
-                "ms": "2.0.0"
+                "ms": "2.1.2"
             }
         },
         "decamelize": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
         "decompress-response": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
             "requires": {
@@ -1879,13 +2323,13 @@
         },
         "deep-is": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
         "default-require-extensions": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
             "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
             "dev": true,
             "requires": {
@@ -1909,36 +2353,41 @@
         },
         "delayed-stream": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "dependency-graph": {
+            "version": "0.10.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dependency-graph/-/dependency-graph-0.10.0.tgz",
+            "integrity": "sha1-3+vjhPHzb693gr4gOnpxECpjNaY="
         },
         "destroy": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "detect-node": {
-            "version": "2.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.0.4.tgz",
-            "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE="
         },
         "diagnostic-channel": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "version": "0.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+            "integrity": "sha1-f6oUPhB/hhvjBGU560kI+qs/U/0=",
             "requires": {
                 "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
-            "version": "0.3.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-            "integrity": "sha1-2GKlFWCQCT4NEvblno07EZ76lWM="
+            "version": "0.4.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
+            "integrity": "sha1-V8O4C35/V2+VvjolfV6UVQ8AgtY="
         },
         "diff": {
             "version": "3.5.0",
@@ -1971,7 +2420,7 @@
             "dependencies": {
                 "semaphore": {
                     "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.0.5.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semaphore/-/semaphore-1.0.5.tgz",
                     "integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
                 },
                 "tunnel": {
@@ -1981,15 +2430,48 @@
                 },
                 "underscore": {
                     "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.8.3.tgz",
                     "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 }
             }
         },
+        "dom-serializer": {
+            "version": "1.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dom-serializer/-/dom-serializer-1.3.2.tgz",
+            "integrity": "sha1-YgZDfTLO767HFhgDIwx6ILwbTZE=",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "domelementtype": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        },
+        "domhandler": {
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha1-+XaKXwNL5gqJonwuTQ9066DYsFk=",
+            "requires": {
+                "domelementtype": "^2.2.0"
+            }
+        },
+        "domutils": {
+            "version": "2.7.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/domutils/-/domutils-2.7.0.tgz",
+            "integrity": "sha1-jrrwxB66/PVbC3LsMcVjI3EsVEI=",
+            "requires": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            }
+        },
         "dot-prop": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.2.0.tgz",
-            "integrity": "sha1-w07MKVVtxF8fTCJpe29JBODMT8s=",
+            "version": "5.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
             "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
@@ -2010,19 +2492,19 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY="
         },
         "duplexer3": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
         "ecc-jsbn": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
                 "jsbn": "~0.1.0",
@@ -2039,7 +2521,7 @@
         },
         "ee-first": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "emitter-listener": {
@@ -2058,16 +2540,22 @@
         },
         "encodeurl": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
+        },
+        "entities": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -2079,22 +2567,41 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.17.5.tgz",
-            "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+            "version": "1.18.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha1-JcTDOAonqiA8RLK2hbupTaMbY+A=",
             "dev": true,
             "requires": {
+                "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
-                "object-inspect": "^1.7.0",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "dependencies": {
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "es-to-primitive": {
@@ -2114,6 +2621,12 @@
             "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
             "dev": true
         },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+            "dev": true
+        },
         "escape-goat": {
             "version": "2.1.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -2122,17 +2635,17 @@
         },
         "escape-html": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-regexp-component": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
             "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
@@ -2181,18 +2694,9 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
                 },
                 "eslint-scope": {
                     "version": "4.0.3",
@@ -2214,9 +2718,9 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -2227,12 +2731,6 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
-                },
                 "regexpp": {
                     "version": "2.0.1",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-2.0.1.tgz",
@@ -2241,7 +2739,7 @@
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
@@ -2257,28 +2755,28 @@
             "dev": true
         },
         "eslint-scope": {
-            "version": "5.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
-            "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+            "version": "5.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
+                "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
-            "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+            "version": "1.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
             "dev": true
         },
         "espree": {
@@ -2295,32 +2793,41 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "dev": true
         },
         "esquery": {
-            "version": "1.3.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esquery/-/esquery-1.3.1.tgz",
-            "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
+            "version": "1.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
             "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha1-N0MJ05/ZNa5QDnuS6Ka0xyDllkI=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
                     "dev": true
                 }
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -2337,7 +2844,7 @@
         },
         "etag": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "eventemitter3": {
@@ -2345,26 +2852,17 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
             "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
         },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/events/-/events-3.3.0.tgz",
+            "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+        },
         "ewma": {
             "version": "2.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ewma/-/ewma-2.0.1.tgz",
             "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
             "requires": {
                 "assert-plus": "^1.0.0"
-            }
-        },
-        "execa": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
-            "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
-            "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
             }
         },
         "extend": {
@@ -2385,7 +2883,7 @@
         },
         "extsprintf": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-decode-uri-component": {
@@ -2394,9 +2892,9 @@
             "integrity": "sha1-Rvi2wisw/3qBNX1PWav66TggJUM="
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ="
+            "version": "3.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -2405,13 +2903,13 @@
         },
         "fast-levenshtein": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
         "figures": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
@@ -2429,13 +2927,13 @@
         },
         "filename-reserved-regex": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
             "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
         },
         "filenamify": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.1.0.tgz",
-            "integrity": "sha1-VNEQgQrnTuv+EVwbmVvQfgPPIYQ=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha1-YjkctY8CsJlxydT51js8+augMQY=",
             "requires": {
                 "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.1",
@@ -2446,7 +2944,6 @@
             "version": "7.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
-            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -2475,9 +2972,9 @@
             }
         },
         "find-my-way": {
-            "version": "2.2.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.3.tgz",
-            "integrity": "sha1-Up9ZadvR5uvtZ0p6EIfDQwmI454=",
+            "version": "2.2.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.5.tgz",
+            "integrity": "sha1-hs6CUmb6KM2WLlOKRewqqoTD1RQ=",
             "requires": {
                 "fast-decode-uri-component": "^1.0.0",
                 "safe-regex2": "^2.0.0",
@@ -2485,27 +2982,26 @@
             }
         },
         "find-up": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
             "dev": true,
             "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
+                "locate-path": "^3.0.0"
             }
         },
         "flat": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.0.tgz",
-            "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.1.tgz",
+            "integrity": "sha1-o5IFnMOCiB/5hkL12k3eCpWfMJs=",
             "requires": {
                 "is-buffer": "~2.0.3"
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                    "version": "2.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE="
                 }
             }
         },
@@ -2521,9 +3017,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -2552,16 +3048,13 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
-            "requires": {
-                "debug": "=3.1.0"
-            }
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha1-2RFN7Qoc/dM04WTmZirQK/2R/0M="
         },
         "foreground-child": {
             "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/foreground-child/-/foreground-child-1.5.6.tgz",
             "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
             "dev": true,
             "requires": {
@@ -2571,7 +3064,7 @@
             "dependencies": {
                 "cross-spawn": {
                     "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-4.0.2.tgz",
                     "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
                     "dev": true,
                     "requires": {
@@ -2591,7 +3084,7 @@
                 },
                 "yallist": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-2.1.2.tgz",
                     "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                     "dev": true
                 }
@@ -2599,7 +3092,7 @@
         },
         "forever-agent": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
@@ -2619,7 +3112,7 @@
         },
         "fresh": {
             "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "fs-extra": {
@@ -2634,26 +3127,24 @@
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
         "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
-            "dev": true,
+            "version": "2.3.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
             "optional": true
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-            "dev": true
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
@@ -2665,21 +3156,28 @@
         },
         "get-func-name": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
             "requires": {
-                "pump": "^3.0.0"
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
             }
+        },
+        "get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
         },
         "getpass": {
             "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
                 "assert-plus": "^1.0.0"
@@ -2687,7 +3185,7 @@
         },
         "glob": {
             "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-6.0.4.tgz",
             "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
             "optional": true,
             "requires": {
@@ -2699,29 +3197,28 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
-            "dev": true,
+            "version": "5.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
             "requires": {
                 "is-glob": "^4.0.1"
             }
         },
         "global-dirs": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-2.0.1.tgz",
-            "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/global-dirs/-/global-dirs-2.1.0.tgz",
+            "integrity": "sha1-6QRqScgG/wTWwYJeGWyPAJHo300=",
             "dev": true,
             "requires": {
-                "ini": "^1.3.5"
+                "ini": "1.3.7"
             }
         },
         "globalize": {
-            "version": "1.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.5.0.tgz",
-            "integrity": "sha1-w0Gd54uS0+/uDVTm2jiJNMe0WxE=",
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.6.0.tgz",
+            "integrity": "sha1-tsZZz6akf6GoJ5GHpFaJVg2FkbE=",
             "requires": {
-                "cldrjs": "^0.5.0"
+                "cldrjs": "^0.5.4"
             }
         },
         "globals": {
@@ -2747,12 +3244,23 @@
                 "p-cancelable": "^1.0.0",
                 "to-readable-stream": "^1.0.0",
                 "url-parse-lax": "^3.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
             }
         },
         "graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs="
+            "version": "4.2.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4="
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -2772,15 +3280,15 @@
         },
         "har-schema": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "version": "5.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -2788,22 +3296,26 @@
             "version": "1.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has/-/has-1.0.3.tgz",
             "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
         },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
+            "dev": true
+        },
         "has-flag": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
-            "dev": true
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
         },
         "has-yarn": {
             "version": "2.1.0",
@@ -2840,7 +3352,7 @@
         },
         "hasha": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hasha/-/hasha-3.0.0.tgz",
             "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
             "dev": true,
             "requires": {
@@ -2854,14 +3366,14 @@
             "dev": true
         },
         "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
+            "version": "2.8.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
             "dev": true
         },
         "hpack.js": {
             "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/hpack.js/-/hpack.js-2.1.6.tgz",
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "requires": {
                 "inherits": "^2.0.1",
@@ -2876,6 +3388,17 @@
             "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
             "dev": true
         },
+        "htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha1-xNditsM3GgXb5l6UrkOp+EX7j7c=",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
+        },
         "http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -2884,12 +3407,12 @@
         },
         "http-deceiver": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
             "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
                 "depd": "~1.1.2",
@@ -2900,14 +3423,24 @@
             "dependencies": {
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.3.tgz",
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 }
             }
         },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
                 "assert-plus": "^1.0.0",
@@ -2915,21 +3448,13 @@
                 "sshpk": "^1.7.0"
             }
         },
-        "i18next": {
-            "version": "15.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.3.tgz",
-            "integrity": "sha1-8ZhMvuDjywDP+QCLA3JkKJzohAo=",
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
             "requires": {
-                "@babel/runtime": "^7.3.1"
-            }
-        },
-        "i18next-node-fs-backend": {
-            "version": "2.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
-            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
-            "requires": {
-                "js-yaml": "3.13.1",
-                "json5": "2.0.0"
+                "agent-base": "6",
+                "debug": "4"
             }
         },
         "iconv-lite": {
@@ -2948,14 +3473,14 @@
         },
         "ignore-by-default": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
             "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
             "dev": true
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -2964,19 +3489,24 @@
         },
         "import-lazy": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-lazy/-/import-lazy-2.1.0.tgz",
             "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
             "dev": true
         },
         "imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
+        },
         "inflight": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
                 "once": "^1.3.0",
@@ -2985,13 +3515,13 @@
         },
         "inherits": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.1.tgz",
             "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+            "version": "1.3.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ini/-/ini-1.3.7.tgz",
+            "integrity": "sha1-oJNj4ZEZcuoW16iFEAXYTPCamoQ=",
             "dev": true
         },
         "inquirer": {
@@ -3017,7 +3547,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
@@ -3039,7 +3569,7 @@
                     "dependencies": {
                         "strip-ansi": {
                             "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
@@ -3069,28 +3599,45 @@
         },
         "int64-buffer": {
             "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/int64-buffer/-/int64-buffer-0.1.10.tgz",
             "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
         },
         "is-arguments": {
-            "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arguments/-/is-arguments-1.0.4.tgz",
-            "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
-            "dev": true
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arguments/-/is-arguments-1.1.0.tgz",
+            "integrity": "sha1-YjUwMd++4HzrNGVqa95Z7+yujdk=",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0"
+            }
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha1-/7OBRCUDI1rSReqJ5Fs9v/BA7lo=",
             "dev": true
         },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha1-PAh48DXLghIo01DS4eNnGXFqPeg=",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
             }
         },
         "is-buffer": {
@@ -3099,9 +3646,9 @@
             "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
+            "version": "1.2.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha1-ix4FALc6HXbHBIdjbzaOUZ3o244=",
             "dev": true
         },
         "is-ci": {
@@ -3113,17 +3660,25 @@
                 "ci-info": "^2.0.0"
             }
         },
+        "is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha1-jp/I4VAnsBFBgCbpjw5vTYYwXME=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
         "is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha1-VQz8wDr62gXuo90wmBx7CVUfc+U=",
             "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -3135,7 +3690,6 @@
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -3150,6 +3704,12 @@
                 "is-path-inside": "^3.0.1"
             }
         },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
+            "dev": true
+        },
         "is-npm": {
             "version": "4.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-npm/-/is-npm-4.0.0.tgz",
@@ -3159,7 +3719,12 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha1-bt+u7XlQz/Ga/tzp+/yp7m3Sies=",
             "dev": true
         },
         "is-obj": {
@@ -3169,37 +3734,44 @@
             "dev": true
         },
         "is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
+            "version": "3.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
             "dev": true
         },
         "is-regex": {
-            "version": "1.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.0.5.tgz",
-            "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha1-0Cn5r/ZEi5Prvj8z2scVEf3L758=",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
             }
         },
         "is-stream": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha1-P+XVmS+w2TQE8yWE1LAXmnG1Sl8=",
+            "dev": true
+        },
         "is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.1"
+                "has-symbols": "^1.0.2"
             }
         },
         "is-typedarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-yarn-global": {
@@ -3210,17 +3782,18 @@
         },
         "isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "istanbul-lib-coverage": {
@@ -3306,15 +3879,6 @@
                 "source-map": "^0.6.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "make-dir": {
                     "version": "2.1.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
@@ -3324,12 +3888,6 @@
                         "pify": "^4.0.1",
                         "semver": "^5.6.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
@@ -3355,17 +3913,23 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "version": "3.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
         },
+        "jsbi": {
+            "version": "3.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbi/-/jsbi-3.1.5.tgz",
+            "integrity": "sha1-cMKqovdeHcdgT+1FKYBhyiNyQEY="
+        },
         "jsbn": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "jschardet": {
@@ -3381,13 +3945,13 @@
         },
         "json-buffer": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-buffer/-/json-buffer-3.0.0.tgz",
             "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
             "dev": true
         },
         "json-edm-parser": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
             "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
             "requires": {
                 "jsonparse": "~1.2.0"
@@ -3401,7 +3965,7 @@
         },
         "json-schema": {
             "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
@@ -3411,26 +3975,18 @@
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "json5": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
-            "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "jsonfile": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
                 "graceful-fs": "^4.1.6"
@@ -3438,12 +3994,12 @@
         },
         "jsonparse": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonparse/-/jsonparse-1.2.0.tgz",
             "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
         },
         "jsonwebtoken": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
             "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
             "requires": {
                 "jws": "^3.1.4",
@@ -3465,7 +4021,7 @@
         },
         "jsprim": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
             "requires": {
                 "assert-plus": "1.0.0",
@@ -3503,6 +4059,13 @@
                     "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
                     "requires": {
                         "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
                     }
                 }
             }
@@ -3536,7 +4099,7 @@
         },
         "levn": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
@@ -3551,7 +4114,7 @@
         },
         "load-json-file": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/load-json-file/-/load-json-file-4.0.0.tgz",
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
@@ -3563,105 +4126,106 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
             }
         },
         "locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
             "dev": true,
             "requires": {
-                "p-locate": "^4.1.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lock": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lock/-/lock-0.1.4.tgz",
             "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+            "version": "4.17.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
         },
         "lodash.escaperegexp": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
             "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
         },
         "lodash.flattendeep": {
             "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
             "dev": true
         },
         "lodash.includes": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
         },
         "lodash.isboolean": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
         },
         "lodash.isequal": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
         },
         "lodash.isinteger": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
         },
         "lodash.isnumber": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
         },
         "lodash.isplainobject": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
         },
         "lodash.isstring": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
         },
         "lodash.last": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.last/-/lodash.last-3.0.0.tgz",
             "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
         },
         "lodash.max": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.max/-/lodash.max-4.0.1.tgz",
             "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
         },
         "lodash.once": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lodash.sortby": {
             "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
         },
         "lodash.tonumber": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
             "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
         },
         "lodash.trimend": {
             "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
             "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
         },
         "log-symbols": {
@@ -3700,7 +4264,7 @@
             "dependencies": {
                 "lru-cache": {
                     "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lru-cache/-/lru-cache-4.0.2.tgz",
                     "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
                     "requires": {
                         "pseudomap": "^1.0.1",
@@ -3709,15 +4273,10 @@
                 },
                 "yallist": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yallist/-/yallist-2.1.2.tgz",
                     "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
                 }
             }
-        },
-        "macos-release": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/macos-release/-/macos-release-2.3.0.tgz",
-            "integrity": "sha1-6xkwsDbAgArevM1fF7xMEt6Ltx8="
         },
         "make-dir": {
             "version": "3.1.0",
@@ -3737,19 +4296,19 @@
             }
         },
         "md5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "version": "2.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha1-w9qaaq46MLRreww0m4exENw72k8=",
             "dev": true,
             "requires": {
-                "charenc": "~0.0.1",
-                "crypt": "~0.0.1",
-                "is-buffer": "~1.1.1"
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
             }
         },
         "md5.js": {
             "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
                 "hash-base": "^3.0.0",
@@ -3774,21 +4333,21 @@
             }
         },
         "mime": {
-            "version": "2.4.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.4.6.tgz",
-            "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE="
+            "version": "2.5.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.5.2.tgz",
+            "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4="
         },
         "mime-db": {
-            "version": "1.44.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.44.0.tgz",
-            "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
+            "version": "1.48.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-db/-/mime-db-1.48.0.tgz",
+            "integrity": "sha1-41sxBF3X6to6qtU37YijOvvvLR0="
         },
         "mime-types": {
-            "version": "2.1.27",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.27.tgz",
-            "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+            "version": "2.1.31",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime-types/-/mime-types-2.1.31.tgz",
+            "integrity": "sha1-oA12t0MXxh+cLbIhi46fjpxcnms=",
             "requires": {
-                "mime-db": "1.44.0"
+                "mime-db": "1.48.0"
             }
         },
         "mimic-fn": {
@@ -3822,9 +4381,9 @@
             "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
         },
         "mixme": {
-            "version": "0.3.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.3.5.tgz",
-            "integrity": "sha1-MEZSza8ko98EhyBeYaxhYsaQbd0="
+            "version": "0.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.5.1.tgz",
+            "integrity": "sha1-s9p5pWOy2kbvupUZgwBZ5MKp5A8="
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -3921,15 +4480,6 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "glob": {
                     "version": "7.1.3",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.3.tgz",
@@ -3950,14 +4500,14 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+                "js-yaml": {
+                    "version": "3.13.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+                    "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "mkdirp": {
@@ -3973,21 +4523,6 @@
                     "version": "2.1.1",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
-                    "dev": true
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -4029,6 +4564,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",
@@ -4075,7 +4616,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
@@ -4088,9 +4629,15 @@
                         "ms": "2.0.0"
                     }
                 },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
@@ -4100,22 +4647,14 @@
             }
         },
         "moment": {
-            "version": "2.26.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.26.0.tgz",
-            "integrity": "sha1-Xh+Cxrr8pug+gIswyHBe7Q3L05o="
-        },
-        "moment-timezone": {
-            "version": "0.5.31",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment-timezone/-/moment-timezone-0.5.31.tgz",
-            "integrity": "sha1-nEDYxQJvDHq0bto9Y+ScFVFI3gU=",
-            "requires": {
-                "moment": ">= 2.9.0"
-            }
+            "version": "2.29.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "ms-rest": {
             "version": "2.5.4",
@@ -4153,13 +4692,13 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 },
                 "adal-node": {
                     "version": "0.1.28",
-                    "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adal-node/-/adal-node-0.1.28.tgz",
                     "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
                     "requires": {
                         "@types/node": "^8.0.47",
@@ -4185,13 +4724,13 @@
         },
         "mute-stream": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
         },
         "mv": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mv/-/mv-2.1.1.tgz",
             "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
             "optional": true,
             "requires": {
@@ -4202,7 +4741,7 @@
             "dependencies": {
                 "rimraf": {
                     "version": "2.4.5",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rimraf/-/rimraf-2.4.5.tgz",
                     "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                     "optional": true,
                     "requires": {
@@ -4212,20 +4751,20 @@
             }
         },
         "nan": {
-            "version": "2.14.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
+            "version": "2.14.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
             "optional": true
         },
         "natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
         "ncp": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "optional": true
         },
@@ -4243,7 +4782,8 @@
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
         },
         "nock": {
             "version": "10.0.6",
@@ -4260,29 +4800,12 @@
                 "propagate": "^1.0.0",
                 "qs": "^6.5.1",
                 "semver": "^5.5.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
-                }
             }
         },
         "node-abort-controller": {
-            "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.0.4.tgz",
-            "integrity": "sha1-QJXkHViy+uFp0vmJKQTWA+Ecejk="
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+            "integrity": "sha1-Ht21frj+pzQZixGyiFdZbcYWVwg="
         },
         "node-environment-flags": {
             "version": "1.0.5",
@@ -4295,14 +4818,14 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+            "version": "2.6.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
         },
         "nodemon": {
-            "version": "2.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.4.tgz",
-            "integrity": "sha1-VbCTGetIjWOUqpgYFIwMLRwExBY=",
+            "version": "2.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.7.tgz",
+            "integrity": "sha1-bwMKCg6+PqG6Kjj3G/m6tIQc7TI=",
             "dev": true,
             "requires": {
                 "chokidar": "^3.2.2",
@@ -4313,30 +4836,24 @@
                 "semver": "^5.7.1",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
-                "undefsafe": "^2.0.2",
-                "update-notifier": "^4.0.0"
+                "undefsafe": "^2.0.3",
+                "update-notifier": "^4.1.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+                    "version": "3.2.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-                    "dev": true
                 }
             }
         },
         "noms": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/noms/-/noms-0.0.0.tgz",
             "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
             "dev": true,
             "requires": {
@@ -4346,13 +4863,13 @@
             "dependencies": {
                 "isarray": {
                     "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isarray/-/isarray-0.0.1.tgz",
                     "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                     "dev": true
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
@@ -4364,7 +4881,7 @@
                 },
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 }
@@ -4372,7 +4889,7 @@
         },
         "nopt": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nopt/-/nopt-1.0.10.tgz",
             "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
             "dev": true,
             "requires": {
@@ -4394,22 +4911,13 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-            "dev": true
+            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
         },
         "normalize-url": {
-            "version": "4.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-url/-/normalize-url-4.5.0.tgz",
-            "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
+            "version": "4.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-url/-/normalize-url-4.5.1.tgz",
+            "integrity": "sha1-DdkM8SiO4dExO4cIHJpZMu5IUYo=",
             "dev": true
-        },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "^2.0.0"
-            }
         },
         "nyc": {
             "version": "14.1.1",
@@ -4491,19 +4999,10 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4520,16 +5019,6 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
                 "make-dir": {
                     "version": "2.1.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-2.1.0.tgz",
@@ -4539,21 +5028,6 @@
                         "pify": "^4.0.1",
                         "semver": "^5.6.0"
                     }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
                 },
                 "string-width": {
                     "version": "3.1.0",
@@ -4585,6 +5059,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",
@@ -4623,23 +5103,22 @@
         },
         "object-assign": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
-            "dev": true
+            "version": "1.10.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha1-wqp9LQn1DJk3VwT3oK3yTFeC02k="
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha1-xdLof/nhGfeLegiEQVGeLuwVc7Y=",
+            "version": "1.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "object-keys": {
@@ -4661,13 +5140,14 @@
             }
         },
         "object.getownpropertydescriptors": {
-            "version": "2.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-            "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+            "version": "2.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+            "integrity": "sha1-G9Y66s8NXS0vMbXjk7A6fGAaI/c=",
             "dev": true,
             "requires": {
+                "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
+                "es-abstract": "^1.18.0-next.2"
             }
         },
         "obuf": {
@@ -4677,7 +5157,7 @@
         },
         "on-finished": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/on-finished/-/on-finished-2.3.0.tgz",
             "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
             "requires": {
                 "ee-first": "1.1.1"
@@ -4685,7 +5165,7 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1"
@@ -4693,7 +5173,7 @@
         },
         "onetime": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
@@ -4716,22 +5196,13 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
-        "os-name": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-name/-/os-name-3.1.0.tgz",
-            "integrity": "sha1-3sGdlmKW4c1i1wGlpm7h3ernCAE=",
-            "requires": {
-                "macos-release": "^2.2.0",
-                "windows-release": "^3.1.0"
-            }
-        },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -4740,11 +5211,6 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
             "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
             "dev": true
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "2.3.0",
@@ -4756,12 +5222,20 @@
             }
         },
         "p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
             "dev": true,
             "requires": {
-                "p-limit": "^2.2.0"
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-map": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
+            "requires": {
+                "aggregate-error": "^3.0.0"
             }
         },
         "p-queue": {
@@ -4821,7 +5295,7 @@
         },
         "parse-json": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
@@ -4831,7 +5305,7 @@
         },
         "path": {
             "version": "0.12.7",
-            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path/-/path-0.12.7.tgz",
             "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
             "requires": {
                 "process": "^0.11.1",
@@ -4839,31 +5313,32 @@
             }
         },
         "path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "path-key": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "version": "1.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
             "dev": true
         },
         "path-type": {
@@ -4877,35 +5352,34 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
             }
         },
         "pathval": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pathval/-/pathval-1.1.1.tgz",
+            "integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
             "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
-            "dev": true
+            "version": "2.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI="
         },
         "pidusage": {
-            "version": "2.0.20",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.20.tgz",
-            "integrity": "sha1-IGrZLwhsiSwBTc+5FZkJ6uwHLhg=",
+            "version": "2.0.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.21.tgz",
+            "integrity": "sha1-cGiWez2VK66nPldmjJi56qh2iU4=",
             "requires": {
-                "safe-buffer": "^5.1.2"
+                "safe-buffer": "^5.2.1"
             }
         },
         "pify": {
@@ -4921,69 +5395,33 @@
             "dev": true,
             "requires": {
                 "find-up": "^3.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
-                }
             }
         },
         "prelude-ls": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
         "prepend-http": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/prepend-http/-/prepend-http-2.0.0.tgz",
             "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
             "dev": true
         },
         "priorityqueuejs": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
             "integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
         },
         "process": {
             "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process/-/process-0.11.10.tgz",
             "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
         "process-nextick-args": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "progress": {
@@ -4994,13 +5432,13 @@
         },
         "propagate": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/propagate/-/propagate-1.0.0.tgz",
             "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
             "dev": true
         },
         "pseudomap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
@@ -5018,6 +5456,7 @@
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pump/-/pump-3.0.0.tgz",
             "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -5029,9 +5468,9 @@
             "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
         },
         "pupa": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.0.1.tgz",
-            "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.1.1.tgz",
+            "integrity": "sha1-9ej9SvwsXZeCj6pSNUnth0SiDWI=",
             "dev": true,
             "requires": {
                 "escape-goat": "^2.0.0"
@@ -5043,9 +5482,9 @@
             "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4="
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y="
         },
         "range-parser": {
             "version": "1.2.1",
@@ -5066,7 +5505,7 @@
         },
         "read-pkg": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-pkg/-/read-pkg-3.0.0.tgz",
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
@@ -5083,47 +5522,11 @@
             "requires": {
                 "find-up": "^3.0.0",
                 "read-pkg": "^3.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
-                }
             }
         },
         "read-text-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-text-file/-/read-text-file-1.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/read-text-file/-/read-text-file-1.1.0.tgz",
             "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
             "requires": {
                 "iconv-lite": "^0.4.17",
@@ -5132,7 +5535,7 @@
         },
         "readable-stream": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readable-stream/-/readable-stream-2.0.6.tgz",
             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -5145,45 +5548,39 @@
             "dependencies": {
                 "string_decoder": {
                     "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
             }
         },
         "readdirp": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.4.0.tgz",
-            "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
-            "dev": true,
+            "version": "3.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
             "requires": {
                 "picomatch": "^2.2.1"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc="
-        },
         "regexp.prototype.flags": {
-            "version": "1.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-            "integrity": "sha1-erqJs8E6ZFCdq888qNn7ub31y3U=",
+            "version": "1.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+            "integrity": "sha1-fvNSro0VnnWMDq3Kb4/LTu8HviY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "regexpp": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-3.1.0.tgz",
-            "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
+            "version": "3.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
             "dev": true
         },
         "registry-auth-token": {
-            "version": "4.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-            "integrity": "sha1-QKM74eglOUYPlDKLD38PhMFtlHk=",
+            "version": "4.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+            "integrity": "sha1-bXtABkQZGJcszV/tzUHcMix5slA=",
             "dev": true,
             "requires": {
                 "rc": "^1.2.8"
@@ -5200,7 +5597,7 @@
         },
         "release-zalgo": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/release-zalgo/-/release-zalgo-1.0.0.tgz",
             "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
             "dev": true,
             "requires": {
@@ -5208,14 +5605,107 @@
             }
         },
         "replace": {
-            "version": "1.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/replace/-/replace-1.2.0.tgz",
-            "integrity": "sha1-ol2iiIQaqyLw9+ldwdJJ29LtbiY=",
+            "version": "1.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/replace/-/replace-1.2.1.tgz",
+            "integrity": "sha1-5uKNuNx9z6KmwLmciSI2BXDxrq0=",
             "dev": true,
             "requires": {
                 "chalk": "2.4.2",
                 "minimatch": "3.0.4",
                 "yargs": "^15.3.1"
+            },
+            "dependencies": {
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
             }
         },
         "request": {
@@ -5258,26 +5748,26 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.3.tgz",
-            "integrity": "sha1-6aPAgbUTgN/qZ3M2Bh/qh5qCnuk=",
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
             "requires": {
-                "lodash": "^4.17.15"
+                "lodash": "^4.17.19"
             }
         },
         "request-promise-native": {
-            "version": "1.0.8",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.8.tgz",
-            "integrity": "sha1-pFW5YLgm5E4r+Jma9k3/K/5YyzY=",
+            "version": "1.0.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
             "requires": {
-                "request-promise-core": "1.1.3",
+                "request-promise-core": "1.1.4",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
@@ -5289,15 +5779,16 @@
         },
         "requires-port": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+            "version": "1.20.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.2.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -5309,7 +5800,7 @@
         },
         "responselike": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/responselike/-/responselike-1.0.2.tgz",
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
             "dev": true,
             "requires": {
@@ -5346,9 +5837,12 @@
             },
             "dependencies": {
                 "qs": {
-                    "version": "6.9.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.9.4.tgz",
-                    "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
+                    "version": "6.10.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/qs/-/qs-6.10.1.tgz",
+                    "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 },
                 "semver": {
                     "version": "6.3.0",
@@ -5370,7 +5864,7 @@
         },
         "restore-cursor": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
@@ -5393,9 +5887,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -5410,7 +5904,7 @@
         },
         "rsa-pem-from-mod-exp": {
             "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
             "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
         },
         "run-async": {
@@ -5419,10 +5913,15 @@
             "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
             "dev": true
         },
+        "runtypes": {
+            "version": "5.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/runtypes/-/runtypes-5.1.0.tgz",
+            "integrity": "sha1-ofJQG1yo/aR9UeoVtszKRekkqMM="
+        },
         "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
+            "version": "6.6.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.6.7.tgz",
+            "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -5459,7 +5958,7 @@
         },
         "select-hose": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/select-hose/-/select-hose-2.0.0.tgz",
             "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
         },
         "semaphore": {
@@ -5526,12 +6025,17 @@
                     "version": "1.4.1",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-1.4.1.tgz",
                     "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
         "set-blocking": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
@@ -5542,26 +6046,39 @@
         },
         "shebang-command": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shimmer": {
             "version": "1.2.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shimmer/-/shimmer-1.2.1.tgz",
             "integrity": "sha1-YQhZ994ye1h+/r9QH7QxF/mv8zc="
         },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -5608,7 +6125,7 @@
         },
         "source-map": {
             "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
@@ -5653,9 +6170,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+            "version": "3.0.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+            "integrity": "sha1-illRNd75WSvaaXCUdPHL7qfCRn8=",
             "dev": true
         },
         "spdy": {
@@ -5668,21 +6185,6 @@
                 "http-deceiver": "^1.2.7",
                 "select-hose": "^2.0.0",
                 "spdy-transport": "^3.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-                }
             }
         },
         "spdy-transport": {
@@ -5698,23 +6200,10 @@
                 "wbuf": "^1.7.3"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "inherits": {
                     "version": "2.0.4",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inherits/-/inherits-2.0.4.tgz",
                     "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
                 },
                 "readable-stream": {
                     "version": "3.6.0",
@@ -5730,8 +6219,9 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "sshpk": {
             "version": "1.16.1",
@@ -5751,7 +6241,7 @@
         },
         "stack-chain": {
             "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stack-chain/-/stack-chain-1.3.7.tgz",
             "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
         },
         "statuses": {
@@ -5761,21 +6251,21 @@
         },
         "stealthy-require": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
         },
         "stream-transform": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.0.2.tgz",
-            "integrity": "sha1-PLehTIAus5vEDKqrBTXlhPOmXK8=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.1.0.tgz",
+            "integrity": "sha1-5ozAYsztW47maa6X9L5HPu5dkic=",
             "requires": {
-                "mixme": "^0.3.1"
+                "mixme": "^0.5.0"
             }
         },
         "string-width": {
-            "version": "4.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-4.2.0.tgz",
-            "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+            "version": "4.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
             "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
@@ -5784,45 +6274,23 @@
             }
         },
         "string.prototype.trimend": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-            "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
-            }
-        },
-        "string.prototype.trimleft": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-            "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimstart": "^1.0.0"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-            "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimend": "^1.0.0"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-            "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
             }
         },
         "string_decoder": {
@@ -5844,18 +6312,13 @@
         },
         "strip-bom": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
         },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-        },
         "strip-json-comments": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
@@ -5929,9 +6392,9 @@
             }
         },
         "term-size": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.0.tgz",
-            "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.1.tgz",
+            "integrity": "sha1-KmpUhAQywvtjIP6g9BVTHpAYn1Q=",
             "dev": true
         },
         "test-exclude": {
@@ -5947,9 +6410,9 @@
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                    "version": "7.1.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -5964,13 +6427,13 @@
         },
         "text-table": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
@@ -6038,7 +6501,7 @@
         },
         "to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
@@ -6052,7 +6515,6 @@
             "version": "5.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -6077,21 +6539,21 @@
         },
         "trim-repeated": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
         },
         "tslib": {
-            "version": "1.13.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.13.0.tgz",
-            "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
         },
         "tsutils": {
-            "version": "3.17.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-3.17.1.tgz",
-            "integrity": "sha1-7XGZF/EcoN7lhicrKsSeAVot11k=",
+            "version": "3.21.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=",
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
@@ -6104,7 +6566,7 @@
         },
         "tunnel-agent": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
                 "safe-buffer": "^5.0.1"
@@ -6112,12 +6574,12 @@
         },
         "tweetnacl": {
             "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type-check": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
@@ -6146,10 +6608,22 @@
             }
         },
         "typescript": {
-            "version": "3.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.9.3.tgz",
-            "integrity": "sha1-06yIg6l8JhOeQt9ek+7s4z1hC4o=",
+            "version": "3.9.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.9.10.tgz",
+            "integrity": "sha1-cPORCselHta+952ngAaQsZv3eLg=",
             "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha1-CF4hViXsMWJXTciFmr7nilmxRHE=",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
         },
         "undefsafe": {
             "version": "2.0.3",
@@ -6168,13 +6642,19 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "underscore": {
-            "version": "1.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.10.2.tgz",
-            "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8="
+            "version": "1.13.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.13.1.tgz",
+            "integrity": "sha1-DBxr0t9UtrafIxQGbWW2zeb8+dE="
         },
         "unique-string": {
             "version": "2.0.0",
@@ -6185,15 +6665,26 @@
                 "crypto-random-string": "^2.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4="
+        },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
         },
+        "untildify": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs=",
+            "dev": true
+        },
         "update-notifier": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.0.tgz",
-            "integrity": "sha1-SGa5jDvFtUc8AgsSUFg2KPmjKPM=",
+            "version": "4.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.3.tgz",
+            "integrity": "sha1-vobuE+jOSPtQBD/3IFe1vVmOHqM=",
             "dev": true,
             "requires": {
                 "boxen": "^4.2.0",
@@ -6228,9 +6719,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -6239,17 +6730,17 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "version": "4.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
             "requires": {
                 "punycode": "^2.1.0"
             }
         },
         "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+            "version": "1.5.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha1-1fqYkK+KXh8nSiyYN2UQ9kJfbjs=",
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -6257,7 +6748,7 @@
         },
         "url-parse-lax": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "dev": true,
             "requires": {
@@ -6266,7 +6757,7 @@
         },
         "util": {
             "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util/-/util-0.10.3.tgz",
             "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
             "requires": {
                 "inherits": "2.0.1"
@@ -6274,7 +6765,7 @@
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
@@ -6299,7 +6790,7 @@
         },
         "vasync": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/vasync/-/vasync-2.2.0.tgz",
             "integrity": "sha1-z951GGChWCLbOxMrxZsRakra8Bs=",
             "requires": {
                 "verror": "1.10.0"
@@ -6307,7 +6798,7 @@
         },
         "verror": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
                 "assert-plus": "^1.0.0",
@@ -6317,7 +6808,7 @@
         },
         "very-fast-args": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/very-fast-args/-/very-fast-args-1.1.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/very-fast-args/-/very-fast-args-1.1.0.tgz",
             "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
         },
         "wbuf": {
@@ -6332,13 +6823,27 @@
             "version": "1.3.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which/-/which-1.3.1.tgz",
             "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
         },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
         "which-module": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
@@ -6353,7 +6858,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
@@ -6375,7 +6880,7 @@
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
@@ -6393,14 +6898,6 @@
                 "string-width": "^4.0.0"
             }
         },
-        "windows-release": {
-            "version": "3.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/windows-release/-/windows-release-3.3.0.tgz",
-            "integrity": "sha1-3OFn6fi+cz8hyEnr1NA/5mspufA=",
-            "requires": {
-                "execa": "^1.0.0"
-            }
-        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6408,9 +6905,9 @@
             "dev": true
         },
         "wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+            "version": "7.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
@@ -6420,7 +6917,7 @@
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
@@ -6445,9 +6942,24 @@
             }
         },
         "ws": {
-            "version": "7.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.3.0.tgz",
-            "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0="
+            "version": "7.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.5.0.tgz",
+            "integrity": "sha1-ADO6/qAx+53wQbICb8cqVxykRpE="
+        },
+        "x2js": {
+            "version": "3.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/x2js/-/x2js-3.4.1.tgz",
+            "integrity": "sha1-ni8rnUGB7VBKWQcRDcNg6YKdHO4=",
+            "requires": {
+                "xmldom": "^0.5.0"
+            },
+            "dependencies": {
+                "xmldom": {
+                    "version": "0.5.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.5.0.tgz",
+                    "integrity": "sha1-GTy5a4SqNIYSfqYnLEWWNUy0li4="
+                }
+            }
         },
         "xdg-basedir": {
             "version": "4.0.0",
@@ -6457,7 +6969,7 @@
         },
         "xml": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xml/-/xml-1.0.1.tgz",
             "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
             "dev": true
         },
@@ -6484,9 +6996,14 @@
             "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
         },
         "xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha1-5iVFf0MAtd+cLh7Ld2FH7OR/Plo="
+            "version": "0.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.6.0.tgz",
+            "integrity": "sha1-Q6luy4vuzpkc7zgsCDl9gtTQxG8="
+        },
+        "xpath": {
+            "version": "0.0.32",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xpath/-/xpath-0.0.32.tgz",
+            "integrity": "sha1-G3PTNRr3NuF+wHjW2kuBdUBcSK8="
         },
         "xpath.js": {
             "version": "1.1.0",
@@ -6499,9 +7016,9 @@
             "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "version": "5.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
             "dev": true
         },
         "yallist": {
@@ -6510,33 +7027,25 @@
             "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
         },
         "yargs": {
-            "version": "15.3.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-15.3.1.tgz",
-            "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
+            "version": "16.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
             "dev": true,
             "requires": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
                 "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.1"
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
             }
         },
         "yargs-parser": {
-            "version": "18.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
-            "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-            }
+            "version": "20.2.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+            "dev": true
         },
         "yargs-unparser": {
             "version": "1.6.0",
@@ -6596,44 +7105,10 @@
                     "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
                     "dev": true
                 },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -6666,6 +7141,12 @@
                         "string-width": "^3.0.0",
                         "strip-ansi": "^5.0.0"
                     }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.3.2",


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
As the TypeScript [bot-solutions@1.1.0](https://www.npmjs.com/package/bot-solutions/v/1.1.0) was published in npmjs, the `package-lock.json` files of the Virtual Assistant Sample and Skill Sample should be consume the new version

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Regenerate the `package-lock.json` file of the Virtual Assistant Sample in TypeScript
- Regenerate the `package-lock.json` file of the Skill Sample in TypeScript

![image](https://user-images.githubusercontent.com/11904023/123099268-6ab4e900-d408-11eb-8db6-843c76adcb21.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
The compilation and the unit tests worked correctly

_Unit tests passing in the TypeScript Virtual Assistant Sample_
![image](https://user-images.githubusercontent.com/11904023/123098847-f1b59180-d407-11eb-8c74-4e40b6811944.png)

_Unit tests passing in the TypeScript Skill Sample_
![image](https://user-images.githubusercontent.com/11904023/123098858-f5491880-d407-11eb-8fb1-402aef462ddb.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
