### PR TITLE
[C#][VA] Fix Virtual Assistant's Pipeline compatibility issues

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -60,7 +60,8 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'
+    # if your working directory is not root, you may change the following path
+    SourceFolder: '$(System.DefaultWorkingDirectory)\VirtualAssistantSample'
     Contents: '**\*'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\VA'
 

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -57,7 +57,7 @@ steps:
     summaryFileLocation: '$(Build.SourcesDirectory)\VirtualAssistantSample.Tests\coverage.cobertura.xml'
     reportDirectory: '$(Build.SourcesDirectory)\VirtualAssistantSample.Tests'
 
- - task: CopyFiles@2
+- task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -1,31 +1,28 @@
 # specific branch build
 trigger:
-  branches:  
+  branches:
     include:
     - master
     - feature/*
-  
+
 pool:
-   name: Hosted VS2017
-   demands:
-    - msbuild
-    - visualstudio
+   vmimage: 'windows-2019'
 
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.100'
+- task: DotNetCoreInstaller@2
+  displayName: 'Use .NET Core sdk 3.1'
   inputs:
-    version: 2.2.100
+    version: 3.1.x
   continueOnError: true
 
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
+  displayName: 'Use NuGet 5.3.0'
   inputs:
-    versionSpec: 4.9.1
+    versionSpec: 5.3.0
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'

--- a/templates/csharp/VA/VA/Pipeline/VirtualAssistantSample.yml
+++ b/templates/csharp/VA/VA/Pipeline/VirtualAssistantSample.yml
@@ -1,31 +1,28 @@
 # specific branch build
 trigger:
-  branches:  
+  branches:
     include:
     - master
     - feature/*
-  
+
 pool:
-   name: Hosted VS2017
-   demands:
-    - msbuild
-    - visualstudio
+   vmimage: 'windows-2019'
 
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.100'
+- task: DotNetCoreInstaller@2
+  displayName: 'Use .NET Core sdk 3.1'
   inputs:
-    version: 2.2.100
+    version: 3.1.x
   continueOnError: true
 
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
+  displayName: 'Use NuGet 5.3.0'
   inputs:
-    versionSpec: 4.9.1
+    versionSpec: 5.3.0
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
@@ -60,10 +57,11 @@ steps:
     summaryFileLocation: '$(Build.SourcesDirectory)\$safeprojectname$.Tests\coverage.cobertura.xml'
     reportDirectory: '$(Build.SourcesDirectory)\$safeprojectname$.Tests'
 
- - task: CopyFiles@2
+- task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'
+    # if your working directory is not root, you may change the following path
+    SourceFolder: '$(System.DefaultWorkingDirectory)\$safeprojectname$'
     Contents: '**\*'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\VA'
 


### PR DESCRIPTION
Fixes #3833

### Purpose
The Pipeline created using the provided [VirtualAssistantSample.yml](https://github.com/microsoft/botframework-solutions/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml) file would fail due to being outdated, as reported on issue #3833.

### Changes
The following changes were applied to the Pipeline use on the sample and the VSIX template

- `NuGetToolInstaller` task NuGet version was updated from version `4.9.1` to `5.3.0`.
- `DotNetCoreInstaller` task was updated to install version `3.1` of NET Core to match with the Virtual Assistant dependency.
- `DotNetCoreInstaller` task was upgraded to version 2.
- Build tool were upgraded for NET Core 3.1 by updating the pool version to `windows-2019`.

### Tests
With the changes, the Pipeline is now passing:
![image](https://user-images.githubusercontent.com/20074735/125841942-f048e589-bd8a-4f44-b1c8-c3d1a5736395.png)

### Feature Plan
N/A

### Checklist

#### General
- [X] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
